### PR TITLE
Emit row_ids

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -24,7 +24,7 @@ concurrency:
 jobs:
   duckdb-stable-build:
     name: Build extension binaries
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@v1.3.2
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: vss
       duckdb_version: main
@@ -33,7 +33,7 @@ jobs:
   duckdb-stable-deploy:
     name: Deploy extension binaries
     needs: duckdb-stable-build
-    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@v1.3.2
+    uses: duckdb/extension-ci-tools/.github/workflows/_extension_deploy.yml@main
     secrets: inherit
     with:
       extension_name: vss

--- a/test/sql/hnsw/where_clause_segfault.test
+++ b/test/sql/hnsw/where_clause_segfault.test
@@ -1,0 +1,154 @@
+# name: test/sql/hnsw/where_clause_segfault.test
+# description: If a where clause is present the code segfaults
+# group: [hnsw]
+
+require vss
+
+# First try the failing case
+
+statement ok
+CREATE TABLE my_vector_table (id INTEGER, vec FLOAT[3]);
+
+statement ok
+INSERT INTO my_vector_table (id, vec)
+SELECT id, array_value(a, b, c)
+FROM range(1, 10) t1(id),
+     range(1, 10) t2(a),
+     range(1, 10) t3(b),
+     range(1, 10) t4(c);
+
+statement ok
+CREATE INDEX my_hnsw_index ON my_vector_table USING hnsw (vec);
+
+query II
+SELECT *
+FROM my_vector_table
+WHERE id > 0
+ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
+LIMIT 3;
+----
+7	[1.0, 2.0, 3.0]
+8	[1.0, 2.0, 3.0]
+9	[1.0, 2.0, 3.0]
+
+# Make sure the plan is not falling back to a sequential scan. Maybe that is not even possible in that case. I think it is possible only if I first materialize the distances (maybe???)
+
+query II
+EXPLAIN ANALYZE SELECT *
+FROM my_vector_table
+WHERE id > 0
+ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
+LIMIT 3;
+----
+analyzed_plan	<REGEX>:.*HSNW Index:.*my_hnsw_index.*
+
+
+query II
+SELECT *
+FROM my_vector_table
+WHERE id > 3
+ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
+LIMIT 3;
+----
+7	[1.0, 2.0, 3.0]
+8	[1.0, 2.0, 3.0]
+9	[1.0, 2.0, 3.0]
+
+# try id only
+
+query I
+SELECT id
+FROM my_vector_table
+ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
+LIMIT 3;
+----
+7
+8
+9
+
+# try vector only
+
+query I
+SELECT vec
+FROM my_vector_table
+ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
+LIMIT 3;
+----
+[1.0, 2.0, 3.0]
+[1.0, 2.0, 3.0]
+[1.0, 2.0, 3.0]
+
+
+# Change the ranges. That was working before the changes, it should work now as well
+
+statement ok
+CREATE TABLE my_vector_table2 (id INTEGER, vec FLOAT[3]);
+
+statement ok
+INSERT INTO my_vector_table2 (id, vec)
+SELECT id, array_value(a, b, c)
+FROM range(0, 10) t1(id),
+     range(0, 10) t2(a),
+     range(0, 10) t3(b),
+     range(0, 10) t4(c);
+
+statement ok
+CREATE INDEX my_hnsw_index2 ON my_vector_table2 USING hnsw (vec);
+
+query II
+SELECT *
+FROM my_vector_table2
+WHERE id > 0
+ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
+LIMIT 3;
+----
+7	[1.0, 2.0, 3.0]
+8	[1.0, 2.0, 3.0]
+9	[1.0, 2.0, 3.0]
+
+query II
+SELECT *
+FROM my_vector_table2
+WHERE id > 3
+ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
+LIMIT 3;
+----
+7	[1.0, 2.0, 3.0]
+8	[1.0, 2.0, 3.0]
+9	[1.0, 2.0, 3.0]
+
+# Try without the id
+
+statement ok
+CREATE TABLE vec_only(vec FLOAT[3]);
+
+statement ok
+INSERT INTO vec_only
+SELECT array_value(a, b, c)
+FROM range(1, 10) t1(a),
+     range(1, 10) t2(b),
+     range(1, 10) t3(c);
+
+statement ok
+CREATE INDEX vec_only_idx ON vec_only USING hnsw(vec);
+
+query I
+SELECT *
+FROM vec_only
+ORDER BY array_distance(vec, [1,2,3]::FLOAT[3])
+LIMIT 3;
+----
+[1.0, 2.0, 3.0]
+[2.0, 2.0, 3.0]
+[1.0, 2.0, 4.0]
+
+query II
+SELECT id, array_distance(vec, [1,2,3]::FLOAT[3]) as dist
+FROM my_vector_table
+WHERE id > 0
+ORDER BY dist
+LIMIT 3;
+----
+7	0.0
+8	0.0
+9	0.0

--- a/test/sql/hnsw/where_clause_segfault.test
+++ b/test/sql/hnsw/where_clause_segfault.test
@@ -20,16 +20,16 @@ FROM range(1, 10) t1(id),
 statement ok
 CREATE INDEX my_hnsw_index ON my_vector_table USING hnsw (vec);
 
-query II
-SELECT *
+query I
+SELECT array_distance(vec, [1, 2, 3]::FLOAT[3]) < 1.0
 FROM my_vector_table
 WHERE id > 0
 ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
 LIMIT 3;
 ----
-7	[1.0, 2.0, 3.0]
-8	[1.0, 2.0, 3.0]
-9	[1.0, 2.0, 3.0]
+1
+1
+1
 
 # Make sure the plan is not falling back to a sequential scan. Maybe that is not even possible in that case. I think it is possible only if I first materialize the distances (maybe???)
 
@@ -95,16 +95,16 @@ FROM range(0, 10) t1(id),
 statement ok
 CREATE INDEX my_hnsw_index2 ON my_vector_table2 USING hnsw (vec);
 
-query II
-SELECT *
+query I
+SELECT array_distance(vec, [1, 2, 3]::FLOAT[3]) < 1.0
 FROM my_vector_table2
 WHERE id > 0
 ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
 LIMIT 3;
 ----
-7	[1.0, 2.0, 3.0]
-8	[1.0, 2.0, 3.0]
-9	[1.0, 2.0, 3.0]
+1
+1
+1
 
 query II
 SELECT *
@@ -116,31 +116,6 @@ LIMIT 3;
 7	[1.0, 2.0, 3.0]
 8	[1.0, 2.0, 3.0]
 9	[1.0, 2.0, 3.0]
-
-# Try without the id
-
-statement ok
-CREATE TABLE vec_only(vec FLOAT[3]);
-
-statement ok
-INSERT INTO vec_only
-SELECT array_value(a, b, c)
-FROM range(1, 10) t1(a),
-     range(1, 10) t2(b),
-     range(1, 10) t3(c);
-
-statement ok
-CREATE INDEX vec_only_idx ON vec_only USING hnsw(vec);
-
-query I
-SELECT *
-FROM vec_only
-ORDER BY array_distance(vec, [1,2,3]::FLOAT[3])
-LIMIT 3;
-----
-[1.0, 2.0, 3.0]
-[2.0, 2.0, 3.0]
-[1.0, 2.0, 4.0]
 
 query II
 SELECT id, array_distance(vec, [1,2,3]::FLOAT[3]) as dist

--- a/test/sql/hnsw/where_clause_segfault.test
+++ b/test/sql/hnsw/where_clause_segfault.test
@@ -106,16 +106,16 @@ LIMIT 3;
 1
 1
 
-query II
-SELECT *
+query I
+SELECT array_distance(vec, [1, 2, 3]::FLOAT[3]) < 1.0
 FROM my_vector_table2
 WHERE id > 3
 ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
 LIMIT 3;
 ----
-7	[1.0, 2.0, 3.0]
-8	[1.0, 2.0, 3.0]
-9	[1.0, 2.0, 3.0]
+1
+1
+1
 
 query II
 SELECT id, array_distance(vec, [1,2,3]::FLOAT[3]) as dist


### PR DESCRIPTION
fixes: https://github.com/duckdb/duckdb-vss/issues/62

This fixes a binding mismatch that happened when late materialization is applied . The ```HNSWIndexScan``` function was not emitting ```row_ids```, which caused a mismatch between what the planner expected and what the function returned, leading to a segmentation fault. The fix ensures that the index scan correctly emits row_ids when needed, based on the columns requested by the planner. 

Known Issue: A query like 
```sql
EXPLAIN ANALYZE SELECT *
FROM my_vector_table
WHERE id = 4
ORDER BY array_distance(vec, [1, 2, 3]::FLOAT[3])
LIMIT 3;
```
does not return any results. The problem here is that we push the ```LIMIT``` into the index scan. There are multiple possible solutions. I will try to come up with one that does not hurt performance.

Possible solutions:
- Always fetch a chunk of 2048 items, and let core DuckDB do the filtering and limit. I believe 2048 is a reasonable (magic) number, it assumes a fairly selective query and offers a good performance trade-off (though benchmarks will confirm this). The downside is that if a user asks for a less selective query ( > 2048) we cannot provide all the results.
- Figure out whether and how we can use ```filtered_search``` to pass a predicate function directly to the search method. This could enable filtering results at query time, potentially improving performance or reducing post-processing.
- ...
