### PR TITLE
Support static 'table_filters' in HNSW_INDEX_SCAN

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,38 @@ The following table shows the supported distance metrics and their corresponding
 | Cosine similarity | `cosine` | `array_cosine_distance`        |
 | Inner product | `ip` | `array_negative_inner_product` |
 
+## Filtered Queries
+
+The HNSW index supports WHERE clause filters on the same table. Filters are pushed into the index scan so that filtered rows do not consume the `LIMIT` budget — you reliably get `LIMIT` results as long as enough rows satisfy the filter.
+
+```sql
+-- Filtered nearest-neighbor search
+SELECT id, category
+FROM items
+WHERE category = 'electronics'
+ORDER BY array_distance(vec, [0.5, 0.5, 0.5]::FLOAT[3])
+LIMIT 10;
+```
+
+Supported filter types: equality (`=`), range (`>`, `>=`, `<`, `<=`, `BETWEEN`), `IN (...)`, `IS NOT NULL`, and AND combinations of the above.
+
+Use `EXPLAIN` to verify the filter is being pushed in — the plan should show `HNSW_INDEX_SCAN` with no `FILTER` node above it:
+
+```sql
+EXPLAIN SELECT id FROM items
+WHERE category = 'electronics'
+ORDER BY array_distance(vec, [0.5, 0.5, 0.5]::FLOAT[3])
+LIMIT 10;
+```
+
+**How it works:** before the HNSW search, a single O(n) pass over the filter column(s) builds a row-ID bitmap marking rows that pass the predicate. The HNSW search then uses this bitmap to skip non-matching rows, ensuring they do not count against the `LIMIT`. This means every filtered query has an O(n) pre-scan cost over the filter columns. For large tables with non-selective filters where post-filter underfill is acceptable, the pushdown can be disabled:
+
+```sql
+SET hnsw_enable_filter_pushdown = false;
+```
+
+For deeper design details see [docs/filtered_hnsw.md](docs/filtered_hnsw.md).
+
 ## Inserts, Updates,  Deletes and Re-Compaction
 
 The HNSW index does support inserting, updating and deleting rows from the table after index creation. However, there are two things to keep in mind:  

--- a/src/hnsw/CMakeLists.txt
+++ b/src/hnsw/CMakeLists.txt
@@ -1,5 +1,6 @@
 set(EXTENSION_SOURCES
     ${EXTENSION_SOURCES}
+    ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_filter_bitmap.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index_macros.cpp
     ${CMAKE_CURRENT_SOURCE_DIR}/hnsw_index_physical_create.cpp

--- a/src/hnsw/hnsw_filter_bitmap.cpp
+++ b/src/hnsw/hnsw_filter_bitmap.cpp
@@ -1,0 +1,162 @@
+#include "hnsw/hnsw_filter_bitmap.hpp"
+
+#include "duckdb/catalog/catalog_entry/table_catalog_entry.hpp"
+#include "duckdb/common/allocator.hpp"
+#include "duckdb/common/constants.hpp"
+#include "duckdb/execution/expression_executor.hpp"
+#include "duckdb/planner/expression/bound_reference_expression.hpp"
+#include "duckdb/planner/expression/bound_conjunction_expression.hpp"
+#include "duckdb/storage/data_table.hpp"
+#include "duckdb/storage/storage_index.hpp"
+#include "duckdb/storage/table/scan_state.hpp"
+#include "duckdb/transaction/duck_transaction.hpp"
+#include "duckdb/transaction/local_storage.hpp"
+
+namespace duckdb {
+
+//! Marks row_ids from a scanned chunk that pass the given ExpressionExecutor filter into the bitmap.
+//! sel is a scratch buffer; chunk has filter columns at positions 0..n-1, row_id at position n.
+static void MarkMatchingRows(ExpressionExecutor &executor, DataChunk &chunk, SelectionVector &sel,
+                             idx_t filter_col_count, FilterBitmap &bitmap) {
+	// The executor expression references columns 0..filter_col_count-1.
+	// We pass the whole chunk; the row_id at position filter_col_count is ignored.
+	idx_t valid_count = executor.SelectExpression(chunk, sel);
+
+	auto &row_id_vec = chunk.data[filter_col_count]; // last column = row_id
+	// DuckDB may return row_ids as a SequenceVector (lazy base+increment representation).
+	// Flatten materialises the values into a FlatVector so GetData returns correct row IDs.
+	row_id_vec.Flatten(chunk.size());
+	auto row_ids_ptr = FlatVector::GetData<row_t>(row_id_vec);
+	for (idx_t i = 0; i < valid_count; i++) {
+		bitmap.Set(row_ids_ptr[sel.get_index(i)]);
+	}
+}
+
+unique_ptr<FilterBitmap> BuildFilterBitmap(ClientContext &context, TableCatalogEntry &table,
+                                           const TableFilterSet &filters,
+                                           const vector<idx_t> &logical_col_ids,
+                                           const vector<LogicalType> &col_types) {
+	D_ASSERT(!filters.filters.empty());
+	D_ASSERT(logical_col_ids.size() == col_types.size());
+
+	auto &storage = table.GetStorage();
+	auto &transaction = DuckTransaction::Get(context, table.catalog);
+
+	// Pre-allocate bitmap to the current total committed row count (safe upper bound for main storage).
+	// Local storage row_ids can exceed this; FilterBitmap::Set grows the vector on demand.
+	auto bitmap = make_uniq<FilterBitmap>();
+	const idx_t total_rows = storage.GetTotalRows();
+	bitmap->bits.assign(total_rows, 0);
+
+	// Build scan column IDs: [filter_col_0, filter_col_1, ..., row_id]
+	vector<StorageIndex> scan_col_ids;
+	scan_col_ids.reserve(logical_col_ids.size() + 1);
+	for (idx_t i = 0; i < logical_col_ids.size(); i++) {
+		auto storage_oid = table.GetColumn(LogicalIndex(logical_col_ids[i])).StorageOid();
+		scan_col_ids.emplace_back(storage_oid);
+	}
+	scan_col_ids.emplace_back(DConstants::INVALID_INDEX); // row_id column marker
+
+	// Build scan types: [filter_col_types..., ROW_TYPE]
+	vector<LogicalType> scan_types = col_types;
+	scan_types.push_back(LogicalType::ROW_TYPE);
+	const idx_t filter_col_count = col_types.size();
+
+	// Build filter expressions, each bound to its chunk-position index (0, 1, ...) rather
+	// than the original logical column ID.  This is critical: after scanning, chunk columns
+	// are laid out at positions 0..n-1, independent of the source table's column numbering.
+	vector<unique_ptr<Expression>> filter_exprs;
+	filter_exprs.reserve(filters.filters.size());
+	for (idx_t i = 0; i < logical_col_ids.size(); i++) {
+		idx_t orig_col_id = logical_col_ids[i];
+		auto it = filters.filters.find(orig_col_id);
+		if (it == filters.filters.end()) {
+			continue;
+		}
+		auto col_ref = make_uniq<BoundReferenceExpression>(col_types[i], i);
+		filter_exprs.push_back(it->second->ToExpression(*col_ref));
+	}
+
+	if (filter_exprs.empty()) {
+		// No evaluable filters (shouldn't normally happen given the caller's guard)
+		return bitmap;
+	}
+
+	// Combine multiple filters into a single AND expression so we can use SelectExpression
+	unique_ptr<Expression> combined_expr;
+	if (filter_exprs.size() == 1) {
+		combined_expr = std::move(filter_exprs[0]);
+	} else {
+		auto conjunction = make_uniq<BoundConjunctionExpression>(ExpressionType::CONJUNCTION_AND);
+		for (auto &expr : filter_exprs) {
+			conjunction->children.push_back(std::move(expr));
+		}
+		combined_expr = std::move(conjunction);
+	}
+
+	ExpressionExecutor executor(context, *combined_expr);
+	SelectionVector sel(STANDARD_VECTOR_SIZE);
+	DataChunk chunk;
+	chunk.Initialize(Allocator::Get(context), scan_types);
+
+	// Build a POSITION-remapped TableFilterSet for zone-map pruning.
+	// ScanFilterInfo::Initialize treats filter keys as indices into scan_col_ids, NOT logical col IDs.
+	// We scan with [label_storage_col, row_id], so label is at scan position 0, not logical position 1.
+	TableFilterSet remapped_filters;
+	for (idx_t i = 0; i < logical_col_ids.size(); i++) {
+		idx_t orig_col_id = logical_col_ids[i];
+		auto it = filters.filters.find(orig_col_id);
+		if (it != filters.filters.end()) {
+			remapped_filters.filters.emplace(i, it->second->Copy());
+		}
+	}
+
+	// --- Scan main (committed) storage ---
+	// Passing the remapped TableFilterSet enables zone-map pruning (row-group skipping).
+	// Row-level filtering is applied via ExpressionExecutor above.
+	{
+		TableScanState scan_state;
+		storage.InitializeScan(context, transaction, scan_state, scan_col_ids,
+		                       optional_ptr<TableFilterSet>(&remapped_filters));
+
+		while (true) {
+			chunk.Reset();
+			storage.Scan(transaction, chunk, scan_state);
+			if (chunk.size() == 0) {
+				break;
+			}
+			MarkMatchingRows(executor, chunk, sel, filter_col_count, *bitmap);
+		}
+	}
+
+	// --- Scan local (transaction-local / uncommitted) storage ---
+	// Rows inserted within the current transaction are in local storage and may also
+	// have been added to the HNSW index.  They must be included in the bitmap so that
+	// filtered_ef_search does not exclude them.
+	// FilterBitmap::Set grows the vector on demand for row_ids beyond the pre-allocated size.
+	{
+		auto &local_storage = LocalStorage::Get(context, table.catalog);
+		if (local_storage.Find(storage)) {
+			// TableScanState acts as the required parent for local_state (CollectionScanState).
+			TableScanState local_ts;
+			local_storage.InitializeScan(storage, local_ts.local_state,
+			                             optional_ptr<TableFilterSet>(&remapped_filters));
+
+			DataChunk local_chunk;
+			local_chunk.Initialize(Allocator::Get(context), scan_types);
+
+			while (true) {
+				local_chunk.Reset();
+				local_storage.Scan(local_ts.local_state, scan_col_ids, local_chunk);
+				if (local_chunk.size() == 0) {
+					break;
+				}
+				MarkMatchingRows(executor, local_chunk, sel, filter_col_count, *bitmap);
+			}
+		}
+	}
+
+	return bitmap;
+}
+
+} // namespace duckdb

--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -231,6 +231,11 @@ HNSWIndex::HNSWIndex(const string &name, IndexConstraintType index_constraint_ty
 
 		// Is there anything to deserialize? We could have an empty index
 		if (!info.allocator_infos[0].buffer_ids.empty()) {
+			// Reserve with hardware_concurrency threads so load_from_stream captures a non-zero
+			// old_limits.threads() and properly initializes cast_buffer_ and available_threads_.
+			// (In usearch 2.25.0, make() initialises limits to {0,0,0}; load_from_stream uses
+			// old_limits before its internal reset(), so it would otherwise leave both at zero.)
+			index.try_reserve(unum::usearch::index_limits_t {0});
 			LinkedBlockReader reader(*linked_block_allocator, root_block_ptr);
 			index.load_from_stream(
 			    [&](void *data, size_t size) { return size == reader.ReadData(static_cast<data_ptr_t>(data), size); });
@@ -332,14 +337,14 @@ unique_ptr<IndexScanState> HNSWIndex::InitializeScan(float *query_vector, idx_t 
 
 	// Acquire a shared lock to search the index
 	auto lock = rwlock.GetSharedLock();
-	USearchIndexType::search_result_t search_result;
-	if (bitmap) {
-		search_result = index.filtered_ef_search(
-		    query_vector, limit, [&](row_t key) noexcept { return bitmap->Contains(key); }, ef_search,
-		    index.any_thread());
-	} else {
-		search_result = index.ef_search(query_vector, limit, ef_search);
-	}
+	auto search_result = [&]() -> USearchIndexType::search_result_t {
+		if (bitmap) {
+			return index.filtered_ef_search(
+			    query_vector, limit, [&](row_t key) noexcept { return bitmap->Contains(key); }, ef_search,
+			    index.any_thread());
+		}
+		return index.ef_search(query_vector, limit, ef_search);
+	}();
 
 	state->current_row = 0;
 	state->total_rows = search_result.size();
@@ -396,18 +401,16 @@ unique_ptr<IndexScanState> HNSWIndex::InitializeMultiScan(ClientContext &context
 idx_t HNSWIndex::ExecuteMultiScan(IndexScanState &state_p, float *query_vector, idx_t limit) {
 	auto &state = state_p.Cast<MultiScanState>();
 
-	USearchIndexType::search_result_t search_result;
-	{
-		auto lock = rwlock.GetSharedLock();
+	auto lock = rwlock.GetSharedLock();
+	auto search_result = [&]() -> USearchIndexType::search_result_t {
 		if (state.filter_bitmap) {
 			const auto *bm = state.filter_bitmap;
-			search_result = index.filtered_ef_search(
+			return index.filtered_ef_search(
 			    query_vector, limit, [&](row_t key) noexcept { return bm->Contains(key); }, state.ef_search,
 			    index.any_thread());
-		} else {
-			search_result = index.ef_search(query_vector, limit, state.ef_search);
 		}
-	}
+		return index.ef_search(query_vector, limit, state.ef_search);
+	}();
 
 	const auto offset = state.row_ids.size();
 	state.row_ids.resize(state.row_ids.size() + search_result.size());

--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -1,4 +1,5 @@
 #include "hnsw/hnsw_index.hpp"
+#include "hnsw/hnsw_filter_bitmap.hpp"
 
 #include "duckdb/common/allocator.hpp"
 #include "duckdb/common/assert.hpp"
@@ -312,7 +313,8 @@ struct HNSWIndexScanState : public IndexScanState {
 	unique_array<row_t> row_ids = nullptr;
 };
 
-unique_ptr<IndexScanState> HNSWIndex::InitializeScan(float *query_vector, idx_t limit, ClientContext &context) {
+unique_ptr<IndexScanState> HNSWIndex::InitializeScan(float *query_vector, idx_t limit, ClientContext &context,
+                                                     const FilterBitmap *bitmap) {
 	auto state = make_uniq<HNSWIndexScanState>();
 
 	// Try to get the ef_search parameter from the database or use the default value
@@ -330,7 +332,14 @@ unique_ptr<IndexScanState> HNSWIndex::InitializeScan(float *query_vector, idx_t 
 
 	// Acquire a shared lock to search the index
 	auto lock = rwlock.GetSharedLock();
-	auto search_result = index.ef_search(query_vector, limit, ef_search);
+	USearchIndexType::search_result_t search_result;
+	if (bitmap) {
+		search_result = index.filtered_ef_search(
+		    query_vector, limit, [&](row_t key) noexcept { return bitmap->Contains(key); }, ef_search,
+		    index.any_thread());
+	} else {
+		search_result = index.ef_search(query_vector, limit, ef_search);
+	}
 
 	state->current_row = 0;
 	state->total_rows = search_result.size();
@@ -359,11 +368,14 @@ struct MultiScanState final : IndexScanState {
 	Vector vec;
 	vector<row_t> row_ids;
 	size_t ef_search;
+	//! Non-owning pointer; bitmap is owned by the calling operator state.
+	const FilterBitmap *filter_bitmap = nullptr;
+
 	MultiScanState(size_t ef_search_p) : vec(LogicalType::ROW_TYPE, nullptr), ef_search(ef_search_p) {
 	}
 };
 
-unique_ptr<IndexScanState> HNSWIndex::InitializeMultiScan(ClientContext &context) {
+unique_ptr<IndexScanState> HNSWIndex::InitializeMultiScan(ClientContext &context, const FilterBitmap *bitmap) {
 	// Try to get the ef_search parameter from the database or use the default value
 	auto ef_search = index.expansion_search();
 
@@ -376,8 +388,9 @@ unique_ptr<IndexScanState> HNSWIndex::InitializeMultiScan(ClientContext &context
 			}
 		}
 	}
-	// Return the new state
-	return make_uniq<MultiScanState>(ef_search);
+	auto state = make_uniq<MultiScanState>(ef_search);
+	state->filter_bitmap = bitmap;
+	return std::move(state);
 }
 
 idx_t HNSWIndex::ExecuteMultiScan(IndexScanState &state_p, float *query_vector, idx_t limit) {
@@ -386,7 +399,14 @@ idx_t HNSWIndex::ExecuteMultiScan(IndexScanState &state_p, float *query_vector, 
 	USearchIndexType::search_result_t search_result;
 	{
 		auto lock = rwlock.GetSharedLock();
-		search_result = index.ef_search(query_vector, limit, state.ef_search);
+		if (state.filter_bitmap) {
+			const auto *bm = state.filter_bitmap;
+			search_result = index.filtered_ef_search(
+			    query_vector, limit, [&](row_t key) noexcept { return bm->Contains(key); }, state.ef_search,
+			    index.any_thread());
+		} else {
+			search_result = index.ef_search(query_vector, limit, state.ef_search);
+		}
 	}
 
 	const auto offset = state.row_ids.size();
@@ -715,9 +735,18 @@ void HNSWModule::RegisterIndex(DatabaseInstance &db) {
 	                             LogicalType::BOOLEAN, Value::BOOLEAN(false));
 
 	// Register scan option
-	db.config.AddExtensionOption("hnsw_ef_search",
-	                             "experimental: override the ef_search parameter when scanning HNSW indexes",
-	                             LogicalType::BIGINT);
+	db.config.AddExtensionOption(
+	    "hnsw_ef_search",
+	    "experimental: override the ef_search parameter when scanning HNSW indexes. "
+	    "Increase this value when using filtered queries with selective predicates to improve ANN recall.",
+	    LogicalType::BIGINT);
+
+	// Register filter pushdown option
+	db.config.AddExtensionOption("hnsw_enable_filter_pushdown",
+	                             "when true (default), WHERE clause filters on the HNSW table are pushed into the "
+	                             "index scan via a pre-built row bitmap so filtered candidates do not consume the "
+	                             "result budget. Set to false to revert to post-filter behavior.",
+	                             LogicalType::BOOLEAN, Value::BOOLEAN(true));
 
 	// Register the index type
 	db.config.GetIndexTypes().RegisterIndexType(index_type);

--- a/src/hnsw/hnsw_index_scan.cpp
+++ b/src/hnsw/hnsw_index_scan.cpp
@@ -15,6 +15,7 @@
 #include "duckdb/transaction/local_storage.hpp"
 
 #include "hnsw/hnsw.hpp"
+#include "hnsw/hnsw_filter_bitmap.hpp"
 #include "hnsw/hnsw_index.hpp"
 
 namespace duckdb {
@@ -38,6 +39,9 @@ struct HNSWIndexScanGlobalState : public GlobalTableFunctionState {
 
 	DataChunk all_columns;
 	vector<idx_t> projection_ids;
+
+	//! Bitmap built from pushed-down filters; nullptr when no filter pushdown.
+	unique_ptr<FilterBitmap> filter_bitmap;
 };
 
 static unique_ptr<GlobalTableFunctionState> HNSWIndexScanInitGlobal(ClientContext &context,
@@ -63,9 +67,16 @@ static unique_ptr<GlobalTableFunctionState> HNSWIndexScanInitGlobal(ClientContex
 	result->local_storage_state.Initialize(result->column_ids, context, input.filters);
 	local_storage.InitializeScan(bind_data.table.GetStorage(), result->local_storage_state.local_state, input.filters);
 
-	// Initialize the scan state for the index
-	result->index_state =
-	    bind_data.index.Cast<HNSWIndex>().InitializeScan(bind_data.query.get(), bind_data.limit, context);
+	// Build filter bitmap if filters were pushed down by the optimizer
+	if (bind_data.pushed_filters && !bind_data.pushed_filters->filters.empty()) {
+		result->filter_bitmap =
+		    BuildFilterBitmap(context, bind_data.table, *bind_data.pushed_filters,
+		                      bind_data.filter_logical_col_ids, bind_data.filter_col_types);
+	}
+
+	// Initialize the scan state for the index (pass bitmap when available)
+	result->index_state = bind_data.index.Cast<HNSWIndex>().InitializeScan(
+	    bind_data.query.get(), bind_data.limit, context, result->filter_bitmap.get());
 
 	if (!input.CanRemoveFilterColumns()) {
 		return std::move(result);
@@ -161,6 +172,19 @@ static InsertionOrderPreservingMap<string> HNSWIndexScanToString(TableFunctionTo
 	auto &bind_data = input.bind_data->Cast<HNSWIndexScanBindData>();
 	result["Table"] = bind_data.table.name;
 	result["HNSW Index"] = bind_data.index.GetIndexName();
+
+	if (bind_data.pushed_filters && !bind_data.pushed_filters->filters.empty()) {
+		string filter_str;
+		for (const auto &entry : bind_data.pushed_filters->filters) {
+			auto col_name = bind_data.table.GetColumn(LogicalIndex(entry.first)).Name();
+			if (!filter_str.empty()) {
+				filter_str += ", ";
+			}
+			filter_str += entry.second->ToString(col_name);
+		}
+		result["Filters"] = filter_str;
+	}
+
 	return result;
 }
 

--- a/src/hnsw/hnsw_optimize_scan.cpp
+++ b/src/hnsw/hnsw_optimize_scan.cpp
@@ -1,7 +1,9 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
+#include "duckdb/optimizer/column_binding_replacer.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
+#include "duckdb/planner/operator/logical_comparison_join.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
@@ -17,6 +19,10 @@
 #include "hnsw/hnsw_index_scan.hpp"
 
 namespace duckdb {
+
+// Forward declarations — defined after HNSWIndexScanOptimizer
+static void FoldLateMaterializationJoins(unique_ptr<LogicalOperator> &plan);
+static void EliminateRedundantOrders(unique_ptr<LogicalOperator> &plan);
 
 //-----------------------------------------------------------------------------
 // Plan rewriter
@@ -159,41 +165,66 @@ public:
 		get.estimated_cardinality = cardinality->estimated_cardinality;
 		get.bind_data = std::move(bind_data);
 		if (get.table_filters.filters.empty()) {
-
 			// Remove the TopN operator
 			plan = std::move(top_n.children[0]);
 			return true;
 		}
 
-		// Otherwise, things get more complicated. We need to pullup the filters from the table scan as our index scan
-		// does not support regular filter pushdown.
-		get.projection_ids.clear();
-		get.types.clear();
-
-		auto new_filter = make_uniq<LogicalFilter>();
-		auto &column_ids = get.GetColumnIds();
-		for (const auto &entry : get.table_filters.filters) {
-			idx_t column_id = entry.first;
-			auto &type = get.returned_types[column_id];
-			bool found = false;
-			for (idx_t i = 0; i < column_ids.size(); i++) {
-				if (column_ids[i].GetPrimaryIndex() == column_id) {
-					column_id = i;
-					found = true;
-					break;
-				}
+		// Check whether filter pushdown into the HNSW scan is enabled
+		Value pushdown_enabled_val;
+		bool use_pushdown = true;
+		if (context.TryGetCurrentSetting("hnsw_enable_filter_pushdown", pushdown_enabled_val)) {
+			if (!pushdown_enabled_val.IsNull()) {
+				use_pushdown = pushdown_enabled_val.GetValue<bool>();
 			}
-			if (!found) {
-				throw InternalException("Could not find column id for filter");
-			}
-			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
-			new_filter->expressions.push_back(entry.second->ToExpression(*column));
 		}
-		new_filter->children.push_back(std::move(get_ptr));
-		new_filter->ResolveOperatorTypes();
-		get_ptr = std::move(new_filter);
 
-		// Remove the TopN operator
+		auto &hnsw_bind = get.bind_data->Cast<HNSWIndexScanBindData>();
+
+		if (use_pushdown) {
+			// Push filters into the bind data so the scan builds a FilterBitmap at execution time.
+			// This ensures filtered candidates don't consume the wanted budget in filtered_ef_search.
+			for (const auto &entry : get.table_filters.filters) {
+				hnsw_bind.filter_logical_col_ids.push_back(entry.first);
+				hnsw_bind.filter_col_types.push_back(get.returned_types[entry.first]);
+			}
+			hnsw_bind.pushed_filters = get.table_filters.Copy();
+			// Clear from LogicalGet so DuckDB does not create a duplicate LogicalFilter above.
+			get.table_filters.filters.clear();
+		} else {
+			// Escape hatch: fall back to the original post-filter pull-up behavior.
+			// Keep the TopN in the plan so LIMIT/ORDER BY are preserved.
+			get.projection_ids.clear();
+			get.types.clear();
+
+			auto new_filter = make_uniq<LogicalFilter>();
+			auto &column_ids = get.GetColumnIds();
+			for (const auto &entry : get.table_filters.filters) {
+				idx_t column_id = entry.first;
+				auto &type = get.returned_types[column_id];
+				bool found = false;
+				for (idx_t i = 0; i < column_ids.size(); i++) {
+					if (column_ids[i].GetPrimaryIndex() == column_id) {
+						column_id = i;
+						found = true;
+						break;
+					}
+				}
+				if (!found) {
+					throw InternalException("Could not find column id for filter");
+				}
+				auto column =
+				    make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
+				new_filter->expressions.push_back(entry.second->ToExpression(*column));
+			}
+			new_filter->children.push_back(std::move(get_ptr));
+			new_filter->ResolveOperatorTypes();
+			get_ptr = std::move(new_filter);
+			// Don't remove TopN here — the Filter node sits above the scan, TopN stays above everything.
+			return true;
+		}
+
+		// Pushdown path: remove the TopN operator (HNSW scan already enforces the limit).
 		plan = std::move(top_n.children[0]);
 		return true;
 	}
@@ -252,9 +283,251 @@ public:
 		auto did_use_hnsw_scan = OptimizeChildren(input.context, plan);
 		if (did_use_hnsw_scan) {
 			MergeProjections(plan);
+			FoldLateMaterializationJoins(plan);
+			EliminateRedundantOrders(plan);
 		}
 	}
 };
+
+//-----------------------------------------------------------------------------
+// LateMaterialization join folder
+//-----------------------------------------------------------------------------
+// DuckDB's LateMaterialization optimizer (which runs before extension optimizers)
+// may split a query like:
+//
+//   SELECT id FROM t ORDER BY array_distance(vec, q) LIMIT k
+//
+// into:
+//
+//   PROJECTION(id, dist)
+//     SEMI_JOIN(left.rowid = right.rowid)
+//       left:  SEQ_SCAN(t, [id, vec])          ← O(n) full scan
+//       right: PROJECTION → HNSW_INDEX_SCAN(t, [vec, rowid])
+//
+// After OUR scan optimizer runs (on the right branch), the right side already
+// has an HNSW index scan.  Here we fold the SEMI JOIN away: we add the
+// missing columns (e.g., `id`) directly to the HNSW scan so the O(n) left
+// seq_scan can be eliminated entirely.
+//-----------------------------------------------------------------------------
+
+// Return the unique_ptr owner of the first LogicalGet(hnsw_index_scan) found in
+// the subtree rooted at `root`, or nullptr if none exists.
+// Stops (returns nullptr) if a LOGICAL_FILTER node is encountered — this means
+// the escape-hatch path was taken and the filter must not be discarded.
+static unique_ptr<LogicalOperator> *FindHNSWGetOwner(unique_ptr<LogicalOperator> &root) {
+	// A filter node signals the escape hatch was used; bail out to preserve it.
+	if (root->type == LogicalOperatorType::LOGICAL_FILTER) {
+		return nullptr;
+	}
+	if (root->type == LogicalOperatorType::LOGICAL_GET &&
+	    root->Cast<LogicalGet>().function.name == "hnsw_index_scan") {
+		return &root;
+	}
+	for (auto &child : root->children) {
+		auto *found = FindHNSWGetOwner(child);
+		if (found) {
+			return found;
+		}
+	}
+	return nullptr;
+}
+
+// Attempt to fold a LateMaterialization SEMI JOIN into the HNSW scan.
+//
+// On success:
+//   - Missing columns are added to hnsw_get.column_ids / hnsw_get.types.
+//   - `semi_join_ref` is replaced with the HNSW GET node directly.
+//   - `replacer` is populated with (left_tbl_binding → hnsw_tbl_binding) mappings
+//     so the caller can fix column references in the parent operator.
+static bool TryFoldSemiJoin(unique_ptr<LogicalOperator> &semi_join_ref, ColumnBindingReplacer &replacer) {
+	auto &join = semi_join_ref->Cast<LogicalComparisonJoin>();
+	if (join.join_type != JoinType::SEMI || join.children.size() != 2) {
+		return false;
+	}
+
+	// Left child must be a seq_scan on a DuckDB table
+	auto &left = join.children[0];
+	if (left->type != LogicalOperatorType::LOGICAL_GET) {
+		return false;
+	}
+	auto &left_get = left->Cast<LogicalGet>();
+	if (left_get.function.name != "seq_scan") {
+		return false;
+	}
+	if (!left_get.GetTable() || !left_get.GetTable()->IsDuckTable()) {
+		return false;
+	}
+
+	// Validate this is DuckDB's LateMaterialization pattern: a rowid-equality semi join.
+	// LateMaterialization always produces exactly one condition: left.rowid = right.rowid.
+	// If the condition is anything else this is a user-written semi join we must not fold.
+	if (join.conditions.size() != 1) {
+		return false;
+	}
+	const auto &cond = join.conditions[0];
+	if (cond.comparison != ExpressionType::COMPARE_EQUAL ||
+	    cond.left->type != ExpressionType::BOUND_COLUMN_REF) {
+		return false;
+	}
+	const auto &left_ref = cond.left->Cast<BoundColumnRefExpression>();
+	if (left_ref.binding.table_index != left_get.table_index) {
+		return false;
+	}
+	{
+		const auto &left_col_ids = left_get.GetColumnIds();
+		const idx_t output_k = left_ref.binding.column_index;
+		const idx_t scan_pos =
+		    left_get.projection_ids.empty() ? output_k : left_get.projection_ids[output_k];
+		if (scan_pos >= left_col_ids.size() || !left_col_ids[scan_pos].IsRowIdColumn()) {
+			return false;
+		}
+	}
+
+	// Right subtree must contain an hnsw_index_scan for the same physical table
+	auto *hnsw_owner = FindHNSWGetOwner(join.children[1]);
+	if (!hnsw_owner) {
+		return false;
+	}
+	auto &hnsw_get = (*hnsw_owner)->Cast<LogicalGet>();
+	if (!hnsw_get.GetTable() ||
+	    &left_get.GetTable()->GetStorage() != &hnsw_get.GetTable()->GetStorage()) {
+		return false;
+	}
+
+	// Build a map: logical column ID → current scan position in hnsw_get
+	unordered_map<idx_t, idx_t> logical_to_hnsw_pos;
+	idx_t hnsw_rowid_pos = DConstants::INVALID_INDEX;
+	{
+		const auto &h_col_ids = hnsw_get.GetColumnIds();
+		for (idx_t j = 0; j < h_col_ids.size(); j++) {
+			if (h_col_ids[j].IsRowIdColumn()) {
+				hnsw_rowid_pos = j;
+			} else if (!h_col_ids[j].IsVirtualColumn()) {
+				logical_to_hnsw_pos[h_col_ids[j].GetPrimaryIndex()] = j;
+			}
+		}
+	}
+
+	// Clear projection_ids so we manage column positions directly.
+	// Types will be rebuilt from scratch once all columns are finalised.
+	hnsw_get.projection_ids.clear();
+
+	// For each output column of left_get, ensure hnsw_get projects it and
+	// record the binding replacement (left_binding → hnsw_binding).
+	const auto left_bindings = left_get.GetColumnBindings();
+	const auto &left_col_ids = left_get.GetColumnIds();
+
+	for (idx_t k = 0; k < left_bindings.size(); k++) {
+		const auto old_binding = left_bindings[k]; // (left_tbl_idx, col_idx)
+
+		// Resolve the physical ColumnIndex for this output slot,
+		// taking into account possible projection_ids on the left scan.
+		const idx_t scan_pos = left_get.projection_ids.empty() ? k : left_get.projection_ids[k];
+		const auto &left_col_idx = left_col_ids[scan_pos];
+
+		idx_t hnsw_pos;
+		if (left_col_idx.IsRowIdColumn()) {
+			// rowid
+			if (hnsw_rowid_pos == DConstants::INVALID_INDEX) {
+				hnsw_rowid_pos = hnsw_get.GetMutableColumnIds().size();
+				hnsw_get.GetMutableColumnIds().emplace_back(COLUMN_IDENTIFIER_ROW_ID);
+			}
+			hnsw_pos = hnsw_rowid_pos;
+		} else {
+			auto primary = left_col_idx.GetPrimaryIndex();
+			auto it = logical_to_hnsw_pos.find(primary);
+			if (it != logical_to_hnsw_pos.end()) {
+				hnsw_pos = it->second;
+			} else {
+				// Column is not yet in hnsw_get – add it
+				hnsw_pos = hnsw_get.GetMutableColumnIds().size();
+				hnsw_get.GetMutableColumnIds().push_back(left_col_idx);
+				logical_to_hnsw_pos[primary] = hnsw_pos;
+			}
+		}
+
+		replacer.replacement_bindings.emplace_back(old_binding,
+		                                            ColumnBinding(hnsw_get.table_index, hnsw_pos));
+	}
+
+	// Rebuild output types to match the (now-final) column_ids
+	hnsw_get.types.clear();
+	for (const auto &col_id : hnsw_get.GetColumnIds()) {
+		hnsw_get.types.push_back(hnsw_get.GetColumnType(col_id));
+	}
+
+	// Extract the HNSW GET from the right branch and replace the SEMI JOIN
+	auto hnsw_node = std::move(*hnsw_owner);
+	semi_join_ref = std::move(hnsw_node);
+	// semi_join (and the left seq_scan) are now destroyed.
+
+	return true;
+}
+
+// Walk the plan tree.  For each direct child that is a SEMI JOIN, attempt to
+// fold it.  On success, apply the column-binding replacer to the current node
+// (which fixes all references to the eliminated left scan's bindings).
+static void FoldLateMaterializationJoins(unique_ptr<LogicalOperator> &plan) {
+	for (auto &child : plan->children) {
+		if (child->type == LogicalOperatorType::LOGICAL_COMPARISON_JOIN &&
+		    child->Cast<LogicalComparisonJoin>().join_type == JoinType::SEMI) {
+			ColumnBindingReplacer replacer;
+			if (TryFoldSemiJoin(child, replacer)) {
+				// Fix all column refs in the current node (and, recursively, its
+				// children – which now include the newly-placed HNSW GET).
+				replacer.VisitOperator(*plan);
+				// child is now the HNSW GET (a leaf), nothing to recurse into.
+				continue;
+			}
+		}
+		// Not a SEMI JOIN we could fold – recurse normally
+		FoldLateMaterializationJoins(child);
+	}
+}
+
+//-----------------------------------------------------------------------------
+// Redundant ORDER_BY elimination
+//-----------------------------------------------------------------------------
+// After FoldLateMaterializationJoins the plan may look like:
+//
+//   ORDER_BY(array_distance(vec, q))
+//     PROJECTION(...)
+//       HNSW_INDEX_SCAN(vec, id)
+//
+// HNSW_INDEX_SCAN already returns rows sorted by distance (ascending), so the
+// ORDER_BY is redundant.  Remove it to avoid re-evaluating the distance
+// expression on every returned row.
+//
+// We only remove ORDER_BY nodes whose entire subtree (modulo projections) is a
+// single HNSW_INDEX_SCAN — any other data source could break order guarantees.
+//-----------------------------------------------------------------------------
+
+// Returns true iff the subtree rooted at `op` is an HNSW_INDEX_SCAN
+// reachable through zero or more LOGICAL_PROJECTION nodes.
+static bool SubtreeIsHNSWOnly(const LogicalOperator &op) {
+	if (op.type == LogicalOperatorType::LOGICAL_GET) {
+		return op.Cast<LogicalGet>().function.name == "hnsw_index_scan";
+	}
+	if (op.type == LogicalOperatorType::LOGICAL_PROJECTION && op.children.size() == 1) {
+		return SubtreeIsHNSWOnly(*op.children[0]);
+	}
+	return false;
+}
+
+// Walk the plan and replace any LOGICAL_ORDER_BY whose subtree is HNSW-only
+// with that subtree directly (promoting the child past the sort).
+static void EliminateRedundantOrders(unique_ptr<LogicalOperator> &plan) {
+	if (plan->type == LogicalOperatorType::LOGICAL_ORDER_BY && plan->children.size() == 1 &&
+	    SubtreeIsHNSWOnly(*plan->children[0])) {
+		// Replace the ORDER_BY with its child; then recurse in case of nesting.
+		plan = std::move(plan->children[0]);
+		EliminateRedundantOrders(plan);
+		return;
+	}
+	for (auto &child : plan->children) {
+		EliminateRedundantOrders(child);
+	}
+}
 
 //-----------------------------------------------------------------------------
 // Register

--- a/src/hnsw/hnsw_optimize_topk.cpp
+++ b/src/hnsw/hnsw_optimize_topk.cpp
@@ -196,33 +196,55 @@ public:
 			return true;
 		}
 
-		// We need to pullup the filters from the table scan as our index scan does not support regular filter pushdown.
-		get.projection_ids.clear();
-		get.types.clear();
-
-		auto new_filter = make_uniq<LogicalFilter>();
-		auto &column_ids = get.GetColumnIds();
-		for (const auto &entry : get.table_filters.filters) {
-			idx_t column_id = entry.first;
-			auto &type = get.returned_types[column_id];
-			bool found = false;
-			for (idx_t i = 0; i < column_ids.size(); i++) {
-				if (column_ids[i].GetPrimaryIndex() == column_id) {
-					column_id = i;
-					found = true;
-					break;
-				}
+		// Check whether filter pushdown into the HNSW scan is enabled
+		Value pushdown_enabled_val;
+		bool use_pushdown = true;
+		if (context.TryGetCurrentSetting("hnsw_enable_filter_pushdown", pushdown_enabled_val)) {
+			if (!pushdown_enabled_val.IsNull()) {
+				use_pushdown = pushdown_enabled_val.GetValue<bool>();
 			}
-			if (!found) {
-				throw InternalException("Could not find column id for filter");
-			}
-			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
-			new_filter->expressions.push_back(entry.second->ToExpression(*column));
 		}
 
-		new_filter->children.push_back(std::move(get_ptr));
-		new_filter->ResolveOperatorTypes();
-		get_ptr = std::move(new_filter);
+		auto &hnsw_bind = get.bind_data->Cast<HNSWIndexScanBindData>();
+
+		if (use_pushdown) {
+			// Push filters into the bind data so the scan builds a FilterBitmap at execution time.
+			for (const auto &entry : get.table_filters.filters) {
+				hnsw_bind.filter_logical_col_ids.push_back(entry.first);
+				hnsw_bind.filter_col_types.push_back(get.returned_types[entry.first]);
+			}
+			hnsw_bind.pushed_filters = get.table_filters.Copy();
+			// Clear from LogicalGet so DuckDB does not create a duplicate LogicalFilter above.
+			get.table_filters.filters.clear();
+		} else {
+			// Escape hatch: fall back to the original post-filter pull-up behavior.
+			get.projection_ids.clear();
+			get.types.clear();
+
+			auto new_filter = make_uniq<LogicalFilter>();
+			auto &column_ids = get.GetColumnIds();
+			for (const auto &entry : get.table_filters.filters) {
+				idx_t column_id = entry.first;
+				auto &type = get.returned_types[column_id];
+				bool found = false;
+				for (idx_t i = 0; i < column_ids.size(); i++) {
+					if (column_ids[i].GetPrimaryIndex() == column_id) {
+						column_id = i;
+						found = true;
+						break;
+					}
+				}
+				if (!found) {
+					throw InternalException("Could not find column id for filter");
+				}
+				auto column =
+				    make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, column_id));
+				new_filter->expressions.push_back(entry.second->ToExpression(*column));
+			}
+			new_filter->children.push_back(std::move(get_ptr));
+			new_filter->ResolveOperatorTypes();
+			get_ptr = std::move(new_filter);
+		}
 
 		return true;
 	}

--- a/src/include/hnsw/hnsw_filter_bitmap.hpp
+++ b/src/include/hnsw/hnsw_filter_bitmap.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/types.hpp"
+#include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
+#include "duckdb/planner/table_filter.hpp"
+#include "duckdb/storage/storage_index.hpp"
+
+namespace duckdb {
+
+class ClientContext;
+class TableCatalogEntry;
+
+//! A dense boolean bitmap indexed by row_t. Used to pre-filter HNSW searches.
+//! Rows not present in the bitmap are excluded from graph traversal so they do
+//! not consume the `wanted` budget, avoiding post-filter underfill.
+//!
+//! Uses vector<uint8_t> (one byte per slot) rather than vector<bool> (bit-packed)
+//! to avoid bit-manipulation overhead on the hot predicate path inside USearch's
+//! linear filtered scan.
+struct FilterBitmap {
+	vector<uint8_t> bits; // 1 byte per row_id slot: 0 = absent, 1 = present
+
+	bool Contains(row_t row_id) const noexcept {
+		if (row_id < 0) {
+			return false;
+		}
+		auto idx = static_cast<idx_t>(row_id);
+		return idx < bits.size() && bits[idx] != 0;
+	}
+
+	void Set(row_t row_id) {
+		if (row_id < 0) {
+			return;
+		}
+		auto idx = static_cast<idx_t>(row_id);
+		if (idx >= bits.size()) {
+			bits.resize(idx + 1, 0);
+		}
+		bits[idx] = 1;
+	}
+};
+
+//! Scan the filter columns of `table` for all transaction-visible rows that
+//! satisfy `filters` and mark their row_ids in the returned bitmap.
+//!
+//! @param logical_col_ids  Logical column indices that are keys in filters.filters
+//! @param col_types        Types of those columns (positionally aligned)
+unique_ptr<FilterBitmap> BuildFilterBitmap(ClientContext &context, TableCatalogEntry &table,
+                                           const TableFilterSet &filters,
+                                           const vector<idx_t> &logical_col_ids,
+                                           const vector<LogicalType> &col_types);
+
+} // namespace duckdb

--- a/src/include/hnsw/hnsw_index.hpp
+++ b/src/include/hnsw/hnsw_index.hpp
@@ -50,12 +50,14 @@ public:
 	//! The allocator used to persist linked blocks
 	unique_ptr<FixedSizeAllocator> linked_block_allocator;
 
-	unique_ptr<IndexScanState> InitializeMultiScan(ClientContext &context);
+	unique_ptr<IndexScanState> InitializeMultiScan(ClientContext &context,
+	                                               const struct FilterBitmap *bitmap = nullptr);
 	idx_t ExecuteMultiScan(IndexScanState &state, float *query_vector, idx_t limit);
 	const Vector &GetMultiScanResult(IndexScanState &state);
 	void ResetMultiScan(IndexScanState &state);
 
-	unique_ptr<IndexScanState> InitializeScan(float *query_vector, idx_t limit, ClientContext &context);
+	unique_ptr<IndexScanState> InitializeScan(float *query_vector, idx_t limit, ClientContext &context,
+	                                          const struct FilterBitmap *bitmap = nullptr);
 	idx_t Scan(IndexScanState &state, Vector &result, idx_t result_offset = 0);
 	idx_t GetVectorSize() const;
 	string GetMetric() const;

--- a/src/include/hnsw/hnsw_index_scan.hpp
+++ b/src/include/hnsw/hnsw_index_scan.hpp
@@ -2,10 +2,14 @@
 
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/types.hpp"
 #include "duckdb/common/unique_ptr.hpp"
+#include "duckdb/common/vector.hpp"
 #include "duckdb/function/function.hpp"
 #include "duckdb/function/table_function.hpp"
 #include "duckdb/function/table/table_scan.hpp"
+#include "duckdb/planner/table_filter.hpp"
+#include "duckdb/storage/storage_index.hpp"
 
 namespace duckdb {
 
@@ -26,6 +30,12 @@ struct HNSWIndexScanBindData final : public TableScanBindData {
 
 	//! The query vector
 	unsafe_unique_array<float> query;
+
+	//! Optional filter pushdown: set by the optimizer when static table_filters are present.
+	//! When non-empty, a FilterBitmap is built at scan-init time and passed to filtered_ef_search.
+	unique_ptr<TableFilterSet> pushed_filters;
+	vector<idx_t>       filter_logical_col_ids; // logical col IDs (keys in pushed_filters->filters)
+	vector<LogicalType> filter_col_types;
 
 public:
 	bool Equals(const FunctionData &other_p) const override {

--- a/src/include/usearch/index.hpp
+++ b/src/include/usearch/index.hpp
@@ -8,13 +8,16 @@
 #define UNUM_USEARCH_HPP
 
 #define USEARCH_VERSION_MAJOR 2
-#define USEARCH_VERSION_MINOR 12
+#define USEARCH_VERSION_MINOR 25
 #define USEARCH_VERSION_PATCH 0
 
 // Inferring C++ version
 // https://stackoverflow.com/a/61552074
 #if ((defined(_MSVC_LANG) && _MSVC_LANG >= 201703L) || __cplusplus >= 201703L)
 #define USEARCH_DEFINED_CPP17
+#endif
+#if ((defined(_MSVC_LANG) && _MSVC_LANG >= 202002L) || __cplusplus >= 202002L)
+#define USEARCH_DEFINED_CPP20
 #endif
 
 // Inferring target OS: Windows, MacOS, or Linux
@@ -24,6 +27,9 @@
 #define USEARCH_DEFINED_APPLE
 #elif defined(__linux__)
 #define USEARCH_DEFINED_LINUX
+#if defined(__ANDROID_API__)
+#define USEARCH_DEFINED_ANDROID
+#endif
 #endif
 
 // Inferring the compiler: Clang vs GCC
@@ -31,6 +37,14 @@
 #define USEARCH_DEFINED_CLANG
 #elif defined(__GNUC__)
 #define USEARCH_DEFINED_GCC
+#endif
+
+// The `#pragma region` and `#pragma endregion` are not supported by GCC 12 and older.
+// But they are supported by GCC 13, all recent Clang versions, and MSVC.
+#if defined(__GNUC__) && ((__GNUC__ > 13) || (__GNUC__ == 13 && __GNUC_MINOR__ >= 0))
+#define USEARCH_USE_PRAGMA_REGION
+#elif defined(__clang__) || defined(_MSC_VER)
+#define USEARCH_USE_PRAGMA_REGION
 #endif
 
 // Inferring hardware architecture: x86 vs Arm
@@ -41,13 +55,14 @@
 #endif
 
 // Inferring hardware bitness: 32 vs 64
+// Using compiler predefined macros for is technically safer than including `<cstdint>` and
+// using the commonly advised `UINTPTR_MAX` trick, as that constant is optional in standard C/C++.
 // https://stackoverflow.com/a/5273354
-#if INTPTR_MAX == INT64_MAX
+// https://en.cppreference.com/w/cpp/types/integer.html
+#if defined(_WIN64) || defined(__LP64__) || defined(__x86_64__) || defined(__aarch64__) || defined(__powerpc64__)
 #define USEARCH_64BIT_ENV
-#elif INTPTR_MAX == INT32_MAX
-#define USEARCH_32BIT_ENV
 #else
-#error Unknown pointer size or missing size macros!
+#define USEARCH_32BIT_ENV
 #endif
 
 #if !defined(USEARCH_USE_OPENMP)
@@ -57,7 +72,9 @@
 // OS-specific includes
 #if defined(USEARCH_DEFINED_WINDOWS)
 #define _USE_MATH_DEFINES
+#ifndef NOMINMAX
 #define NOMINMAX
+#endif
 #include <Windows.h>
 #include <sys/stat.h> // `fstat` for file size
 #undef NOMINMAX
@@ -84,17 +101,39 @@
 #include <thread>    // `std::thread`
 #include <utility>   // `std::pair`
 
+// Helper macros for concatenation and stringification
+#define usearch_concat_helper_m(a, b) a##b
+#define usearch_concat_m(a, b) usearch_concat_helper_m(a, b)
+#define usearch_stringify_helper_m(x) #x
+#define usearch_stringify_m(x) usearch_stringify_helper_m(x)
+
 // Prefetching
 #if defined(USEARCH_DEFINED_GCC)
 // https://gcc.gnu.org/onlinedocs/gcc/Other-Builtins.html
 // Zero means we are only going to read from that memory.
 // Three means high temporal locality and suggests to keep
 // the data in all layers of cache.
-#define prefetch_m(ptr) __builtin_prefetch((void *)(ptr), 0, 3)
+#define usearch_prefetch_m(ptr) __builtin_prefetch((void*)(ptr), 0, 3)
 #elif defined(USEARCH_DEFINED_X86)
-#define prefetch_m(ptr) _mm_prefetch((void *)(ptr), _MM_HINT_T0)
+#define usearch_prefetch_m(ptr) _mm_prefetch((void*)(ptr), _MM_HINT_T0)
 #else
-#define prefetch_m(ptr)
+#define usearch_prefetch_m(ptr)
+#endif
+
+// Function profiling
+#if defined(usearch_defined_x86)
+#define usearch_profiled_m __attribute__((noinline))
+#define usearch_profile_name_m(name)                                                                                   \
+    __asm__ volatile(".globl " usearch_stringify_m(usearch_concat_m(name, __COUNTER__)) "\n" usearch_stringify_m(      \
+        usearch_concat_m(name, __COUNTER__)) ":")
+#elif defined(usearch_defined_arm)
+#define usearch_profiled_m __attribute__((noinline))
+#define usearch_profile_name_m(name)                                                                                   \
+    __asm__ volatile(".global " usearch_stringify_m(usearch_concat_m(name, __COUNTER__)) "\n" usearch_stringify_m(     \
+        usearch_concat_m(name, __COUNTER__)) ":")
+#else
+#define usearch_profiled_m
+#define usearch_profile_name_m(name)
 #endif
 
 // Alignment
@@ -102,7 +141,7 @@
 #define usearch_pack_m
 #define usearch_align_m __declspec(align(64))
 #else
-#define usearch_pack_m  __attribute__((packed))
+#define usearch_pack_m __attribute__((packed))
 #define usearch_align_m __attribute__((aligned(64)))
 #endif
 
@@ -112,22 +151,22 @@
 #define usearch_noexcept_m noexcept
 #else
 #define usearch_assert_m(must_be_true, message)                                                                        \
-	if (!(must_be_true)) {                                                                                             \
-		__usearch_raise_runtime_error(message);                                                                        \
-	}
+    if (!(must_be_true)) {                                                                                             \
+        usearch_raise_runtime_error(message);                                                                          \
+    }
 #define usearch_noexcept_m
 #endif
 
 extern "C" {
-/// @brief  Helper function to simplify debugging - trace just one symbol - `__usearch_raise_runtime_error`.
+/// @brief  Helper function to simplify debugging - trace just one symbol - `usearch_raise_runtime_error`.
 ///         Assuming the `extern C` block, the name won't be mangled.
-inline static void __usearch_raise_runtime_error(char const *message) {
-	// On Windows we compile with `/EHc` flag, which specifies that functions
-	// with C linkage do not throw C++ exceptions.
+inline static void usearch_raise_runtime_error(char const* message) {
+    // On Windows we compile with `/EHc` flag, which specifies that functions
+    // with C linkage do not throw C++ exceptions.
 #if !defined(__cpp_exceptions) || defined(USEARCH_DEFINED_WINDOWS)
-	std::terminate();
+    std::terminate();
 #else
-	throw std::runtime_error(message);
+    throw std::runtime_error(message);
 #endif
 }
 }
@@ -137,99 +176,94 @@ namespace usearch {
 
 using byte_t = char;
 
-template <std::size_t multiple_ak>
-std::size_t divide_round_up(std::size_t num) noexcept {
-	return (num + multiple_ak - 1) / multiple_ak;
+template <std::size_t multiple_ak> std::size_t divide_round_up(std::size_t num) noexcept {
+    return (num + multiple_ak - 1) / multiple_ak;
 }
 
 inline std::size_t divide_round_up(std::size_t num, std::size_t denominator) noexcept {
-	return (num + denominator - 1) / denominator;
+    return (num + denominator - 1) / denominator;
 }
 
 inline std::size_t ceil2(std::size_t v) noexcept {
-	v--;
-	v |= v >> 1;
-	v |= v >> 2;
-	v |= v >> 4;
-	v |= v >> 8;
-	v |= v >> 16;
+    v--;
+    v |= v >> 1;
+    v |= v >> 2;
+    v |= v >> 4;
+    v |= v >> 8;
+    v |= v >> 16;
 #ifdef USEARCH_64BIT_ENV
-	v |= v >> 32;
+    v |= v >> 32;
 #endif
-	v++;
-	return v;
+    v++;
+    return v;
 }
 
 /// @brief  Simply dereferencing misaligned pointers can be dangerous.
-template <typename at>
-void misaligned_store(void *ptr, at v) noexcept {
-	static_assert(!std::is_reference<at>::value, "Can't store a reference");
-	std::memcpy(ptr, &v, sizeof(at));
+template <typename at> void misaligned_store(void* ptr, at v) noexcept {
+    static_assert(!std::is_reference<at>::value, "Can't store a reference");
+    std::memcpy(ptr, &v, sizeof(at));
 }
 
 /// @brief  Simply dereferencing misaligned pointers can be dangerous.
-template <typename at>
-at misaligned_load(void *ptr) noexcept {
-	static_assert(!std::is_reference<at>::value, "Can't load a reference");
-	at v;
-	std::memcpy(&v, ptr, sizeof(at));
-	return v;
+template <typename at> at misaligned_load(void const* ptr) noexcept {
+    static_assert(!std::is_reference<at>::value, "Can't load a reference");
+    at v;
+    std::memcpy(&v, ptr, sizeof(at));
+    return v;
 }
 
 /// @brief  The `std::exchange` alternative for C++11.
-template <typename at, typename other_at = at>
-at exchange(at &obj, other_at &&new_value) {
-	at old_value = std::move(obj);
-	obj = std::forward<other_at>(new_value);
-	return old_value;
+template <typename at, typename other_at = at> at exchange(at& obj, other_at&& new_value) {
+    at old_value = std::move(obj);
+    obj = std::forward<other_at>(new_value);
+    return old_value;
 }
+
+#if defined(USEARCH_DEFINED_CPP20)
+
+template <typename at> void destroy_at(at* obj) { std::destroy_at(obj); }
+template <typename at> void construct_at(at* obj) { std::construct_at(obj); }
+
+#else
 
 /// @brief  The `std::destroy_at` alternative for C++11.
 template <typename at, typename sfinae_at = at>
-typename std::enable_if<std::is_pod<sfinae_at>::value>::type destroy_at(at *) {
-}
+typename std::enable_if<std::is_pod<sfinae_at>::value>::type destroy_at(at*) {}
 template <typename at, typename sfinae_at = at>
-typename std::enable_if<!std::is_pod<sfinae_at>::value>::type destroy_at(at *obj) {
-	obj->~sfinae_at();
+typename std::enable_if<!std::is_pod<sfinae_at>::value>::type destroy_at(at* obj) {
+    obj->~sfinae_at();
 }
 
 /// @brief  The `std::construct_at` alternative for C++11.
 template <typename at, typename sfinae_at = at>
-typename std::enable_if<std::is_pod<sfinae_at>::value>::type construct_at(at *) {
-}
+typename std::enable_if<std::is_pod<sfinae_at>::value>::type construct_at(at*) {}
 template <typename at, typename sfinae_at = at>
-typename std::enable_if<!std::is_pod<sfinae_at>::value>::type construct_at(at *obj) {
-	new (obj) at();
+typename std::enable_if<!std::is_pod<sfinae_at>::value>::type construct_at(at* obj) {
+    new (obj) at();
 }
+
+#endif
 
 /**
  *  @brief  A reference to a misaligned memory location with a specific type.
  *          It is needed to avoid Undefined Behavior when dereferencing addresses
  *          indivisible by `sizeof(at)`.
  */
-template <typename at>
-class misaligned_ref_gt {
-	using element_t = at;
-	using mutable_t = typename std::remove_const<element_t>::type;
-	byte_t *ptr_;
+template <typename at> class misaligned_ref_gt {
+    using element_t = at;
+    using mutable_t = typename std::remove_const<element_t>::type;
+    byte_t* ptr_;
 
-public:
-	misaligned_ref_gt(byte_t *ptr) noexcept : ptr_(ptr) {
-	}
-	operator mutable_t() const noexcept {
-		return misaligned_load<mutable_t>(ptr_);
-	}
-	misaligned_ref_gt &operator=(mutable_t const &v) noexcept {
-		misaligned_store<mutable_t>(ptr_, v);
-		return *this;
-	}
+  public:
+    misaligned_ref_gt(byte_t* ptr) noexcept : ptr_(ptr) {}
+    operator mutable_t() const noexcept { return misaligned_load<mutable_t>(ptr_); }
+    misaligned_ref_gt& operator=(mutable_t const& v) noexcept {
+        misaligned_store<mutable_t>(ptr_, v);
+        return *this;
+    }
 
-	void reset(byte_t *ptr) noexcept {
-		ptr_ = ptr;
-	}
-	byte_t *ptr() const noexcept {
-		return ptr_;
-	}
+    void reset(byte_t* ptr) noexcept { ptr_ = ptr; }
+    byte_t* ptr() const noexcept { return ptr_; }
 };
 
 /**
@@ -237,155 +271,135 @@ public:
  *          It is needed to avoid Undefined Behavior when dereferencing addresses
  *          indivisible by `sizeof(at)`.
  */
-template <typename at>
-class misaligned_ptr_gt {
-	using element_t = at;
-	using mutable_t = typename std::remove_const<element_t>::type;
-	byte_t *ptr_;
+template <typename at> class misaligned_ptr_gt {
+    using element_t = at;
+    using mutable_t = typename std::remove_const<element_t>::type;
+    byte_t* ptr_;
 
-public:
-	using iterator_category = std::random_access_iterator_tag;
-	using value_type = element_t;
-	using difference_type = std::ptrdiff_t;
-	using pointer = misaligned_ptr_gt<element_t>;
-	using reference = misaligned_ref_gt<element_t>;
+  public:
+    using iterator_category = std::random_access_iterator_tag;
+    using value_type = element_t;
+    using difference_type = std::ptrdiff_t;
+    using pointer = misaligned_ptr_gt<element_t>;
+    using reference = misaligned_ref_gt<element_t>;
 
-	reference operator*() const noexcept {
-		return {ptr_};
-	}
-	reference operator[](std::size_t i) noexcept {
-		return reference(ptr_ + i * sizeof(element_t));
-	}
-	value_type operator[](std::size_t i) const noexcept {
-		return misaligned_load<element_t>(ptr_ + i * sizeof(element_t));
-	}
+    misaligned_ptr_gt(byte_t* ptr) noexcept : ptr_(ptr) {}
 
-	misaligned_ptr_gt(byte_t *ptr) noexcept : ptr_(ptr) {
-	}
-	misaligned_ptr_gt operator++(int) noexcept {
-		return misaligned_ptr_gt(ptr_ + sizeof(element_t));
-	}
-	misaligned_ptr_gt operator--(int) noexcept {
-		return misaligned_ptr_gt(ptr_ - sizeof(element_t));
-	}
-	misaligned_ptr_gt operator+(difference_type d) noexcept {
-		return misaligned_ptr_gt(ptr_ + d * sizeof(element_t));
-	}
-	misaligned_ptr_gt operator-(difference_type d) noexcept {
-		return misaligned_ptr_gt(ptr_ - d * sizeof(element_t));
-	}
+    reference operator*() const noexcept { return {ptr_}; }
+    reference operator[](std::size_t i) noexcept { return reference(ptr_ + i * sizeof(element_t)); }
+    value_type operator[](std::size_t i) const noexcept {
+        return misaligned_load<element_t>(ptr_ + i * sizeof(element_t));
+    }
 
-	// clang-format off
-    misaligned_ptr_gt& operator++() noexcept { ptr_ += sizeof(element_t); return *this; }
-    misaligned_ptr_gt& operator--() noexcept { ptr_ -= sizeof(element_t); return *this; }
-    misaligned_ptr_gt& operator+=(difference_type d) noexcept { ptr_ += d * sizeof(element_t); return *this; }
-    misaligned_ptr_gt& operator-=(difference_type d) noexcept { ptr_ -= d * sizeof(element_t); return *this; }
-	// clang-format on
+    misaligned_ptr_gt& operator++() noexcept {
+        ptr_ += sizeof(element_t);
+        return *this;
+    }
+    misaligned_ptr_gt& operator--() noexcept {
+        ptr_ -= sizeof(element_t);
+        return *this;
+    }
+    misaligned_ptr_gt operator++(int) noexcept {
+        misaligned_ptr_gt tmp = *this;
+        ++(*this);
+        return tmp;
+    }
+    misaligned_ptr_gt operator--(int) noexcept {
+        misaligned_ptr_gt tmp = *this;
+        --(*this);
+        return tmp;
+    }
+    misaligned_ptr_gt operator+(difference_type d) const noexcept {
+        return misaligned_ptr_gt(ptr_ + d * sizeof(element_t));
+    }
+    misaligned_ptr_gt operator-(difference_type d) const noexcept {
+        return misaligned_ptr_gt(ptr_ - d * sizeof(element_t));
+    }
+    difference_type operator-(const misaligned_ptr_gt& other) const noexcept {
+        return (ptr_ - other.ptr_) / sizeof(element_t);
+    }
 
-	bool operator==(misaligned_ptr_gt const &other) noexcept {
-		return ptr_ == other.ptr_;
-	}
-	bool operator!=(misaligned_ptr_gt const &other) noexcept {
-		return ptr_ != other.ptr_;
-	}
+    misaligned_ptr_gt& operator+=(difference_type d) noexcept {
+        ptr_ += d * sizeof(element_t);
+        return *this;
+    }
+    misaligned_ptr_gt& operator-=(difference_type d) noexcept {
+        ptr_ -= d * sizeof(element_t);
+        return *this;
+    }
+
+    bool operator==(misaligned_ptr_gt const& other) const noexcept { return ptr_ == other.ptr_; }
+    bool operator!=(misaligned_ptr_gt const& other) const noexcept { return ptr_ != other.ptr_; }
+    bool operator<(misaligned_ptr_gt const& other) const noexcept { return ptr_ < other.ptr_; }
+    bool operator<=(misaligned_ptr_gt const& other) const noexcept { return ptr_ <= other.ptr_; }
+    bool operator>(misaligned_ptr_gt const& other) const noexcept { return ptr_ > other.ptr_; }
+    bool operator>=(misaligned_ptr_gt const& other) const noexcept { return ptr_ >= other.ptr_; }
 };
 
 /**
  *  @brief  Non-owning memory range view, similar to `std::span`, but for C++11.
  */
-template <typename scalar_at>
-class span_gt {
-	scalar_at *data_;
-	std::size_t size_;
+template <typename scalar_at> class span_gt {
+    scalar_at* data_;
+    std::size_t size_;
 
-public:
-	span_gt() noexcept : data_(nullptr), size_(0u) {
-	}
-	span_gt(scalar_at *begin, scalar_at *end) noexcept : data_(begin), size_(end - begin) {
-	}
-	span_gt(scalar_at *begin, std::size_t size) noexcept : data_(begin), size_(size) {
-	}
-	scalar_at *data() const noexcept {
-		return data_;
-	}
-	std::size_t size() const noexcept {
-		return size_;
-	}
-	scalar_at *begin() const noexcept {
-		return data_;
-	}
-	scalar_at *end() const noexcept {
-		return data_ + size_;
-	}
-	operator scalar_at *() const noexcept {
-		return data();
-	}
+  public:
+    span_gt() noexcept : data_(nullptr), size_(0u) {}
+    span_gt(scalar_at* begin, scalar_at* end) noexcept : data_(begin), size_(end - begin) {}
+    span_gt(scalar_at* begin, std::size_t size) noexcept : data_(begin), size_(size) {}
+    scalar_at* data() const noexcept { return data_; }
+    std::size_t size() const noexcept { return size_; }
+    scalar_at* begin() const noexcept { return data_; }
+    scalar_at* end() const noexcept { return data_ + size_; }
+    operator scalar_at*() const noexcept { return data(); }
 };
 
 /**
  *  @brief  Similar to `std::vector`, but doesn't support dynamic resizing.
  *          On the bright side, this can't throw exceptions.
  */
-template <typename scalar_at, typename allocator_at = std::allocator<scalar_at>>
-class buffer_gt {
-	scalar_at *data_;
-	std::size_t size_;
+template <typename scalar_at, typename allocator_at = std::allocator<scalar_at>> class buffer_gt {
+    scalar_at* data_;
+    std::size_t size_;
 
-public:
-	buffer_gt() noexcept : data_(nullptr), size_(0u) {
-	}
-	buffer_gt(std::size_t size) noexcept : data_(allocator_at {}.allocate(size)), size_(data_ ? size : 0u) {
-		if (!std::is_trivially_default_constructible<scalar_at>::value)
-			for (std::size_t i = 0; i != size_; ++i)
-				construct_at(data_ + i);
-	}
-	~buffer_gt() noexcept {
-		if (!std::is_trivially_destructible<scalar_at>::value)
-			for (std::size_t i = 0; i != size_; ++i)
-				destroy_at(data_ + i);
-		allocator_at {}.deallocate(data_, size_);
-		data_ = nullptr;
-		size_ = 0;
-	}
-	scalar_at *data() const noexcept {
-		return data_;
-	}
-	std::size_t size() const noexcept {
-		return size_;
-	}
-	scalar_at *begin() const noexcept {
-		return data_;
-	}
-	scalar_at *end() const noexcept {
-		return data_ + size_;
-	}
-	operator scalar_at *() const noexcept {
-		return data();
-	}
-	scalar_at &operator[](std::size_t i) noexcept {
-		return data_[i];
-	}
-	scalar_at const &operator[](std::size_t i) const noexcept {
-		return data_[i];
-	}
-	explicit operator bool() const noexcept {
-		return data_;
-	}
-	scalar_at *release() noexcept {
-		size_ = 0;
-		return exchange(data_, nullptr);
-	}
+  public:
+    buffer_gt() noexcept : data_(nullptr), size_(0u) {}
+    buffer_gt(std::size_t size) noexcept : data_(allocator_at{}.allocate(size)), size_(data_ ? size : 0u) {
+        if (!std::is_trivially_default_constructible<scalar_at>::value)
+            for (std::size_t i = 0; i != size_; ++i)
+                construct_at(data_ + i);
+    }
+    ~buffer_gt() noexcept { reset(); }
+    void reset() noexcept {
+        if (!std::is_trivially_destructible<scalar_at>::value)
+            for (std::size_t i = 0; i != size_; ++i)
+                unum::usearch::destroy_at(data_ + i); //< Facing some symbol visibility/ambiguity issues
+        allocator_at{}.deallocate(data_, size_);
+        data_ = nullptr;
+        size_ = 0;
+    }
+    scalar_at* data() const noexcept { return data_; }
+    std::size_t size() const noexcept { return size_; }
+    scalar_at* begin() const noexcept { return data_; }
+    scalar_at* end() const noexcept { return data_ + size_; }
+    operator scalar_at*() const noexcept { return data(); }
+    scalar_at& operator[](std::size_t i) noexcept { return data_[i]; }
+    scalar_at const& operator[](std::size_t i) const noexcept { return data_[i]; }
+    explicit operator bool() const noexcept { return data_; }
+    scalar_at* release() noexcept {
+        size_ = 0;
+        return exchange(data_, nullptr);
+    }
 
-	buffer_gt(buffer_gt const &) = delete;
-	buffer_gt &operator=(buffer_gt const &) = delete;
+    buffer_gt(buffer_gt const&) = delete;
+    buffer_gt& operator=(buffer_gt const&) = delete;
 
-	buffer_gt(buffer_gt &&other) noexcept : data_(exchange(other.data_, nullptr)), size_(exchange(other.size_, 0)) {
-	}
-	buffer_gt &operator=(buffer_gt &&other) noexcept {
-		std::swap(data_, other.data_);
-		std::swap(size_, other.size_);
-		return *this;
-	}
+    buffer_gt(buffer_gt&& other) noexcept : data_(exchange(other.data_, nullptr)), size_(exchange(other.size_, 0)) {}
+    buffer_gt& operator=(buffer_gt&& other) noexcept {
+        std::swap(data_, other.data_);
+        std::swap(size_, other.size_);
+        return *this;
+    }
 };
 
 /**
@@ -393,55 +407,58 @@ public:
  *          which are expected to be allocated in static memory.
  */
 class error_t {
-	char const *message_ {};
+    char const* message_{};
 
-public:
-	error_t(char const *message = nullptr) noexcept : message_(message) {
-	}
-	error_t &operator=(char const *message) noexcept {
-		message_ = message;
-		return *this;
-	}
+  public:
+    error_t() noexcept : message_(nullptr) {}
+    error_t(char const* message) noexcept : message_(message) {}
+    error_t& operator=(char const* message) noexcept {
+        message_ = message;
+        return *this;
+    }
 
-	error_t(error_t const &) = delete;
-	error_t &operator=(error_t const &) = delete;
-	error_t(error_t &&other) noexcept : message_(exchange(other.message_, nullptr)) {
-	}
-	error_t &operator=(error_t &&other) noexcept {
-		std::swap(message_, other.message_);
-		return *this;
-	}
-	explicit operator bool() const noexcept {
-		return message_ != nullptr;
-	}
-	char const *what() const noexcept {
-		return message_;
-	}
-	char const *release() noexcept {
-		return exchange(message_, nullptr);
-	}
+    error_t(error_t const&) = delete;
+    error_t& operator=(error_t const&) = delete;
+    error_t(error_t&& other) noexcept : message_(exchange(other.message_, nullptr)) {}
+    error_t& operator=(error_t&& other) noexcept {
+        std::swap(message_, other.message_);
+        return *this;
+    }
+
+    /// @brief Checks if there was an error.
+    explicit operator bool() const noexcept { return message_ != nullptr; }
+
+    /// @brief Returns the error message.
+    char const* what() const noexcept { return message_; }
+
+    /// @brief Releases the error message, meaning the caller takes ownership.
+    char const* release() noexcept { return exchange(message_, nullptr); }
 
 #if defined(__cpp_exceptions) || defined(__EXCEPTIONS)
-	~error_t() noexcept(false) {
+    /// @brief Destructor raises an exception if an error was recorded.
+    ~error_t() noexcept(false) {
 #if defined(USEARCH_DEFINED_CPP17)
-		if (message_ && std::uncaught_exceptions() == 0)
+        if (message_ && std::uncaught_exceptions() == 0)
 #else
-		if (message_ && std::uncaught_exception() == 0)
+        if (message_ && std::uncaught_exception() == 0)
 #endif
-			raise();
-	}
-	void raise() noexcept(false) {
-		if (message_)
-			throw std::runtime_error(exchange(message_, nullptr));
-	}
+            raise();
+    }
+
+    /// @brief Throws an exception using to be caught by `try` / `catch`.
+    void raise() noexcept(false) {
+        if (message_)
+            throw std::runtime_error(exchange(message_, nullptr));
+    }
 #else
-	~error_t() noexcept {
-		raise();
-	}
-	void raise() noexcept {
-		if (message_)
-			std::terminate();
-	}
+    /// @brief Destructor terminates if an error was recorded.
+    ~error_t() noexcept { raise(); }
+
+    /// @brief Terminates if an error was recorded.
+    void raise() noexcept {
+        if (message_)
+            std::terminate();
+    }
 #endif
 };
 
@@ -450,326 +467,494 @@ public:
  *          or an error. It's used to avoid raising exception, and gracefully propagate
  *          the error.
  *
- * @tparam result_at The type of the expected result.
+ *  @tparam result_at The type of the expected result.
  */
-template <typename result_at>
-struct expected_gt {
-	result_at result;
-	error_t error;
+template <typename result_at> struct expected_gt {
+    result_at result;
+    error_t error;
 
-	operator result_at &() & {
-		error.raise();
-		return result;
-	}
-	operator result_at &&() && {
-		error.raise();
-		return std::move(result);
-	}
-	result_at const &operator*() const noexcept {
-		return result;
-	}
-	explicit operator bool() const noexcept {
-		return !error;
-	}
-	expected_gt failed(error_t message) noexcept {
-		error = std::move(message);
-		return std::move(*this);
-	}
+    operator result_at&() & {
+        error.raise();
+        return result;
+    }
+    operator result_at&&() && {
+        error.raise();
+        return std::move(result);
+    }
+    result_at const& operator*() const noexcept { return result; }
+    explicit operator bool() const noexcept { return !error; }
+    expected_gt failed(error_t message) noexcept {
+        error = std::move(message);
+        return std::move(*this);
+    }
 };
 
 /**
  *  @brief  Light-weight bitset implementation to sync nodes updates during graph mutations.
  *          Extends basic functionality with @b atomic operations.
  */
-template <typename allocator_at = std::allocator<byte_t>>
-class bitset_gt {
-	using allocator_t = allocator_at;
-	using byte_t = typename allocator_t::value_type;
-	static_assert(sizeof(byte_t) == 1, "Allocator must allocate separate addressable bytes");
+template <typename allocator_at = std::allocator<byte_t>> class bitset_gt {
+    using allocator_t = allocator_at;
+    using byte_t = typename allocator_t::value_type;
+    static_assert(sizeof(byte_t) == 1, "Allocator must allocate separate addressable bytes");
 
-	using compressed_slot_t = unsigned long;
+    using compressed_slot_t = unsigned long;
 
-	static constexpr std::size_t bits_per_slot() {
-		return sizeof(compressed_slot_t) * CHAR_BIT;
-	}
-	static constexpr compressed_slot_t bits_mask() {
-		return sizeof(compressed_slot_t) * CHAR_BIT - 1;
-	}
-	static constexpr std::size_t slots(std::size_t bits) {
-		return divide_round_up<bits_per_slot()>(bits);
-	}
+    static constexpr std::size_t bits_per_slot() { return sizeof(compressed_slot_t) * CHAR_BIT; }
+    static constexpr compressed_slot_t bits_mask() { return sizeof(compressed_slot_t) * CHAR_BIT - 1; }
+    static constexpr std::size_t bits_slots(std::size_t bits) { return divide_round_up<bits_per_slot()>(bits); }
 
-	compressed_slot_t *slots_ {};
-	/// @brief Number of slots.
-	std::size_t count_ {};
+    compressed_slot_t* slots_{};
+    /// @brief Number of slots.
+    std::size_t count_{};
 
-public:
-	bitset_gt() noexcept {
-	}
-	~bitset_gt() noexcept {
-		reset();
-	}
+  public:
+    bitset_gt() noexcept {}
+    ~bitset_gt() noexcept { reset(); }
 
-	explicit operator bool() const noexcept {
-		return slots_;
-	}
-	void clear() noexcept {
-		if (slots_)
-			std::memset(slots_, 0, count_ * sizeof(compressed_slot_t));
-	}
+    explicit operator bool() const noexcept { return slots_; }
+    void clear() noexcept {
+        if (slots_)
+            std::memset(slots_, 0, count_ * sizeof(compressed_slot_t));
+    }
 
-	void reset() noexcept {
-		if (slots_)
-			allocator_t {}.deallocate((byte_t *)slots_, count_ * sizeof(compressed_slot_t));
-		slots_ = nullptr;
-		count_ = 0;
-	}
+    void reset() noexcept {
+        if (slots_)
+            allocator_t{}.deallocate((byte_t*)slots_, count_ * sizeof(compressed_slot_t));
+        slots_ = nullptr;
+        count_ = 0;
+    }
 
-	bitset_gt(std::size_t capacity) noexcept
-	    : slots_((compressed_slot_t *)allocator_t {}.allocate(slots(capacity) * sizeof(compressed_slot_t))),
-	      count_(slots_ ? slots(capacity) : 0u) {
-		clear();
-	}
+    bitset_gt(std::size_t capacity) noexcept
+        : slots_((compressed_slot_t*)allocator_t{}.allocate(bits_slots(capacity) * sizeof(compressed_slot_t))),
+          count_(slots_ ? bits_slots(capacity) : 0u) {
+        clear();
+    }
 
-	bitset_gt(bitset_gt &&other) noexcept {
-		slots_ = exchange(other.slots_, nullptr);
-		count_ = exchange(other.count_, 0);
-	}
+    bitset_gt(bitset_gt&& other) noexcept {
+        slots_ = exchange(other.slots_, nullptr);
+        count_ = exchange(other.count_, 0);
+    }
 
-	bitset_gt &operator=(bitset_gt &&other) noexcept {
-		std::swap(slots_, other.slots_);
-		std::swap(count_, other.count_);
-		return *this;
-	}
+    bitset_gt& operator=(bitset_gt&& other) noexcept {
+        std::swap(slots_, other.slots_);
+        std::swap(count_, other.count_);
+        return *this;
+    }
 
-	bitset_gt(bitset_gt const &) = delete;
-	bitset_gt &operator=(bitset_gt const &) = delete;
+    bitset_gt(bitset_gt const&) = delete;
+    bitset_gt& operator=(bitset_gt const&) = delete;
 
-	inline bool test(std::size_t i) const noexcept {
-		return slots_[i / bits_per_slot()] & (1ul << (i & bits_mask()));
-	}
-	inline bool set(std::size_t i) noexcept {
-		compressed_slot_t &slot = slots_[i / bits_per_slot()];
-		compressed_slot_t mask {1ul << (i & bits_mask())};
-		bool value = slot & mask;
-		slot |= mask;
-		return value;
-	}
+    inline bool test(std::size_t i) const noexcept { return slots_[i / bits_per_slot()] & (1ul << (i & bits_mask())); }
+    inline bool set(std::size_t i) noexcept {
+        compressed_slot_t& slot = slots_[i / bits_per_slot()];
+        compressed_slot_t mask{1ul << (i & bits_mask())};
+        bool value = slot & mask;
+        slot |= mask;
+        return value;
+    }
 
 #if defined(USEARCH_DEFINED_WINDOWS)
 
-	inline bool atomic_set(std::size_t i) noexcept {
-		compressed_slot_t mask {1ul << (i & bits_mask())};
-		return InterlockedOr((long volatile *)&slots_[i / bits_per_slot()], mask) & mask;
-	}
+    inline bool atomic_set(std::size_t i) noexcept {
+        compressed_slot_t mask{1ul << (i & bits_mask())};
+        return InterlockedOr((long volatile*)&slots_[i / bits_per_slot()], mask) & mask;
+    }
 
-	inline void atomic_reset(std::size_t i) noexcept {
-		compressed_slot_t mask {1ul << (i & bits_mask())};
-		InterlockedAnd((long volatile *)&slots_[i / bits_per_slot()], ~mask);
-	}
+    inline void atomic_reset(std::size_t i) noexcept {
+        compressed_slot_t mask{1ul << (i & bits_mask())};
+        InterlockedAnd((long volatile*)&slots_[i / bits_per_slot()], ~mask);
+    }
 
 #else
 
-	inline bool atomic_set(std::size_t i) noexcept {
-		compressed_slot_t mask {1ul << (i & bits_mask())};
-		return __atomic_fetch_or(&slots_[i / bits_per_slot()], mask, __ATOMIC_ACQUIRE) & mask;
-	}
+    inline bool atomic_set(std::size_t i) noexcept {
+        compressed_slot_t mask{1ul << (i & bits_mask())};
+        return __atomic_fetch_or(&slots_[i / bits_per_slot()], mask, __ATOMIC_ACQUIRE) & mask;
+    }
 
-	inline void atomic_reset(std::size_t i) noexcept {
-		compressed_slot_t mask {1ul << (i & bits_mask())};
-		__atomic_fetch_and(&slots_[i / bits_per_slot()], ~mask, __ATOMIC_RELEASE);
-	}
+    inline void atomic_reset(std::size_t i) noexcept {
+        compressed_slot_t mask{1ul << (i & bits_mask())};
+        __atomic_fetch_and(&slots_[i / bits_per_slot()], ~mask, __ATOMIC_RELEASE);
+    }
 
 #endif
 
-	class lock_t {
-		bitset_gt &bitset_;
-		std::size_t bit_offset_;
+    class lock_t {
+        bitset_gt& bitset_;
+        std::size_t bit_offset_;
 
-	public:
-		inline ~lock_t() noexcept {
-			bitset_.atomic_reset(bit_offset_);
-		}
-		inline lock_t(bitset_gt &bitset, std::size_t bit_offset) noexcept : bitset_(bitset), bit_offset_(bit_offset) {
-			while (bitset_.atomic_set(bit_offset_))
-				;
-		}
-	};
+      public:
+        inline ~lock_t() noexcept { bitset_.atomic_reset(bit_offset_); }
+        inline lock_t(bitset_gt& bitset, std::size_t bit_offset) noexcept : bitset_(bitset), bit_offset_(bit_offset) {
+            while (bitset_.atomic_set(bit_offset_))
+                ;
+        }
+    };
 
-	inline lock_t lock(std::size_t i) noexcept {
-		return {*this, i};
-	}
+    inline lock_t lock(std::size_t i) noexcept { return {*this, i}; }
 };
 
 using bitset_t = bitset_gt<>;
 
 /**
+ *  @brief  Cache-line-padded striped spin-lock array for concurrent graph mutations.
+ *          Maps node slots to lock stripes via Fibonacci hashing, with each stripe
+ *          occupying its own cache line to eliminate false sharing.
+ *          The number of stripes is proportional to `threads * connectivity`, not
+ *          graph size, keeping the lock array comfortably within L2/L3 cache.
+ */
+template <typename allocator_at = std::allocator<byte_t>, std::size_t cache_line_ak = 128> //
+class striped_locks_gt {
+    using allocator_t = allocator_at;
+    using byte_t = typename allocator_t::value_type;
+    static_assert(sizeof(byte_t) == 1, "Allocator must allocate separate addressable bytes");
+
+    static constexpr std::uint64_t fibonacci_k = 0x9E3779B97F4A7C15ull;
+
+    using atomic_flag_t = std::atomic<std::uint8_t>;
+    struct alignas(cache_line_ak) padded_lock_t {
+        atomic_flag_t flag{0};
+        char padding_[cache_line_ak - sizeof(atomic_flag_t)];
+    };
+    static_assert(sizeof(padded_lock_t) == cache_line_ak, "Lock stripe must be exactly one cache line");
+
+    // `padded_lock_t` is `alignas(cache_line_ak)` (128 B by default) which
+    // exceeds what a plain allocator guarantees (typically 16 B on x86-64).
+    // Rather than demanding an over-aligned allocator, we over-allocate and
+    // keep a pointer to the aligned sub-region — `raw_` is what we hand back
+    // to the allocator, `stripes_` is the aligned view used for reads/writes.
+    byte_t* raw_{};
+    std::size_t raw_bytes_{};
+    padded_lock_t* stripes_{};
+    std::size_t count_{};
+    unsigned shift_{};
+
+    inline std::size_t stripe_for_(std::size_t slot) const noexcept {
+        return static_cast<std::size_t>((static_cast<std::uint64_t>(slot) * fibonacci_k) >> shift_);
+    }
+
+  public:
+    striped_locks_gt() noexcept {}
+    ~striped_locks_gt() noexcept { reset(); }
+
+    explicit operator bool() const noexcept { return stripes_; }
+
+    void reset() noexcept {
+        if (stripes_)
+            for (std::size_t i = 0; i < count_; i++)
+                stripes_[i].~padded_lock_t();
+        if (raw_)
+            allocator_t{}.deallocate(raw_, raw_bytes_);
+        raw_ = nullptr;
+        raw_bytes_ = 0;
+        stripes_ = nullptr;
+        count_ = 0;
+        shift_ = 64;
+    }
+
+    striped_locks_gt(std::size_t threads, std::size_t connectivity) noexcept {
+        std::size_t desired = threads * connectivity * 4;
+        if (desired < 256)
+            desired = 256;
+        count_ = ceil2(desired);
+        shift_ = 64;
+        for (std::size_t n = count_; n > 1; n >>= 1)
+            shift_--;
+        // Request one extra stripe's worth of slack so we can always land on a
+        // `cache_line_ak`-aligned address inside the allocation, regardless of
+        // what the underlying allocator returns.
+        constexpr std::size_t alignment_k = alignof(padded_lock_t);
+        raw_bytes_ = count_ * sizeof(padded_lock_t) + alignment_k;
+        raw_ = allocator_t{}.allocate(raw_bytes_);
+        if (!raw_) {
+            raw_bytes_ = 0;
+            count_ = 0;
+            shift_ = 64;
+            return;
+        }
+        auto raw_address = reinterpret_cast<std::uintptr_t>(raw_);
+        auto aligned_address = (raw_address + alignment_k - 1) & ~(static_cast<std::uintptr_t>(alignment_k) - 1);
+        stripes_ = reinterpret_cast<padded_lock_t*>(aligned_address);
+        for (std::size_t i = 0; i < count_; i++)
+            new (&stripes_[i]) padded_lock_t();
+    }
+
+    striped_locks_gt(striped_locks_gt&& other) noexcept {
+        raw_ = exchange(other.raw_, (byte_t*)nullptr);
+        raw_bytes_ = exchange(other.raw_bytes_, std::size_t{0});
+        stripes_ = exchange(other.stripes_, nullptr);
+        count_ = exchange(other.count_, std::size_t{0});
+        shift_ = exchange(other.shift_, unsigned{64});
+    }
+
+    striped_locks_gt& operator=(striped_locks_gt&& other) noexcept {
+        std::swap(raw_, other.raw_);
+        std::swap(raw_bytes_, other.raw_bytes_);
+        std::swap(stripes_, other.stripes_);
+        std::swap(count_, other.count_);
+        std::swap(shift_, other.shift_);
+        return *this;
+    }
+
+    striped_locks_gt(striped_locks_gt const&) = delete;
+    striped_locks_gt& operator=(striped_locks_gt const&) = delete;
+
+    inline bool atomic_set(std::size_t i) noexcept {
+        return stripes_[stripe_for_(i)].flag.exchange(1, std::memory_order_acquire);
+    }
+
+    inline void atomic_reset(std::size_t i) noexcept {
+        stripes_[stripe_for_(i)].flag.store(0, std::memory_order_release);
+    }
+
+    inline void lock(std::size_t i) noexcept {
+        while (atomic_set(i))
+            std::this_thread::yield();
+    }
+
+    inline void unlock(std::size_t i) noexcept { atomic_reset(i); }
+};
+
+/**
  *  @brief  Similar to `std::priority_queue`, but allows raw access to underlying
  *          memory, in case you want to shuffle it or sort. Good for collections
  *          from 100s to 10'000s elements.
+ *
+ *  In a max-heap, the heap property ensures that the value of each node is greater
+ *  than or equal to the values of its children. This means that the largest element
+ *  is always at the root of the heap.
+ *
+ *  @section    Heap Structures
+ *
+ *  There are several designs of heaps. Binary heaps are the simplest & most common
+ *  variant, that is easy to implement as a succint array. However, they are not the
+ *  most efficient for all operations. Most importantly, @b melding (merging) of
+ *  two heaps has linear complexity in time.
+ *
+ *  +-----------------+---------+-----------+---------+--------------+---------+
+ *  | Operation       | find-max| delete-max| insert  | increase-key | meld    |
+ *  +-----------------+---------+-----------+---------+--------------+---------+
+ *  | Binary          | Θ(1)    | Θ(log n)  | O(log n)| O(log n)     | Θ(n)    |
+ *  | Leftist         | Θ(1)    | Θ(log n)  | O(log n)| Θ(log n)     | Θ(log n)|
+ *  | Binomial        | Θ(1)    | Θ(log n)  | Θ(1)    | Θ(log n)     | O(log n)|
+ *  | Skew binomial   | Θ(1)    | Θ(log n)  | Θ(1)    | O(log n)     | O(log n)|
+ *  | Pairing         | Θ(1)    | O(log n)  | Θ(1)    | o(log n)     | Θ(1)    |
+ *  | Rank-pairing    | Θ(1)    | O(log n)  | Θ(1)    | Θ(1)         | Θ(1)    |
+ *  | Fibonacci       | Θ(1)    | O(log n)  | Θ(1)    | Θ(1)         | Θ(1)    |
+ *  | Strict Fibonacci| Θ(1)    | O(log n)  | Θ(1)    | Θ(1)         | Θ(1)    |
+ *  | Brodal          | Θ(1)    | Θ(log n)  | Θ(1)    | Θ(1)         | Θ(1)    |
+ *  | 2–3 heap        | Θ(1)    | O(log n)  | Θ(1)    | Θ(1)         | O(log n)|
+ *  +-----------------+---------+-----------+---------+--------------+---------+
+ *
+ *  It's well known, that improved priority queue structures translate into better
+ *  graph-transversal algorithms. For example, Dijkstra's algorithm can be sped up
+ *  by using a Fibonacci heap for arbitrary weights. For integer weight bounded
+ *  by L, Schrijver reported following time complexities in 2004:
+ *
+ *  +------------+-------------------------------------+----------------------------+--------------------------+
+ *  | Weights    | Algorithm                           | Time complexity            | Author                   |
+ *  +------------+-------------------------------------+----------------------------+--------------------------+
+ *  | R          |                                     | O(V^2 EL)                  | Ford 1956                |
+ *  | R          | Bellman–Ford algorithm              | O(VE)                      | Shimbel 1955, Bellman    |
+ *  |            |                                     |                            | 1958, Moore 1959         |
+ *  | R          |                                     | O(V^2 log V)               | Dantzig 1960             |
+ *  | R          | Dijkstra's with list                | O(V^2)                     | Leyzorek et al. 1957,    |
+ *  |            |                                     |                            | Dijkstra 1959...         |
+ *  | R          | Dijkstra's with binary heap         | O((E + V) log V)           | Johnson 1977             |
+ *  | R          | Dijkstra's with Fibonacci heap      | O(E + V log V)             | Fredman & Tarjan 1984,   |
+ *  |            |                                     |                            | Fredman & Tarjan 1987    |
+ *  | R          | Quantum Dijkstra                    | O(√VE log^2 V)             | Dürr et al. 2006         |
+ *  | R          | Dial's algorithm (Dijkstra's using  | O(E + LV)                  | Dial 1969                |
+ *  |            | a bucket queue with L buckets)      |                            |                          |
+ *  | N          |                                     | O(E log log L)             | Johnson 1981, Karlsson & |
+ *  |            |                                     |                            | Poblete 1983             |
+ *  | N          | Gabow's algorithm                   | O(E log_E/V L)             | Gabow 1983, Gabow 1985   |
+ *  | N          |                                     | O(E + V √log L)            | Ahuja et al. 1990        |
+ *  | N          | Thorup                              | O(E + V log log V)         | Thorup 2004              |
+ *  +------------+-------------------------------------+----------------------------+--------------------------+
+ *
+ *  Possible improvements:
+ *  - Randomized meldable heaps: https://en.wikipedia.org/wiki/Randomized_meldable_heap
+ *  - D-ary heaps: https://en.wikipedia.org/wiki/D-ary_heap
+ *  - B-heap: https://en.wikipedia.org/wiki/B-heap
  */
 template <typename element_at,                                //
           typename comparator_at = std::less<void>,           // <void> is needed before C++14.
           typename allocator_at = std::allocator<element_at>> //
 class max_heap_gt {
-public:
-	using element_t = element_at;
-	using comparator_t = comparator_at;
-	using allocator_t = allocator_at;
+  public:
+    using element_t = element_at;
+    using comparator_t = comparator_at;
+    using allocator_t = allocator_at;
 
-	using value_type = element_t;
+    using value_type = element_t;
 
-	static_assert(std::is_trivially_destructible<element_t>(), "This heap is designed for trivial structs");
-	static_assert(std::is_trivially_copy_constructible<element_t>(), "This heap is designed for trivial structs");
+    static_assert(std::is_trivially_destructible<element_t>(), "This heap is designed for trivial structs");
+    static_assert(std::is_trivially_copy_constructible<element_t>(), "This heap is designed for trivial structs");
 
-private:
-	element_t *elements_;
-	std::size_t size_;
-	std::size_t capacity_;
+  private:
+    element_t* elements_;
+    std::size_t size_;
+    std::size_t capacity_;
 
-public:
-	max_heap_gt() noexcept : elements_(nullptr), size_(0), capacity_(0) {
-	}
+  public:
+    max_heap_gt() noexcept : elements_(nullptr), size_(0), capacity_(0) {}
 
-	max_heap_gt(max_heap_gt &&other) noexcept
-	    : elements_(exchange(other.elements_, nullptr)), size_(exchange(other.size_, 0)),
-	      capacity_(exchange(other.capacity_, 0)) {
-	}
+    max_heap_gt(max_heap_gt&& other) noexcept
+        : elements_(exchange(other.elements_, nullptr)), size_(exchange(other.size_, 0)),
+          capacity_(exchange(other.capacity_, 0)) {}
 
-	max_heap_gt &operator=(max_heap_gt &&other) noexcept {
-		std::swap(elements_, other.elements_);
-		std::swap(size_, other.size_);
-		std::swap(capacity_, other.capacity_);
-		return *this;
-	}
+    max_heap_gt& operator=(max_heap_gt&& other) noexcept {
+        std::swap(elements_, other.elements_);
+        std::swap(size_, other.size_);
+        std::swap(capacity_, other.capacity_);
+        return *this;
+    }
 
-	max_heap_gt(max_heap_gt const &) = delete;
-	max_heap_gt &operator=(max_heap_gt const &) = delete;
+    max_heap_gt(max_heap_gt const&) = delete;
+    max_heap_gt& operator=(max_heap_gt const&) = delete;
 
-	~max_heap_gt() noexcept {
-		reset();
-	}
+    ~max_heap_gt() noexcept { reset(); }
 
-	void reset() noexcept {
-		if (elements_)
-			allocator_t {}.deallocate(elements_, capacity_);
-		elements_ = nullptr;
-		capacity_ = 0;
-		size_ = 0;
-	}
+    void reset() noexcept {
+        if (elements_)
+            allocator_t{}.deallocate(elements_, capacity_);
+        elements_ = nullptr;
+        capacity_ = 0;
+        size_ = 0;
+    }
 
-	inline bool empty() const noexcept {
-		return !size_;
-	}
-	inline std::size_t size() const noexcept {
-		return size_;
-	}
-	inline std::size_t capacity() const noexcept {
-		return capacity_;
-	}
+    inline bool empty() const noexcept { return !size_; }
+    inline std::size_t size() const noexcept { return size_; }
+    inline std::size_t capacity() const noexcept { return capacity_; }
+    inline element_t* data() noexcept { return elements_; }
+    inline element_t const* data() const noexcept { return elements_; }
+    inline void clear() noexcept { size_ = 0; }
+    inline void shrink(std::size_t n) noexcept { size_ = (std::min<std::size_t>)(n, size_); }
 
-	/// @brief  Selects the largest element in the heap.
-	/// @return Reference to the stored element.
-	inline element_t const &top() const noexcept {
-		return elements_[0];
-	}
-	inline void clear() noexcept {
-		size_ = 0;
-	}
+    /// @brief  Selects the largest element in the heap.
+    /// @return Reference to the stored element.
+    inline element_t const& top() const noexcept { return elements_[0]; }
 
-	bool reserve(std::size_t new_capacity) noexcept {
-		if (new_capacity < capacity_)
-			return true;
+    /// @brief Invalidates the "max-heap" property, transforming into ascending range.
+    inline void sort_ascending() noexcept { std::sort_heap(elements_, elements_ + size_, &less); }
 
-		new_capacity = ceil2(new_capacity);
-		new_capacity = (std::max<std::size_t>)(new_capacity, (std::max<std::size_t>)(capacity_ * 2u, 16u));
-		auto allocator = allocator_t {};
-		auto new_elements = allocator.allocate(new_capacity);
-		if (!new_elements)
-			return false;
+    /**
+     *  @brief Ensures the heap has enough capacity for the specified number of elements.
+     *  @param new_capacity The desired minimum capacity.
+     *  @return True if the capacity was successfully increased, false otherwise.
+     */
+    usearch_profiled_m bool reserve(std::size_t new_capacity) noexcept {
+        usearch_profile_name_m(max_heap_reserve);
+        if (new_capacity <= capacity_)
+            return true;
 
-		if (elements_) {
-			std::memcpy(new_elements, elements_, size_ * sizeof(element_t));
-			allocator.deallocate(elements_, capacity_);
-		}
-		elements_ = new_elements;
-		capacity_ = new_capacity;
-		return new_elements;
-	}
+        new_capacity = ceil2(new_capacity);
+        if (new_capacity == 0)
+            return false;
+        new_capacity = (std::max<std::size_t>)(new_capacity, (std::max<std::size_t>)(capacity_ * 2u, 16u));
+        auto allocator = allocator_t{};
+        auto new_elements = allocator.allocate(new_capacity);
+        if (!new_elements)
+            return false;
 
-	bool insert(element_t &&element) noexcept {
-		if (!reserve(size_ + 1))
-			return false;
+        if (elements_) {
+            std::memcpy(new_elements, elements_, size_ * sizeof(element_t));
+            allocator.deallocate(elements_, capacity_);
+        }
+        elements_ = new_elements;
+        capacity_ = new_capacity;
+        return new_elements;
+    }
 
-		insert_reserved(std::move(element));
-		return true;
-	}
+    /**
+     *  @brief Inserts an element into the heap.
+     *  @param element The element to be inserted.
+     *  @return True if the element was successfully inserted, false otherwise.
+     */
+    bool insert(element_t&& element) noexcept {
+        if (!reserve(size_ + 1))
+            return false;
 
-	inline void insert_reserved(element_t &&element) noexcept {
-		new (&elements_[size_]) element_t(element);
-		size_++;
-		shift_up(size_ - 1);
-	}
+        insert_reserved(std::move(element));
+        return true;
+    }
 
-	inline element_t pop() noexcept {
-		element_t result = top();
-		std::swap(elements_[0], elements_[size_ - 1]);
-		size_--;
-		elements_[size_].~element_t();
-		shift_down(0);
-		return result;
-	}
+    /**
+     *  @brief Inserts an element into the heap without reserving additional space.
+     *  @param element The element to be inserted.
+     */
+    usearch_profiled_m void insert_reserved(element_t&& element) noexcept {
+        usearch_profile_name_m(max_heap_insert_reserved);
+        new (&elements_[size_]) element_t(element);
+        size_++;
+        shift_up(size_ - 1);
+    }
 
-	/** @brief Invalidates the "max-heap" property, transforming into ascending range. */
-	inline void sort_ascending() noexcept {
-		std::sort_heap(elements_, elements_ + size_, &less);
-	}
-	inline void shrink(std::size_t n) noexcept {
-		size_ = (std::min<std::size_t>)(n, size_);
-	}
+    /**
+     *  @brief Inserts multiple elements into the heap.
+     *  @param elements Pointer to the elements to be inserted.
+     *  @return True if the elements were successfully inserted, false otherwise.
+     */
+    inline bool insert_many(element_t const* elements) noexcept {
+        // Wikipedia describes a procedure, due to Floyd, which constructs a heap from an array in linear time.
+        // It also mentions a procedure for merging two heaps, of sizes 𝑛 and 𝑘, in time 𝑂(𝑘+log𝑘log𝑛).
+        // Altogether, we can add 𝑘 elements to a heap of length 𝑛 in time 𝑂(𝑘+log𝑘log𝑛): first build a heap containing
+        // 𝑘 elements to be inserted (takes 𝑂(𝑘) time), then merge that with the heap of size 𝑛 (takes 𝑂(𝑘+log𝑘log𝑛)
+        // time). Compare this to repeated insertion, which would run in time 𝑂(𝑘log𝑛).
+        return false;
+    }
 
-	inline element_t *data() noexcept {
-		return elements_;
-	}
-	inline element_t const *data() const noexcept {
-		return elements_;
-	}
+    usearch_profiled_m element_t pop() noexcept {
+        usearch_profile_name_m(max_heap_pop);
+        element_t result = top();
+        std::swap(elements_[0], elements_[size_ - 1]);
+        size_--;
+        elements_[size_].~element_t();
+        shift_down(0);
+        return result;
+    }
 
-private:
-	inline std::size_t parent_idx(std::size_t i) const noexcept {
-		return (i - 1u) / 2u;
-	}
-	inline std::size_t left_child_idx(std::size_t i) const noexcept {
-		return (i * 2u) + 1u;
-	}
-	inline std::size_t right_child_idx(std::size_t i) const noexcept {
-		return (i * 2u) + 2u;
-	}
-	static bool less(element_t const &a, element_t const &b) noexcept {
-		return comparator_t {}(a, b);
-	}
+  private:
+    static std::size_t parent_idx(std::size_t i) noexcept { return (i - 1u) / 2u; }
+    static std::size_t left_child_idx(std::size_t i) noexcept { return (i * 2u) + 1u; }
+    static std::size_t right_child_idx(std::size_t i) noexcept { return (i * 2u) + 2u; }
+    static bool less(element_t const& a, element_t const& b) noexcept { return comparator_t{}(a, b); }
 
-	void shift_up(std::size_t i) noexcept {
-		for (; i && less(elements_[parent_idx(i)], elements_[i]); i = parent_idx(i))
-			std::swap(elements_[parent_idx(i)], elements_[i]);
-	}
+    /**
+     *  @brief Shifts an element up to maintain the heap property.
+     *         This operation is called when a new element is @b added at the end of the heap.
+     *         The element is moved up until the heap property is restored.
+     *  @param i Index of the element to be shifted up.
+     */
+    void shift_up(std::size_t i) noexcept {
+        for (; i && less(elements_[parent_idx(i)], elements_[i]); i = parent_idx(i))
+            std::swap(elements_[parent_idx(i)], elements_[i]);
+    }
 
-	void shift_down(std::size_t i) noexcept {
-		std::size_t max_idx = i;
+    /**
+     *  @brief Shifts an element down to maintain the heap property.
+     *         This operation is called when the root element is @b removed and the last element is moved to the root.
+     *         The element is moved down until the heap property is restored.
+     *  @param i Index of the element to be shifted down.
+     */
+    void shift_down(std::size_t i) noexcept {
+        std::size_t max_idx = i;
 
-		std::size_t left = left_child_idx(i);
-		if (left < size_ && less(elements_[max_idx], elements_[left]))
-			max_idx = left;
+        std::size_t left = left_child_idx(i);
+        if (left < size_ && less(elements_[max_idx], elements_[left]))
+            max_idx = left;
 
-		std::size_t right = right_child_idx(i);
-		if (right < size_ && less(elements_[max_idx], elements_[right]))
-			max_idx = right;
+        std::size_t right = right_child_idx(i);
+        if (right < size_ && less(elements_[max_idx], elements_[right]))
+            max_idx = right;
 
-		if (i != max_idx) {
-			std::swap(elements_[i], elements_[max_idx]);
-			shift_down(max_idx);
-		}
-	}
+        if (i != max_idx) {
+            std::swap(elements_[i], elements_[max_idx]);
+            shift_down(max_idx);
+        }
+    }
 };
 
 /**
@@ -781,139 +966,118 @@ template <typename element_at,                                //
           typename comparator_at = std::less<void>,           // <void> is needed before C++14.
           typename allocator_at = std::allocator<element_at>> //
 class sorted_buffer_gt {
-public:
-	using element_t = element_at;
-	using comparator_t = comparator_at;
-	using allocator_t = allocator_at;
+  public:
+    using element_t = element_at;
+    using comparator_t = comparator_at;
+    using allocator_t = allocator_at;
 
-	static_assert(std::is_trivially_destructible<element_t>(), "This heap is designed for trivial structs");
-	static_assert(std::is_trivially_copy_constructible<element_t>(), "This heap is designed for trivial structs");
+    static_assert(std::is_trivially_destructible<element_t>(), "This heap is designed for trivial structs");
+    static_assert(std::is_trivially_copy_constructible<element_t>(), "This heap is designed for trivial structs");
 
-	using value_type = element_t;
+    using value_type = element_t;
 
-private:
-	element_t *elements_;
-	std::size_t size_;
-	std::size_t capacity_;
+  private:
+    element_t* elements_;
+    std::size_t size_;
+    std::size_t capacity_;
 
-public:
-	sorted_buffer_gt() noexcept : elements_(nullptr), size_(0), capacity_(0) {
-	}
+  public:
+    sorted_buffer_gt() noexcept : elements_(nullptr), size_(0), capacity_(0) {}
 
-	sorted_buffer_gt(sorted_buffer_gt &&other) noexcept
-	    : elements_(exchange(other.elements_, nullptr)), size_(exchange(other.size_, 0)),
-	      capacity_(exchange(other.capacity_, 0)) {
-	}
+    sorted_buffer_gt(sorted_buffer_gt&& other) noexcept
+        : elements_(exchange(other.elements_, nullptr)), size_(exchange(other.size_, 0)),
+          capacity_(exchange(other.capacity_, 0)) {}
 
-	sorted_buffer_gt &operator=(sorted_buffer_gt &&other) noexcept {
-		std::swap(elements_, other.elements_);
-		std::swap(size_, other.size_);
-		std::swap(capacity_, other.capacity_);
-		return *this;
-	}
+    sorted_buffer_gt& operator=(sorted_buffer_gt&& other) noexcept {
+        std::swap(elements_, other.elements_);
+        std::swap(size_, other.size_);
+        std::swap(capacity_, other.capacity_);
+        return *this;
+    }
 
-	sorted_buffer_gt(sorted_buffer_gt const &) = delete;
-	sorted_buffer_gt &operator=(sorted_buffer_gt const &) = delete;
+    sorted_buffer_gt(sorted_buffer_gt const&) = delete;
+    sorted_buffer_gt& operator=(sorted_buffer_gt const&) = delete;
 
-	~sorted_buffer_gt() noexcept {
-		reset();
-	}
+    ~sorted_buffer_gt() noexcept { reset(); }
 
-	void reset() noexcept {
-		if (elements_)
-			allocator_t {}.deallocate(elements_, capacity_);
-		elements_ = nullptr;
-		capacity_ = 0;
-		size_ = 0;
-	}
+    void reset() noexcept {
+        if (elements_)
+            allocator_t{}.deallocate(elements_, capacity_);
+        elements_ = nullptr;
+        capacity_ = 0;
+        size_ = 0;
+    }
 
-	inline bool empty() const noexcept {
-		return !size_;
-	}
-	inline std::size_t size() const noexcept {
-		return size_;
-	}
-	inline std::size_t capacity() const noexcept {
-		return capacity_;
-	}
-	inline element_t const &top() const noexcept {
-		return elements_[size_ - 1];
-	}
-	inline void clear() noexcept {
-		size_ = 0;
-	}
+    inline bool empty() const noexcept { return !size_; }
+    inline std::size_t size() const noexcept { return size_; }
+    inline std::size_t capacity() const noexcept { return capacity_; }
+    inline element_t const& top() const noexcept { return elements_[size_ - 1]; }
+    inline void clear() noexcept { size_ = 0; }
 
-	bool reserve(std::size_t new_capacity) noexcept {
-		if (new_capacity < capacity_)
-			return true;
+    bool reserve(std::size_t new_capacity) noexcept {
+        if (new_capacity <= capacity_)
+            return true;
 
-		new_capacity = ceil2(new_capacity);
-		new_capacity = (std::max<std::size_t>)(new_capacity, (std::max<std::size_t>)(capacity_ * 2u, 16u));
-		auto allocator = allocator_t {};
-		auto new_elements = allocator.allocate(new_capacity);
-		if (!new_elements)
-			return false;
+        new_capacity = ceil2(new_capacity);
+        if (new_capacity == 0)
+            return false;
+        new_capacity = (std::max<std::size_t>)(new_capacity, (std::max<std::size_t>)(capacity_ * 2u, 16u));
+        auto allocator = allocator_t{};
+        auto new_elements = allocator.allocate(new_capacity);
+        if (!new_elements)
+            return false;
 
-		if (size_)
-			std::memcpy(new_elements, elements_, size_ * sizeof(element_t));
-		if (elements_)
-			allocator.deallocate(elements_, capacity_);
+        if (size_)
+            std::memcpy(new_elements, elements_, size_ * sizeof(element_t));
+        if (elements_)
+            allocator.deallocate(elements_, capacity_);
 
-		elements_ = new_elements;
-		capacity_ = new_capacity;
-		return true;
-	}
+        elements_ = new_elements;
+        capacity_ = new_capacity;
+        return true;
+    }
 
-	inline void insert_reserved(element_t &&element) noexcept {
-		std::size_t slot = size_ ? std::lower_bound(elements_, elements_ + size_, element, &less) - elements_ : 0;
-		std::size_t to_move = size_ - slot;
-		element_t *source = elements_ + size_ - 1;
-		for (; to_move; --to_move, --source)
-			source[1] = source[0];
-		elements_[slot] = element;
-		size_++;
-	}
+    inline void insert_reserved(element_t&& element) noexcept {
+        std::size_t slot = size_ ? std::lower_bound(elements_, elements_ + size_, element, &less) - elements_ : 0;
+        std::size_t to_move = size_ - slot;
+        element_t* source = elements_ + size_ - 1;
+        for (; to_move; --to_move, --source)
+            source[1] = source[0];
+        elements_[slot] = element;
+        size_++;
+    }
 
-	/**
-	 *  @return `true` if the entry was added, `false` if it wasn't relevant enough.
-	 */
-	inline bool insert(element_t &&element, std::size_t limit) noexcept {
-		std::size_t slot = size_ ? std::lower_bound(elements_, elements_ + size_, element, &less) - elements_ : 0;
-		if (slot == limit)
-			return false;
-		std::size_t to_move = size_ - slot - (size_ == limit);
-		element_t *source = elements_ + size_ - 1 - (size_ == limit);
-		for (; to_move; --to_move, --source)
-			source[1] = source[0];
-		elements_[slot] = element;
-		size_ += size_ != limit;
-		return true;
-	}
+    /**
+     *  @return `true` if the entry was added, `false` if it wasn't relevant enough.
+     */
+    inline bool insert(element_t&& element, std::size_t limit) noexcept {
+        std::size_t slot = size_ ? std::lower_bound(elements_, elements_ + size_, element, &less) - elements_ : 0;
+        if (slot == limit)
+            return false;
+        std::size_t to_move = size_ - slot - (size_ == limit);
+        element_t* source = elements_ + size_ - 1 - (size_ == limit);
+        for (; to_move; --to_move, --source)
+            source[1] = source[0];
+        elements_[slot] = element;
+        size_ += size_ != limit;
+        return true;
+    }
 
-	inline element_t pop() noexcept {
-		size_--;
-		element_t result = elements_[size_];
-		elements_[size_].~element_t();
-		return result;
-	}
+    inline element_t pop() noexcept {
+        size_--;
+        element_t result = elements_[size_];
+        elements_[size_].~element_t();
+        return result;
+    }
 
-	void sort_ascending() noexcept {
-	}
-	inline void shrink(std::size_t n) noexcept {
-		size_ = (std::min<std::size_t>)(n, size_);
-	}
+    void sort_ascending() noexcept {}
+    inline void shrink(std::size_t n) noexcept { size_ = (std::min<std::size_t>)(n, size_); }
 
-	inline element_t *data() noexcept {
-		return elements_;
-	}
-	inline element_t const *data() const noexcept {
-		return elements_;
-	}
+    inline element_t* data() noexcept { return elements_; }
+    inline element_t const* data() const noexcept { return elements_; }
 
-private:
-	static bool less(element_t const &a, element_t const &b) noexcept {
-		return comparator_t {}(a, b);
-	}
+  private:
+    static bool less(element_t const& a, element_t const& b) noexcept { return comparator_t{}(a, b); }
 };
 
 #if defined(USEARCH_DEFINED_WINDOWS)
@@ -921,63 +1085,76 @@ private:
 #endif
 
 /**
- *  @brief Five-byte integer type to address node clouds with over 4B entries.
+ *  @brief  Five-byte integer type to address node clouds with over 4B entries.
  *
- * @note Avoid usage in 32bit environment
+ *  40 bits is enough to address a @b Trillion entries potentially colocated on 1 machine.
+ *  At roughly 5 bytes * 20 neighbors + 100 bytes per entry, this translates to 200 TB of data,
+ *  which is similar to a single-server capacity of modern NVME arrays.
  */
 class usearch_pack_m uint40_t {
-	unsigned char octets[5];
+    unsigned char octets[5];
 
-	inline uint40_t &broadcast(unsigned char c) {
-		std::memset(octets, c, 5);
-		return *this;
-	}
+    inline uint40_t& broadcast(unsigned char c) {
+        std::memset(octets, c, 5);
+        return *this;
+    }
 
-public:
-	inline uint40_t() noexcept {
-		broadcast(0);
-	}
-	inline uint40_t(std::uint32_t n) noexcept {
-		std::memcpy(&octets[1], &n, 4);
-	}
+  public:
+    inline uint40_t() noexcept { broadcast(0); }
+    inline uint40_t(std::uint32_t n) noexcept {
+        std::memcpy(&octets, &n, 4);
+        octets[4] = 0;
+    }
 
 #ifdef USEARCH_64BIT_ENV
-	inline uint40_t(std::uint64_t n) noexcept {
-		std::memcpy(octets, &n, 5);
-	}
+    inline uint40_t(std::uint64_t n) noexcept { std::memcpy(octets, &n, 5); }
 #endif
 
-	uint40_t(uint40_t &&) = default;
-	uint40_t(uint40_t const &) = default;
-	uint40_t &operator=(uint40_t &&) = default;
-	uint40_t &operator=(uint40_t const &) = default;
+    uint40_t(uint40_t&&) = default;
+    uint40_t(uint40_t const&) = default;
+    uint40_t& operator=(uint40_t&&) = default;
+    uint40_t& operator=(uint40_t const&) = default;
 
 #if defined(USEARCH_DEFINED_CLANG) && defined(USEARCH_DEFINED_APPLE)
-	inline uint40_t(std::size_t n) noexcept {
+    inline uint40_t(std::size_t n) noexcept {
 #ifdef USEARCH_64BIT_ENV
-		std::memcpy(octets, &n, 5);
+        std::memcpy(octets, &n, 5);
 #else
-		std::memcpy(octets, &n, 4);
-#endif
-	}
-#endif
+        std::memcpy(octets, &n, 4);
+        octets[4] = 0;
+#endif // USEARCH_64BIT_ENV
+    }
+#endif // USEARCH_DEFINED_CLANG && USEARCH_DEFINED_APPLE
 
-	inline operator std::size_t() const noexcept {
-		std::size_t result = 0;
+    inline operator std::size_t() const noexcept {
+        std::size_t result = 0;
 #ifdef USEARCH_64BIT_ENV
-		std::memcpy(&result, octets, 5);
+        std::memcpy(&result, octets, 5);
 #else
-		std::memcpy(&result, octets + 1, 4);
+        std::memcpy(&result, octets, 4);
 #endif
-		return result;
-	}
+        return result;
+    }
 
-	inline static uint40_t max() noexcept {
-		return uint40_t {}.broadcast(0xFF);
-	}
-	inline static uint40_t min() noexcept {
-		return uint40_t {}.broadcast(0);
-	}
+    /* Parenthesized declarator keeps MSVC's preprocessor from expanding
+     * `max` / `min` against `<windows.h>`'s `max(a,b)` / `min(a,b)` macros. */
+    inline static uint40_t(max)() noexcept { return uint40_t{}.broadcast(0xFF); }
+    inline static uint40_t(min)() noexcept { return uint40_t{}.broadcast(0); }
+
+    inline bool operator==(uint40_t const& other) const noexcept { return std::memcmp(octets, other.octets, 5) == 0; }
+    inline bool operator!=(uint40_t const& other) const noexcept { return !(*this == other); }
+    inline bool operator>(uint40_t const& other) const noexcept { return other < *this; }
+    inline bool operator<=(uint40_t const& other) const noexcept { return !(*this > other); }
+    inline bool operator>=(uint40_t const& other) const noexcept { return !(*this < other); }
+    inline bool operator<(uint40_t const& other) const noexcept {
+        for (int i = 0; i < 5; ++i) {
+            if (octets[4 - i] < other.octets[4 - i])
+                return true;
+            if (octets[4 - i] > other.octets[4 - i])
+                return false;
+        }
+        return false;
+    }
 };
 
 #if defined(USEARCH_DEFINED_WINDOWS)
@@ -986,28 +1163,44 @@ public:
 
 static_assert(sizeof(uint40_t) == 5, "uint40_t must be exactly 5 bytes");
 
-// clang-format off
-template <typename key_at, typename std::enable_if<std::is_integral<key_at>::value>::type* = nullptr> key_at default_free_value() { return std::numeric_limits<key_at>::max(); }
-template <typename key_at, typename std::enable_if<std::is_same<key_at, uint40_t>::value>::type* = nullptr> uint40_t default_free_value() { return uint40_t::max(); }
-template <typename key_at, typename std::enable_if<!std::is_integral<key_at>::value && !std::is_same<key_at, uint40_t>::value>::type* = nullptr> key_at default_free_value() { return key_at(); }
-// clang-format on
-
-template <typename element_at>
-struct hash_gt {
-	std::size_t operator()(element_at const &element) const noexcept {
-		return std::hash<element_at> {}(element);
-	}
+/**
+ *  @brief  Reflection-helper to get the default "unused" value for a given type.
+ *          Needed to initialize hash-sets and bit-sets.
+ */
+template <typename element_at> struct default_free_value_gt {
+    template <typename sfinae_element_at = element_at,
+              typename std::enable_if<std::is_integral<sfinae_element_at>::value>::type* = nullptr>
+    static sfinae_element_at value() noexcept {
+        return (std::numeric_limits<element_at>::max)();
+    }
+    template <typename sfinae_element_at = element_at,
+              typename std::enable_if<!std::is_integral<sfinae_element_at>::value>::type* = nullptr>
+    static sfinae_element_at value() noexcept {
+        return element_at();
+    }
 };
 
-template <>
-struct hash_gt<uint40_t> {
-	std::size_t operator()(uint40_t const &element) const noexcept {
-		return std::hash<std::size_t> {}(element);
-	}
+template <> struct default_free_value_gt<uint40_t> {
+    static uint40_t value() noexcept { return (uint40_t::max)(); }
+};
+
+template <typename element_at> element_at default_free_value() { return default_free_value_gt<element_at>::value(); }
+
+/**
+ *  @brief  Adapter to allow definining arbitrary hash functions for keys and slots.
+ *          It's added, as overloading `std::hash` is not recommended by the standard.
+ */
+template <typename element_at> struct hash_gt {
+    std::size_t operator()(element_at const& element) const noexcept { return std::hash<element_at>{}(element); }
+};
+
+template <> struct hash_gt<uint40_t> {
+    std::size_t operator()(uint40_t const& element) const noexcept { return std::hash<std::size_t>{}(element); }
 };
 
 /**
  *  @brief  Minimalistic hash-set implementation to track visited nodes during graph traversal.
+ *          In our primary usecase, its a sparse alternative to a bit-set.
  *
  *  It doesn't support deletion of separate objects, but supports `clear`-ing all at once.
  *  It expects `reserve` to be called ahead of all insertions, so no resizes are needed.
@@ -1018,129 +1211,130 @@ struct hash_gt<uint40_t> {
 template <typename element_at, typename hasher_at = hash_gt<element_at>, typename allocator_at = std::allocator<byte_t>>
 class growing_hash_set_gt {
 
-	using element_t = element_at;
-	using hasher_t = hasher_at;
+    using element_t = element_at;
+    using hasher_t = hasher_at;
 
-	using allocator_t = allocator_at;
-	using byte_t = typename allocator_t::value_type;
-	static_assert(sizeof(byte_t) == 1, "Allocator must allocate separate addressable bytes");
+    using allocator_t = allocator_at;
+    using byte_t = typename allocator_t::value_type;
+    static_assert(sizeof(byte_t) == 1, "Allocator must allocate separate addressable bytes");
 
-	element_t *slots_ {};
-	/// @brief Number of slots.
-	std::size_t capacity_ {};
-	/// @brief Number of populated.
-	std::size_t count_ {};
-	hasher_t hasher_ {};
+    element_t* slots_{};
+    /// @brief Number of slots.
+    std::size_t capacity_{};
+    /// @brief Number of populated.
+    std::size_t count_{};
+    hasher_t hasher_{};
 
-public:
-	growing_hash_set_gt() noexcept {
-	}
-	~growing_hash_set_gt() noexcept {
-		reset();
-	}
+  public:
+    growing_hash_set_gt() noexcept {}
+    ~growing_hash_set_gt() noexcept { reset(); }
 
-	explicit operator bool() const noexcept {
-		return slots_;
-	}
-	std::size_t size() const noexcept {
-		return count_;
-	}
+    explicit operator bool() const noexcept { return slots_; }
+    std::size_t size() const noexcept { return count_; }
 
-	void clear() noexcept {
-		if (slots_)
-			std::memset((void *)slots_, 0xFF, capacity_ * sizeof(element_t));
-		count_ = 0;
-	}
+    void clear() noexcept {
+        if (slots_)
+            std::memset((void*)slots_, 0xFF, capacity_ * sizeof(element_t));
+        count_ = 0;
+    }
 
-	void reset() noexcept {
-		if (slots_)
-			allocator_t {}.deallocate((byte_t *)slots_, capacity_ * sizeof(element_t));
-		slots_ = nullptr;
-		capacity_ = 0;
-		count_ = 0;
-	}
+    void reset() noexcept {
+        if (slots_)
+            allocator_t{}.deallocate((byte_t*)slots_, capacity_ * sizeof(element_t));
+        slots_ = nullptr;
+        capacity_ = 0;
+        count_ = 0;
+    }
 
-	growing_hash_set_gt(std::size_t capacity) noexcept
-	    : slots_((element_t *)allocator_t {}.allocate(ceil2(capacity) * sizeof(element_t))),
-	      capacity_(slots_ ? ceil2(capacity) : 0u), count_(0u) {
-		clear();
-	}
+    growing_hash_set_gt(std::size_t capacity) noexcept
+        : slots_((element_t*)allocator_t{}.allocate(ceil2(capacity) * sizeof(element_t))),
+          capacity_(slots_ ? ceil2(capacity) : 0u), count_(0u) {
+        clear();
+    }
 
-	growing_hash_set_gt(growing_hash_set_gt &&other) noexcept {
-		slots_ = exchange(other.slots_, nullptr);
-		capacity_ = exchange(other.capacity_, 0);
-		count_ = exchange(other.count_, 0);
-	}
+    growing_hash_set_gt(growing_hash_set_gt&& other) noexcept {
+        slots_ = exchange(other.slots_, nullptr);
+        capacity_ = exchange(other.capacity_, 0);
+        count_ = exchange(other.count_, 0);
+    }
 
-	growing_hash_set_gt &operator=(growing_hash_set_gt &&other) noexcept {
-		std::swap(slots_, other.slots_);
-		std::swap(capacity_, other.capacity_);
-		std::swap(count_, other.count_);
-		return *this;
-	}
+    growing_hash_set_gt& operator=(growing_hash_set_gt&& other) noexcept {
+        std::swap(slots_, other.slots_);
+        std::swap(capacity_, other.capacity_);
+        std::swap(count_, other.count_);
+        return *this;
+    }
 
-	growing_hash_set_gt(growing_hash_set_gt const &) = delete;
-	growing_hash_set_gt &operator=(growing_hash_set_gt const &) = delete;
+    growing_hash_set_gt(growing_hash_set_gt const&) = delete;
+    growing_hash_set_gt& operator=(growing_hash_set_gt const&) = delete;
 
-	inline bool test(element_t const &elem) const noexcept {
-		std::size_t index = hasher_(elem) & (capacity_ - 1);
-		while (slots_[index] != default_free_value<element_t>()) {
-			if (slots_[index] == elem)
-				return true;
+    /**
+     *  @brief  Checks if the element is already in the hash-set.
+     *  @return `true` if the element is already in the hash-set.
+     */
+    inline bool test(element_t const& elem) const noexcept {
+        std::size_t index = hasher_(elem) & (capacity_ - 1);
+        while (slots_[index] != default_free_value<element_t>()) {
+            if (slots_[index] == elem)
+                return true;
 
-			index = (index + 1) & (capacity_ - 1);
-		}
-		return false;
-	}
+            index = (index + 1) & (capacity_ - 1);
+        }
+        return false;
+    }
 
-	/**
-	 *
-	 *  @return Similar to `bitset_gt`, returns the previous value.
-	 */
-	inline bool set(element_t const &elem) noexcept {
-		std::size_t index = hasher_(elem) & (capacity_ - 1);
-		while (slots_[index] != default_free_value<element_t>()) {
-			// Already exists
-			if (slots_[index] == elem)
-				return true;
+    /**
+     *  @brief  Inserts an element into the hash-set.
+     *  @return Similar to `bitset_gt`, returns the previous value.
+     */
+    inline bool set(element_t const& elem) noexcept {
+        std::size_t index = hasher_(elem) & (capacity_ - 1);
+        while (slots_[index] != default_free_value<element_t>()) {
+            // Already exists
+            if (slots_[index] == elem)
+                return true;
 
-			index = (index + 1) & (capacity_ - 1);
-		}
-		slots_[index] = elem;
-		++count_;
-		return false;
-	}
+            index = (index + 1) & (capacity_ - 1);
+        }
+        slots_[index] = elem;
+        ++count_;
+        return false;
+    }
 
-	bool reserve(std::size_t new_capacity) noexcept {
-		new_capacity = (new_capacity * 5u) / 3u;
-		if (new_capacity <= capacity_)
-			return true;
+    /**
+     *  @brief  Extends the capacity of the hash-set.
+     *  @return `true` if enough capacity is available, `false` if memory allocation failed.
+     */
+    bool reserve(std::size_t new_capacity) noexcept {
+        new_capacity = (new_capacity * 5u) / 3u;
+        if (new_capacity <= capacity_)
+            return true;
 
-		new_capacity = ceil2(new_capacity);
-		element_t *new_slots = (element_t *)allocator_t {}.allocate(new_capacity * sizeof(element_t));
-		if (!new_slots)
-			return false;
+        new_capacity = ceil2(new_capacity);
+        element_t* new_slots = (element_t*)allocator_t{}.allocate(new_capacity * sizeof(element_t));
+        if (!new_slots)
+            return false;
 
-		std::memset((void *)new_slots, 0xFF, new_capacity * sizeof(element_t));
-		std::size_t new_count = count_;
-		if (count_) {
-			for (std::size_t old_index = 0; old_index != capacity_; ++old_index) {
-				if (slots_[old_index] == default_free_value<element_t>())
-					continue;
+        std::memset((void*)new_slots, 0xFF, new_capacity * sizeof(element_t));
+        std::size_t new_count = count_;
+        if (count_) {
+            for (std::size_t old_index = 0; old_index != capacity_; ++old_index) {
+                if (slots_[old_index] == default_free_value<element_t>())
+                    continue;
 
-				std::size_t new_index = hasher_(slots_[old_index]) & (new_capacity - 1);
-				while (new_slots[new_index] != default_free_value<element_t>())
-					new_index = (new_index + 1) & (new_capacity - 1);
-				new_slots[new_index] = slots_[old_index];
-			}
-		}
+                std::size_t new_index = hasher_(slots_[old_index]) & (new_capacity - 1);
+                while (new_slots[new_index] != default_free_value<element_t>())
+                    new_index = (new_index + 1) & (new_capacity - 1);
+                new_slots[new_index] = slots_[old_index];
+            }
+        }
 
-		reset();
-		slots_ = new_slots;
-		capacity_ = new_capacity;
-		count_ = new_count;
-		return true;
-	}
+        reset();
+        slots_ = new_slots;
+        capacity_ = new_capacity;
+        count_ = new_count;
+        return true;
+    }
 };
 
 /**
@@ -1148,158 +1342,141 @@ public:
  */
 template <typename element_at, typename allocator_at = std::allocator<element_at>> //
 class ring_gt {
-public:
-	using element_t = element_at;
-	using allocator_t = allocator_at;
+  public:
+    using element_t = element_at;
+    using allocator_t = allocator_at;
 
-	static_assert(std::is_trivially_destructible<element_t>(), "This heap is designed for trivial structs");
-	static_assert(std::is_trivially_copy_constructible<element_t>(), "This heap is designed for trivial structs");
+    static_assert(std::is_trivially_destructible<element_t>(), "This ring is designed for trivial structs");
+    static_assert(std::is_trivially_copy_constructible<element_t>(), "This ring is designed for trivial structs");
 
-	using value_type = element_t;
+    using value_type = element_t;
 
-private:
-	element_t *elements_ {};
-	std::size_t capacity_ {};
-	std::size_t head_ {};
-	std::size_t tail_ {};
-	bool empty_ {true};
-	allocator_t allocator_ {};
+  private:
+    element_t* elements_{};
+    std::size_t capacity_{};
+    std::size_t head_{};
+    std::size_t tail_{};
+    bool empty_{true};
+    allocator_t allocator_{};
 
-public:
-	explicit ring_gt(allocator_t const &alloc = allocator_t()) noexcept : allocator_(alloc) {
-	}
+  public:
+    explicit ring_gt(allocator_t const& alloc = allocator_t()) noexcept : allocator_(alloc) {}
 
-	ring_gt(ring_gt const &) = delete;
-	ring_gt &operator=(ring_gt const &) = delete;
+    ring_gt(ring_gt const&) = delete;
+    ring_gt& operator=(ring_gt const&) = delete;
 
-	ring_gt(ring_gt &&other) noexcept {
-		swap(other);
-	}
-	ring_gt &operator=(ring_gt &&other) noexcept {
-		swap(other);
-		return *this;
-	}
+    ring_gt(ring_gt&& other) noexcept { swap(other); }
+    ring_gt& operator=(ring_gt&& other) noexcept {
+        swap(other);
+        return *this;
+    }
 
-	void swap(ring_gt &other) noexcept {
-		std::swap(elements_, other.elements_);
-		std::swap(capacity_, other.capacity_);
-		std::swap(head_, other.head_);
-		std::swap(tail_, other.tail_);
-		std::swap(empty_, other.empty_);
-		std::swap(allocator_, other.allocator_);
-	}
+    void swap(ring_gt& other) noexcept {
+        std::swap(elements_, other.elements_);
+        std::swap(capacity_, other.capacity_);
+        std::swap(head_, other.head_);
+        std::swap(tail_, other.tail_);
+        std::swap(empty_, other.empty_);
+        std::swap(allocator_, other.allocator_);
+    }
 
-	~ring_gt() noexcept {
-		reset();
-	}
+    ~ring_gt() noexcept { reset(); }
 
-	bool empty() const noexcept {
-		return empty_;
-	}
-	size_t capacity() const noexcept {
-		return capacity_;
-	}
-	size_t size() const noexcept {
-		if (empty_)
-			return 0;
-		else if (head_ >= tail_)
-			return head_ - tail_;
-		else
-			return capacity_ - (tail_ - head_);
-	}
+    bool empty() const noexcept { return empty_; }
+    size_t capacity() const noexcept { return capacity_; }
+    size_t size() const noexcept {
+        if (empty_)
+            return 0;
+        else if (head_ > tail_)
+            return head_ - tail_;
+        else
+            return capacity_ - (tail_ - head_);
+    }
 
-	void clear() noexcept {
-		head_ = 0;
-		tail_ = 0;
-		empty_ = true;
-	}
+    void clear() noexcept {
+        head_ = 0;
+        tail_ = 0;
+        empty_ = true;
+    }
 
-	void reset() noexcept {
-		if (elements_)
-			allocator_.deallocate(elements_, capacity_);
-		elements_ = nullptr;
-		capacity_ = 0;
-		head_ = 0;
-		tail_ = 0;
-		empty_ = true;
-	}
+    void reset() noexcept {
+        if (elements_)
+            allocator_.deallocate(elements_, capacity_);
+        elements_ = nullptr;
+        capacity_ = 0;
+        head_ = 0;
+        tail_ = 0;
+        empty_ = true;
+    }
 
-	bool reserve(std::size_t n) noexcept {
-		if (n < size())
-			return false; // prevent data loss
-		if (n <= capacity())
-			return true;
-		n = (std::max<std::size_t>)(ceil2(n), 64u);
-		element_t *elements = allocator_.allocate(n);
-		if (!elements)
-			return false;
+    bool reserve(std::size_t n) noexcept {
+        if (n < size())
+            return false; // prevent data loss
+        if (n <= capacity())
+            return true;
+        n = (std::max<std::size_t>)(ceil2(n), 64u);
+        element_t* elements = allocator_.allocate(n);
+        if (!elements)
+            return false;
 
-		std::size_t i = 0;
-		while (try_pop(elements[i]))
-			i++;
+        std::size_t i = 0;
+        while (try_pop(elements[i]))
+            i++;
 
-		reset();
-		elements_ = elements;
-		capacity_ = n;
-		head_ = i;
-		tail_ = 0;
-		empty_ = (i == 0);
-		return true;
-	}
+        reset();
+        elements_ = elements;
+        capacity_ = n;
+        head_ = i;
+        tail_ = 0;
+        empty_ = (i == 0);
+        return true;
+    }
 
-	void push(element_t const &value) noexcept {
-		elements_[head_] = value;
-		head_ = (head_ + 1) % capacity_;
-		empty_ = false;
-	}
+    void push(element_t const& value) usearch_noexcept_m {
+        usearch_assert_m(capacity() > 0, "Ring buffer is not initialized");
+        usearch_assert_m(size() < capacity(), "Ring buffer is full");
+        elements_[head_] = value;
+        head_ = (head_ + 1) % capacity_;
+        empty_ = false;
+    }
 
-	bool try_push(element_t const &value) noexcept {
-		if (head_ == tail_ && !empty_)
-			return false; // elements_ is full
+    bool try_push(element_t const& value) noexcept {
+        if (head_ == tail_ && !empty_)
+            return false; // `elements_` is full
 
-		return push(value);
-		return true;
-	}
+        return push(value);
+        return true;
+    }
 
-	bool try_pop(element_t &value) noexcept {
-		if (empty_)
-			return false;
+    bool try_pop(element_t& value) noexcept {
+        if (empty_)
+            return false;
 
-		value = std::move(elements_[tail_]);
-		tail_ = (tail_ + 1) % capacity_;
-		empty_ = head_ == tail_;
-		return true;
-	}
+        value = std::move(elements_[tail_]);
+        tail_ = (tail_ + 1) % capacity_;
+        empty_ = head_ == tail_;
+        return true;
+    }
 
-	element_t const &operator[](std::size_t i) const noexcept {
-		return elements_[(tail_ + i) % capacity_];
-	}
+    element_t const& operator[](std::size_t i) const noexcept { return elements_[(tail_ + i) % capacity_]; }
 };
 
 /// @brief Number of neighbors per graph node.
 /// Defaults to 32 in FAISS and 16 in hnswlib.
 /// > It is called `M` in the paper.
-constexpr std::size_t default_connectivity() {
-	return 16;
-}
+constexpr std::size_t default_connectivity() { return 16; }
 
 /// @brief Hyper-parameter controlling the quality of indexing.
 /// Defaults to 40 in FAISS and 200 in hnswlib.
 /// > It is called `efConstruction` in the paper.
-constexpr std::size_t default_expansion_add() {
-	return 128;
-}
+constexpr std::size_t default_expansion_add() { return 128; }
 
 /// @brief Hyper-parameter controlling the quality of search.
 /// Defaults to 16 in FAISS and 10 in hnswlib.
 /// > It is called `ef` in the paper.
-constexpr std::size_t default_expansion_search() {
-	return 64;
-}
+constexpr std::size_t default_expansion_search() { return 64; }
 
-constexpr std::size_t default_allocator_entry_bytes() {
-	return 64;
-}
+constexpr std::size_t default_allocator_entry_bytes() { return 64; }
 
 /**
  *  @brief  Configuration settings for the index construction.
@@ -1307,88 +1484,109 @@ constexpr std::size_t default_allocator_entry_bytes() {
  *          and two expansion factors - for construction and search.
  */
 struct index_config_t {
-	/// @brief Number of neighbors per graph node.
-	/// Defaults to 32 in FAISS and 16 in hnswlib.
-	/// > It is called `M` in the paper.
-	std::size_t connectivity = default_connectivity();
+    /// @brief Number of neighbors per graph node.
+    /// Defaults to 32 in FAISS and 16 in hnswlib.
+    /// > It is called `M` in the paper.
+    std::size_t connectivity = default_connectivity();
 
-	/// @brief Number of neighbors per graph node in base level graph.
-	/// Defaults to double of the other levels, so 64 in FAISS and 32 in hnswlib.
-	/// > It is called `M0` in the paper.
-	std::size_t connectivity_base = default_connectivity() * 2;
+    /// @brief Number of neighbors per graph node in base level graph.
+    /// Defaults to double of the other levels, so 64 in FAISS and 32 in hnswlib.
+    /// > It is called `M0` in the paper.
+    std::size_t connectivity_base = default_connectivity() * 2;
 
-	inline index_config_t() = default;
-	inline index_config_t(std::size_t c) noexcept
-	    : connectivity(c ? c : default_connectivity()), connectivity_base(c ? c * 2 : default_connectivity() * 2) {
-	}
-	inline index_config_t(std::size_t c, std::size_t cb) noexcept
-	    : connectivity(c), connectivity_base((std::max)(c, cb)) {
-	}
+    inline index_config_t() = default;
+    inline index_config_t(std::size_t c, std::size_t cb = 0) noexcept : connectivity(c), connectivity_base(cb) {}
+
+    /**
+     *  @brief  Validates the configuration settings, updating them in-place.
+     *  @return Error message, if any.
+     */
+    inline error_t validate() noexcept {
+        if (connectivity == 0)
+            connectivity = default_connectivity();
+        if (connectivity_base == 0)
+            connectivity_base = connectivity * 2;
+        if (connectivity < 2)
+            return "Connectivity must be at least 2, otherwise the index degenerates into ropes";
+        if (connectivity_base < connectivity)
+            return "Base layer should be at least as connected as the rest of the graph";
+        return {};
+    }
+
+    /**
+     *  @brief  Immutable function to check if the configuration is valid.
+     *  @return `true` if the configuration is valid.
+     */
+    inline bool is_valid() const noexcept { return connectivity >= 2 && connectivity_base >= connectivity; }
 };
 
+/**
+ *  @brief  Growth settings for the index container.
+ *          Includes the upper bound for `::members` capacity,
+ *          and the number of read/write threads expected to work with the index.
+ */
 struct index_limits_t {
-	std::size_t members = 0;
-	std::size_t threads_add = std::thread::hardware_concurrency();
-	std::size_t threads_search = std::thread::hardware_concurrency();
+    /// @brief Maximum number of entries in the index.
+    std::size_t members = 0;
+    /// @brief Max number of threads simultaneously updating entries.
+    std::size_t threads_add = std::thread::hardware_concurrency();
+    /// @brief Max number of threads simultaneously searching entries.
+    std::size_t threads_search = std::thread::hardware_concurrency();
 
-	inline index_limits_t(std::size_t n, std::size_t t) noexcept : members(n), threads_add(t), threads_search(t) {
-	}
-	inline index_limits_t(std::size_t n = 0) noexcept : index_limits_t(n, std::thread::hardware_concurrency()) {
-	}
-	inline std::size_t threads() const noexcept {
-		return (std::max)(threads_add, threads_search);
-	}
-	inline std::size_t concurrency() const noexcept {
-		return (std::min)(threads_add, threads_search);
-	}
+    inline index_limits_t(std::size_t n, std::size_t t) noexcept : members(n), threads_add(t), threads_search(t) {}
+    inline index_limits_t(std::size_t n = 0) noexcept : index_limits_t(n, std::thread::hardware_concurrency()) {}
+    /// @brief Returns the upper limit for the number of threads.
+    inline std::size_t threads() const noexcept { return (std::max)(threads_add, threads_search); }
+    /// @brief Returns the concurrency-level of the index - the minimum of thread counts.
+    inline std::size_t concurrency() const noexcept { return (std::min)(threads_add, threads_search); }
 };
 
 struct index_update_config_t {
-	/// @brief Hyper-parameter controlling the quality of indexing.
-	/// Defaults to 40 in FAISS and 200 in hnswlib.
-	/// > It is called `efConstruction` in the paper.
-	std::size_t expansion = default_expansion_add();
+    /// @brief Hyper-parameter controlling the quality of indexing.
+    /// Defaults to 40 in FAISS and 200 in hnswlib.
+    /// > It is called `efConstruction` in the paper.
+    std::size_t expansion = default_expansion_add();
 
-	/// @brief Optional thread identifier for multi-threaded construction.
-	std::size_t thread = 0;
+    /// @brief Optional thread identifier for multi-threaded construction.
+    std::size_t thread = 0;
 };
 
 struct index_search_config_t {
-	/// @brief Hyper-parameter controlling the quality of search.
-	/// Defaults to 16 in FAISS and 10 in hnswlib.
-	/// > It is called `ef` in the paper.
-	std::size_t expansion = default_expansion_search();
+    /// @brief Hyper-parameter controlling the quality of search.
+    /// Defaults to 16 in FAISS and 10 in hnswlib.
+    /// > It is called `ef` in the paper.
+    std::size_t expansion = default_expansion_search();
 
-	/// @brief Optional thread identifier for multi-threaded construction.
-	std::size_t thread = 0;
+    /// @brief Optional thread identifier for multi-threaded construction.
+    std::size_t thread = 0;
 
-	/// @brief Brute-forces exhaustive search over all entries in the index.
-	bool exact = false;
+    /// @brief Brute-forces exhaustive search over all entries in the index.
+    bool exact = false;
 };
 
 struct index_cluster_config_t {
-	/// @brief Hyper-parameter controlling the quality of search.
-	/// Defaults to 16 in FAISS and 10 in hnswlib.
-	/// > It is called `ef` in the paper.
-	std::size_t expansion = default_expansion_search();
+    /// @brief Hyper-parameter controlling the quality of search.
+    /// Defaults to 16 in FAISS and 10 in hnswlib.
+    /// > It is called `ef` in the paper.
+    std::size_t expansion = default_expansion_search();
 
-	/// @brief Optional thread identifier for multi-threaded construction.
-	std::size_t thread = 0;
+    /// @brief Optional thread identifier for multi-threaded construction.
+    std::size_t thread = 0;
 };
 
 struct index_copy_config_t {};
 
 struct index_join_config_t {
-	/// @brief Controls maximum number of proposals per man during stable marriage.
-	std::size_t max_proposals = 0;
+    /// @brief Controls maximum number of proposals per man during stable marriage.
+    std::size_t max_proposals = 0;
 
-	/// @brief Hyper-parameter controlling the quality of search.
-	/// Defaults to 16 in FAISS and 10 in hnswlib.
-	/// > It is called `ef` in the paper.
-	std::size_t expansion = default_expansion_search();
+    /// @brief Hyper-parameter controlling the quality of search.
+    /// Defaults to 16 in FAISS and 10 in hnswlib.
+    /// > It is called `ef` in the paper.
+    std::size_t expansion = default_expansion_search();
 
-	/// @brief Brute-forces exhaustive search over all entries in the index.
-	bool exact = false;
+    /// @brief Brute-forces exhaustive search over all entries in the index.
+    bool exact = false;
 };
 
 /// @brief  C++17 and newer version deprecate the `std::result_of`
@@ -1407,10 +1605,7 @@ using return_type_gt =
  *  on their auxiliary properties, such as some categorical keys stored in an external DBMS.
  */
 struct dummy_predicate_t {
-	template <typename member_at>
-	constexpr bool operator()(member_at &&) const noexcept {
-		return true;
-	}
+    template <typename member_at> constexpr bool operator()(member_at&&) const noexcept { return true; }
 };
 
 /**
@@ -1421,9 +1616,7 @@ struct dummy_predicate_t {
  *  consistency.
  */
 struct dummy_callback_t {
-	template <typename member_at>
-	void operator()(member_at &&) const noexcept {
-	}
+    template <typename member_at> void operator()(member_at&&) const noexcept {}
 };
 
 /**
@@ -1434,9 +1627,7 @@ struct dummy_callback_t {
  *  The reporter checks return value to continue or stop the process, `false` means need to stop.
  */
 struct dummy_progress_t {
-	inline bool operator()(std::size_t /*processed*/, std::size_t /*total*/) const noexcept {
-		return true;
-	}
+    inline bool operator()(std::size_t /*processed*/, std::size_t /*total*/) const noexcept { return true; }
 };
 
 /**
@@ -1455,9 +1646,8 @@ struct dummy_progress_t {
  *      }
  */
 struct dummy_prefetch_t {
-	template <typename member_citerator_like_at>
-	inline void operator()(member_citerator_like_at, member_citerator_like_at) const noexcept {
-	}
+    template <typename member_citerator_like_at>
+    inline void operator()(member_citerator_like_at, member_citerator_like_at) const noexcept {}
 };
 
 /**
@@ -1469,29 +1659,26 @@ struct dummy_prefetch_t {
  *  determine the number of available threads.
  */
 struct dummy_executor_t {
-	dummy_executor_t() noexcept {
-	}
-	std::size_t size() const noexcept {
-		return 1;
-	}
+    dummy_executor_t() noexcept {}
+    std::size_t size() const noexcept { return 1; }
 
-	template <typename thread_aware_function_at>
-	void fixed(std::size_t tasks, thread_aware_function_at &&thread_aware_function) noexcept {
-		for (std::size_t task_idx = 0; task_idx != tasks; ++task_idx)
-			thread_aware_function(0, task_idx);
-	}
+    template <typename thread_aware_function_at>
+    void fixed(std::size_t tasks, thread_aware_function_at&& thread_aware_function) noexcept {
+        for (std::size_t task_idx = 0; task_idx != tasks; ++task_idx)
+            thread_aware_function(0, task_idx);
+    }
 
-	template <typename thread_aware_function_at>
-	void dynamic(std::size_t tasks, thread_aware_function_at &&thread_aware_function) noexcept {
-		for (std::size_t task_idx = 0; task_idx != tasks; ++task_idx)
-			if (!thread_aware_function(0, task_idx))
-				break;
-	}
+    template <typename thread_aware_function_at>
+    void dynamic(std::size_t tasks, thread_aware_function_at&& thread_aware_function) noexcept {
+        for (std::size_t task_idx = 0; task_idx != tasks; ++task_idx)
+            if (!thread_aware_function(0, task_idx))
+                break;
+    }
 
-	template <typename thread_aware_function_at>
-	void parallel(thread_aware_function_at &&thread_aware_function) noexcept {
-		thread_aware_function(0);
-	}
+    template <typename thread_aware_function_at>
+    void parallel(thread_aware_function_at&& thread_aware_function) noexcept {
+        thread_aware_function(0);
+    }
 };
 
 /**
@@ -1502,71 +1689,57 @@ struct dummy_executor_t {
  *  this can be passed to minimize memory usage.
  */
 struct dummy_key_to_key_mapping_t {
-	struct member_ref_t {
-		template <typename key_at>
-		member_ref_t &operator=(key_at &&) noexcept {
-			return *this;
-		}
-	};
-	template <typename key_at>
-	member_ref_t operator[](key_at &&) const noexcept {
-		return {};
-	}
+    struct member_ref_t {
+        template <typename key_at> member_ref_t& operator=(key_at&&) noexcept { return *this; }
+    };
+    template <typename key_at> member_ref_t operator[](key_at&&) const noexcept { return {}; }
 };
 
 /**
  *  @brief  Checks if the provided object has a dummy type, emulating an interface,
  *          but performing no real computation.
  */
-template <typename object_at>
-static constexpr bool is_dummy() {
-	using object_t = typename std::remove_all_extents<object_at>::type;
-	return std::is_same<typename std::decay<object_t>::type, dummy_predicate_t>::value || //
-	       std::is_same<typename std::decay<object_t>::type, dummy_callback_t>::value ||  //
-	       std::is_same<typename std::decay<object_t>::type, dummy_progress_t>::value ||  //
-	       std::is_same<typename std::decay<object_t>::type, dummy_prefetch_t>::value ||  //
-	       std::is_same<typename std::decay<object_t>::type, dummy_executor_t>::value ||  //
-	       std::is_same<typename std::decay<object_t>::type, dummy_key_to_key_mapping_t>::value;
+template <typename object_at> static constexpr bool is_dummy() {
+    using object_t = typename std::remove_all_extents<object_at>::type;
+    return std::is_same<typename std::decay<object_t>::type, dummy_predicate_t>::value || //
+           std::is_same<typename std::decay<object_t>::type, dummy_callback_t>::value ||  //
+           std::is_same<typename std::decay<object_t>::type, dummy_progress_t>::value ||  //
+           std::is_same<typename std::decay<object_t>::type, dummy_prefetch_t>::value ||  //
+           std::is_same<typename std::decay<object_t>::type, dummy_executor_t>::value ||  //
+           std::is_same<typename std::decay<object_t>::type, dummy_key_to_key_mapping_t>::value;
 }
 
-template <typename, typename at>
-struct has_reset_gt {
-	static_assert(std::integral_constant<at, false>::value, "Second template parameter needs to be of function type.");
+template <typename, typename at> struct has_reset_gt {
+    static_assert(std::integral_constant<at, false>::value, "Second template parameter needs to be of function type.");
 };
 
 template <typename check_at, typename return_at, typename... args_at>
 struct has_reset_gt<check_at, return_at(args_at...)> {
-private:
-	template <typename at>
-	static constexpr auto check(at *) ->
-	    typename std::is_same<decltype(std::declval<at>().reset(std::declval<args_at>()...)), return_at>::type;
-	template <typename>
-	static constexpr std::false_type check(...);
+  private:
+    template <typename at>
+    static constexpr auto check(at*) ->
+        typename std::is_same<decltype(std::declval<at>().reset(std::declval<args_at>()...)), return_at>::type;
+    template <typename> static constexpr std::false_type check(...);
 
-	typedef decltype(check<check_at>(0)) type;
+    typedef decltype(check<check_at>(0)) type;
 
-public:
-	static constexpr bool value = type::value;
+  public:
+    static constexpr bool value = type::value;
 };
 
 /**
  *  @brief  Checks if a certain class has a member function called `reset`.
  */
-template <typename at>
-constexpr bool has_reset() {
-	return has_reset_gt<at, void()>::value;
-}
+template <typename at> constexpr bool has_reset() { return has_reset_gt<at, void()>::value; }
 
 struct serialization_result_t {
-	error_t error;
+    error_t error;
 
-	explicit operator bool() const noexcept {
-		return !error;
-	}
-	serialization_result_t failed(error_t message) noexcept {
-		error = std::move(message);
-		return std::move(*this);
-	}
+    explicit operator bool() const noexcept { return !error; }
+    serialization_result_t failed(error_t message) noexcept {
+        error = std::move(message);
+        return std::move(*this);
+    }
 };
 
 /**
@@ -1576,42 +1749,38 @@ struct serialization_result_t {
  * The class automatically closes the file when the object is destroyed.
  */
 class output_file_t {
-	char const *path_ = nullptr;
-	std::FILE *file_ = nullptr;
+    char const* path_ = nullptr;
+    std::FILE* file_ = nullptr;
 
-public:
-	output_file_t(char const *path) noexcept : path_(path) {
-	}
-	~output_file_t() noexcept {
-		close();
-	}
-	output_file_t(output_file_t &&other) noexcept
-	    : path_(exchange(other.path_, nullptr)), file_(exchange(other.file_, nullptr)) {
-	}
-	output_file_t &operator=(output_file_t &&other) noexcept {
-		std::swap(path_, other.path_);
-		std::swap(file_, other.file_);
-		return *this;
-	}
-	serialization_result_t open_if_not() noexcept {
-		serialization_result_t result;
-		if (!file_)
-			file_ = std::fopen(path_, "wb");
-		if (!file_)
-			return result.failed(std::strerror(errno));
-		return result;
-	}
-	serialization_result_t write(void const *begin, std::size_t length) noexcept {
-		serialization_result_t result;
-		std::size_t written = std::fwrite(begin, length, 1, file_);
-		if (length && !written)
-			return result.failed(std::strerror(errno));
-		return result;
-	}
-	void close() noexcept {
-		if (file_)
-			std::fclose(exchange(file_, nullptr));
-	}
+  public:
+    output_file_t(char const* path) noexcept : path_(path) {}
+    ~output_file_t() noexcept { close(); }
+    output_file_t(output_file_t&& other) noexcept
+        : path_(exchange(other.path_, nullptr)), file_(exchange(other.file_, nullptr)) {}
+    output_file_t& operator=(output_file_t&& other) noexcept {
+        std::swap(path_, other.path_);
+        std::swap(file_, other.file_);
+        return *this;
+    }
+    serialization_result_t open_if_not() noexcept {
+        serialization_result_t result;
+        if (!file_)
+            file_ = std::fopen(path_, "wb");
+        if (!file_)
+            return result.failed(std::strerror(errno));
+        return result;
+    }
+    serialization_result_t write(void const* begin, std::size_t length) noexcept {
+        serialization_result_t result;
+        std::size_t written = std::fwrite(begin, length, 1, file_);
+        if (length && !written)
+            return result.failed(std::strerror(errno));
+        return result;
+    }
+    void close() noexcept {
+        if (file_)
+            std::fclose(exchange(file_, nullptr));
+    }
 };
 
 /**
@@ -1621,60 +1790,54 @@ public:
  * The class automatically closes the file when the object is destroyed.
  */
 class input_file_t {
-	char const *path_ = nullptr;
-	std::FILE *file_ = nullptr;
+    char const* path_ = nullptr;
+    std::FILE* file_ = nullptr;
 
-public:
-	input_file_t(char const *path) noexcept : path_(path) {
-	}
-	~input_file_t() noexcept {
-		close();
-	}
-	input_file_t(input_file_t &&other) noexcept
-	    : path_(exchange(other.path_, nullptr)), file_(exchange(other.file_, nullptr)) {
-	}
-	input_file_t &operator=(input_file_t &&other) noexcept {
-		std::swap(path_, other.path_);
-		std::swap(file_, other.file_);
-		return *this;
-	}
+  public:
+    input_file_t(char const* path) noexcept : path_(path) {}
+    ~input_file_t() noexcept { close(); }
+    input_file_t(input_file_t&& other) noexcept
+        : path_(exchange(other.path_, nullptr)), file_(exchange(other.file_, nullptr)) {}
+    input_file_t& operator=(input_file_t&& other) noexcept {
+        std::swap(path_, other.path_);
+        std::swap(file_, other.file_);
+        return *this;
+    }
 
-	serialization_result_t open_if_not() noexcept {
-		serialization_result_t result;
-		if (!file_)
-			file_ = std::fopen(path_, "rb");
-		if (!file_)
-			return result.failed(std::strerror(errno));
-		return result;
-	}
-	serialization_result_t read(void *begin, std::size_t length) noexcept {
-		serialization_result_t result;
-		std::size_t read = std::fread(begin, length, 1, file_);
-		if (length && !read)
-			return result.failed(std::feof(file_) ? "End of file reached!" : std::strerror(errno));
-		return result;
-	}
-	void close() noexcept {
-		if (file_)
-			std::fclose(exchange(file_, nullptr));
-	}
+    serialization_result_t open_if_not() noexcept {
+        serialization_result_t result;
+        if (!file_)
+            file_ = std::fopen(path_, "rb");
+        if (!file_)
+            return result.failed(std::strerror(errno));
+        return result;
+    }
+    serialization_result_t read(void* begin, std::size_t length) noexcept {
+        serialization_result_t result;
+        std::size_t read = std::fread(begin, length, 1, file_);
+        if (length && !read) {
+            bool reached_eof = std::feof(file_);
+            return result.failed(reached_eof ? "End of file reached!" : std::strerror(errno));
+        }
+        return result;
+    }
+    void close() noexcept {
+        if (file_)
+            std::fclose(exchange(file_, nullptr));
+    }
 
-	explicit operator bool() const noexcept {
-		return file_;
-	}
-	bool seek_to(std::size_t progress) noexcept {
-		return std::fseek(file_, static_cast<long>(progress), SEEK_SET) == 0;
-	}
-	bool seek_to_end() noexcept {
-		return std::fseek(file_, 0L, SEEK_END) == 0;
-	}
-	bool infer_progress(std::size_t &progress) noexcept {
-		long int result = std::ftell(file_);
-		if (result == -1L)
-			return false;
-		progress = static_cast<std::size_t>(result);
-		return true;
-	}
+    explicit operator bool() const noexcept { return file_; }
+    bool seek_to(std::size_t progress) noexcept {
+        return std::fseek(file_, static_cast<long>(progress), SEEK_SET) == 0;
+    }
+    bool seek_to_end() noexcept { return std::fseek(file_, 0L, SEEK_END) == 0; }
+    bool infer_progress(std::size_t& progress) noexcept {
+        long int result = std::ftell(file_);
+        if (result == -1L)
+            return false;
+        progress = static_cast<std::size_t>(result);
+        return true;
+    }
 };
 
 /**
@@ -1685,207 +1848,182 @@ public:
  *  The class automatically closes the file when the object is destroyed.
  */
 class memory_mapped_file_t {
-	char const *path_ {}; /**< The path to the file to be memory-mapped. */
-	void *ptr_ {};        /**< A pointer to the memory-mapping. */
-	size_t length_ {};    /**< The length of the memory-mapped file in bytes. */
+    char const* path_{}; /**< The path to the file to be memory-mapped. */
+    void* ptr_{};        /**< A pointer to the memory-mapping. */
+    size_t length_{};    /**< The length of the memory-mapped file in bytes. */
 
 #if defined(USEARCH_DEFINED_WINDOWS)
-	HANDLE file_handle_ {};    /**< The file handle on Windows. */
-	HANDLE mapping_handle_ {}; /**< The mapping handle on Windows. */
+    HANDLE file_handle_{};    /**< The file handle on Windows. */
+    HANDLE mapping_handle_{}; /**< The mapping handle on Windows. */
 #else
-	int file_descriptor_ {}; /**< The file descriptor on Linux and MacOS. */
+    int file_descriptor_{}; /**< The file descriptor on Linux and MacOS. */
 #endif
 
-public:
-	explicit operator bool() const noexcept {
-		return ptr_ != nullptr;
-	}
-	byte_t *data() noexcept {
-		return reinterpret_cast<byte_t *>(ptr_);
-	}
-	byte_t const *data() const noexcept {
-		return reinterpret_cast<byte_t const *>(ptr_);
-	}
-	std::size_t size() const noexcept {
-		return static_cast<std::size_t>(length_);
-	}
+  public:
+    explicit operator bool() const noexcept { return ptr_ != nullptr; }
+    byte_t* data() noexcept { return reinterpret_cast<byte_t*>(ptr_); }
+    byte_t const* data() const noexcept { return reinterpret_cast<byte_t const*>(ptr_); }
+    std::size_t size() const noexcept { return static_cast<std::size_t>(length_); }
 
-	memory_mapped_file_t() noexcept {
-	}
-	memory_mapped_file_t(char const *path) noexcept : path_(path) {
-	}
-	~memory_mapped_file_t() noexcept {
-		close();
-	}
-	memory_mapped_file_t(memory_mapped_file_t &&other) noexcept
-	    : path_(exchange(other.path_, nullptr)), ptr_(exchange(other.ptr_, nullptr)),
-	      length_(exchange(other.length_, 0)),
+    memory_mapped_file_t() noexcept {}
+    memory_mapped_file_t(char const* path) noexcept : path_(path) {}
+    ~memory_mapped_file_t() noexcept { close(); }
+    memory_mapped_file_t(memory_mapped_file_t&& other) noexcept
+        : path_(exchange(other.path_, nullptr)), ptr_(exchange(other.ptr_, nullptr)),
+          length_(exchange(other.length_, 0)),
 #if defined(USEARCH_DEFINED_WINDOWS)
-	      file_handle_(exchange(other.file_handle_, nullptr)), mapping_handle_(exchange(other.mapping_handle_, nullptr))
+          file_handle_(exchange(other.file_handle_, nullptr)), mapping_handle_(exchange(other.mapping_handle_, nullptr))
 #else
-	      file_descriptor_(exchange(other.file_descriptor_, 0))
+          file_descriptor_(exchange(other.file_descriptor_, 0))
 #endif
-	{
-	}
+    {
+    }
 
-	memory_mapped_file_t(byte_t *data, std::size_t length) noexcept : ptr_(data), length_(length) {
-	}
+    memory_mapped_file_t(memory_mapped_file_t const&) = delete;
+    memory_mapped_file_t& operator=(memory_mapped_file_t const&) = delete;
 
-	memory_mapped_file_t &operator=(memory_mapped_file_t &&other) noexcept {
-		std::swap(path_, other.path_);
-		std::swap(ptr_, other.ptr_);
-		std::swap(length_, other.length_);
+    memory_mapped_file_t(byte_t* data, std::size_t length) noexcept : ptr_(data), length_(length) {}
+
+    memory_mapped_file_t& operator=(memory_mapped_file_t&& other) noexcept {
+        std::swap(path_, other.path_);
+        std::swap(ptr_, other.ptr_);
+        std::swap(length_, other.length_);
 #if defined(USEARCH_DEFINED_WINDOWS)
-		std::swap(file_handle_, other.file_handle_);
-		std::swap(mapping_handle_, other.mapping_handle_);
+        std::swap(file_handle_, other.file_handle_);
+        std::swap(mapping_handle_, other.mapping_handle_);
 #else
-		std::swap(file_descriptor_, other.file_descriptor_);
+        std::swap(file_descriptor_, other.file_descriptor_);
 #endif
-		return *this;
-	}
+        return *this;
+    }
 
-	serialization_result_t open_if_not() noexcept {
-		serialization_result_t result;
-		if (!path_ || ptr_)
-			return result;
+    serialization_result_t open_if_not() noexcept {
+        serialization_result_t result;
+        if (!path_ || ptr_)
+            return result;
 
 #if defined(USEARCH_DEFINED_WINDOWS)
 
-		HANDLE file_handle =
-		    CreateFile(path_, GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
-		if (file_handle == INVALID_HANDLE_VALUE)
-			return result.failed("Opening file failed!");
+        HANDLE file_handle =
+            CreateFileA(path_, GENERIC_READ, FILE_SHARE_READ, 0, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL, 0);
+        if (file_handle == INVALID_HANDLE_VALUE)
+            return result.failed("Opening file failed!");
 
-		std::size_t file_length = GetFileSize(file_handle, 0);
-		HANDLE mapping_handle = CreateFileMapping(file_handle, 0, PAGE_READONLY, 0, 0, 0);
-		if (mapping_handle == 0) {
-			CloseHandle(file_handle);
-			return result.failed("Mapping file failed!");
-		}
+        std::size_t file_length = GetFileSize(file_handle, 0);
+        HANDLE mapping_handle = CreateFileMapping(file_handle, 0, PAGE_READONLY, 0, 0, 0);
+        if (mapping_handle == 0) {
+            CloseHandle(file_handle);
+            return result.failed("Mapping file failed!");
+        }
 
-		byte_t *file = (byte_t *)MapViewOfFile(mapping_handle, FILE_MAP_READ, 0, 0, file_length);
-		if (file == 0) {
-			CloseHandle(mapping_handle);
-			CloseHandle(file_handle);
-			return result.failed("View the map failed!");
-		}
-		file_handle_ = file_handle;
-		mapping_handle_ = mapping_handle;
-		ptr_ = file;
-		length_ = file_length;
+        byte_t* file = (byte_t*)MapViewOfFile(mapping_handle, FILE_MAP_READ, 0, 0, file_length);
+        if (file == 0) {
+            CloseHandle(mapping_handle);
+            CloseHandle(file_handle);
+            return result.failed("View the map failed!");
+        }
+        file_handle_ = file_handle;
+        mapping_handle_ = mapping_handle;
+        ptr_ = file;
+        length_ = file_length;
 #else
 
 #if defined(USEARCH_DEFINED_LINUX)
-		int descriptor = open(path_, O_RDONLY | O_NOATIME);
+        int descriptor = open(path_, O_RDONLY | O_NOATIME);
 #else
-		int descriptor = open(path_, O_RDONLY);
+        int descriptor = open(path_, O_RDONLY);
 #endif
-		if (descriptor < 0)
-			return result.failed(std::strerror(errno));
+        if (descriptor < 0)
+            return result.failed(std::strerror(errno));
 
-		// Estimate the file size
-		struct stat file_stat;
-		int fstat_status = fstat(descriptor, &file_stat);
-		if (fstat_status < 0) {
-			::close(descriptor);
-			return result.failed(std::strerror(errno));
-		}
+        // Estimate the file size
+        struct stat file_stat;
+        int fstat_status = fstat(descriptor, &file_stat);
+        if (fstat_status < 0) {
+            ::close(descriptor);
+            return result.failed(std::strerror(errno));
+        }
 
-		// Map the entire file
-		byte_t *file = (byte_t *)mmap(NULL, file_stat.st_size, PROT_READ, MAP_SHARED, descriptor, 0);
-		if (file == MAP_FAILED) {
-			::close(descriptor);
-			return result.failed(std::strerror(errno));
-		}
-		file_descriptor_ = descriptor;
-		ptr_ = file;
-		length_ = file_stat.st_size;
+        // Map the entire file
+        byte_t* file = (byte_t*)mmap(NULL, file_stat.st_size, PROT_READ, MAP_SHARED, descriptor, 0);
+        if (file == MAP_FAILED) {
+            ::close(descriptor);
+            return result.failed(std::strerror(errno));
+        }
+        file_descriptor_ = descriptor;
+        ptr_ = file;
+        length_ = file_stat.st_size;
 #endif // Platform specific code
-		return result;
-	}
+        return result;
+    }
 
-	void close() noexcept {
-		if (!path_) {
-			ptr_ = nullptr;
-			length_ = 0;
-			return;
-		}
+    void close() noexcept {
+        if (!path_) {
+            ptr_ = nullptr;
+            length_ = 0;
+            return;
+        }
 #if defined(USEARCH_DEFINED_WINDOWS)
-		UnmapViewOfFile(ptr_);
-		CloseHandle(mapping_handle_);
-		CloseHandle(file_handle_);
-		mapping_handle_ = nullptr;
-		file_handle_ = nullptr;
+        UnmapViewOfFile(ptr_);
+        CloseHandle(mapping_handle_);
+        CloseHandle(file_handle_);
+        mapping_handle_ = nullptr;
+        file_handle_ = nullptr;
 #else
-		munmap(ptr_, length_);
-		::close(file_descriptor_);
-		file_descriptor_ = 0;
+        munmap(ptr_, length_);
+        ::close(file_descriptor_);
+        file_descriptor_ = 0;
 #endif
-		ptr_ = nullptr;
-		length_ = 0;
-	}
+        ptr_ = nullptr;
+        length_ = 0;
+    }
 };
 
+/**
+ *  @brief  Metadata header for the serialized index.
+ *
+ *  This structure is very minimalistic by design. It contains no information
+ *  about the capacity of the index, so you'll have to `reserve` after loading.
+ *  It also contains no info on the metric or key types, so you'll have to store
+ *  that information elsewhere, like we do in `index_dense_head_t`.
+ */
 struct index_serialized_header_t {
-	std::uint64_t size = 0;
-	std::uint64_t connectivity = 0;
-	std::uint64_t connectivity_base = 0;
-	std::uint64_t max_level = 0;
-	std::uint64_t entry_slot = 0;
+    std::uint64_t size = 0;
+    std::uint64_t connectivity = 0;
+    std::uint64_t connectivity_base = 0;
+    std::uint64_t max_level = 0;
+    std::uint64_t entry_slot = 0;
 };
 
 using default_key_t = std::uint64_t;
 using default_slot_t = std::uint32_t;
 using default_distance_t = float;
 
-template <typename key_at = default_key_t>
-struct member_gt {
-	key_at key;
-	std::size_t slot;
+template <typename key_at = default_key_t> struct member_gt {
+    key_at key;
+    std::size_t slot;
 };
 
-template <typename key_at>
-inline std::size_t get_slot(member_gt<key_at> const &m) noexcept {
-	return m.slot;
-}
-template <typename key_at>
-inline key_at get_key(member_gt<key_at> const &m) noexcept {
-	return m.key;
-}
+template <typename key_at> inline std::size_t get_slot(member_gt<key_at> const& m) noexcept { return m.slot; }
+template <typename key_at> inline key_at get_key(member_gt<key_at> const& m) noexcept { return m.key; }
 
-template <typename key_at = default_key_t>
-struct member_cref_gt {
-	misaligned_ref_gt<key_at const> key;
-	std::size_t slot;
+template <typename key_at = default_key_t> struct member_cref_gt {
+    misaligned_ref_gt<key_at const> key;
+    std::size_t slot;
 };
 
-template <typename key_at>
-inline std::size_t get_slot(member_cref_gt<key_at> const &m) noexcept {
-	return m.slot;
-}
-template <typename key_at>
-inline key_at get_key(member_cref_gt<key_at> const &m) noexcept {
-	return m.key;
-}
+template <typename key_at> inline std::size_t get_slot(member_cref_gt<key_at> const& m) noexcept { return m.slot; }
+template <typename key_at> inline key_at get_key(member_cref_gt<key_at> const& m) noexcept { return m.key; }
 
-template <typename key_at = default_key_t>
-struct member_ref_gt {
-	misaligned_ref_gt<key_at> key;
-	std::size_t slot;
+template <typename key_at = default_key_t> struct member_ref_gt {
+    misaligned_ref_gt<key_at> key;
+    std::size_t slot;
 
-	inline operator member_cref_gt<key_at>() const noexcept {
-		return {key.ptr(), slot};
-	}
+    inline operator member_cref_gt<key_at>() const noexcept { return {key.ptr(), slot}; }
 };
 
-template <typename key_at>
-inline std::size_t get_slot(member_ref_gt<key_at> const &m) noexcept {
-	return m.slot;
-}
-template <typename key_at>
-inline key_at get_key(member_ref_gt<key_at> const &m) noexcept {
-	return m.key;
-}
+template <typename key_at> inline std::size_t get_slot(member_ref_gt<key_at> const& m) noexcept { return m.slot; }
+template <typename key_at> inline key_at get_key(member_ref_gt<key_at> const& m) noexcept { return m.key; }
 
 /**
  *  @brief  Approximate Nearest Neighbors Search @b index-structure using the
@@ -1893,9 +2031,9 @@ inline key_at get_key(member_ref_gt<key_at> const &m) noexcept {
  *          If classical containers store @b Key->Value mappings, this one can
  *          be seen as a network of keys, accelerating approximate @b Value~>Key visited_members.
  *
- *  Unlike most implementations, this one is generic anc can be used for any search,
- *  not just within equi-dimensional vectors. Examples range from texts to similar Chess
- *  positions.
+ *  Unlike most implementations, this one is generic and can be used for any search,
+ *  not just within equi-dimensional vectors. Examples range from Texts to similar Chess
+ *  positions, Geo-Spatial Search, and even Graphs.
  *
  *  @tparam key_at
  *      The type of primary objects stored in the index.
@@ -1973,2110 +2111,2429 @@ template <typename distance_at = default_distance_t,              //
           typename dynamic_allocator_at = std::allocator<byte_t>, //
           typename tape_allocator_at = dynamic_allocator_at>      //
 class index_gt {
-public:
-	using distance_t = distance_at;
-	using vector_key_t = key_at;
-	using key_t = vector_key_t;
-	using compressed_slot_t = compressed_slot_at;
-	using dynamic_allocator_t = dynamic_allocator_at;
-	using tape_allocator_t = tape_allocator_at;
-	static_assert(sizeof(vector_key_t) >= sizeof(compressed_slot_t), "Having tiny keys doesn't make sense.");
+  public:
+    using distance_t = distance_at;
+    using vector_key_t = key_at;
+    using key_t = vector_key_t;
+    using compressed_slot_t = compressed_slot_at;
+    using dynamic_allocator_t = dynamic_allocator_at;
+    using tape_allocator_t = tape_allocator_at;
+    static_assert(sizeof(vector_key_t) >= sizeof(compressed_slot_t), "Having tiny keys doesn't make sense.");
+    static_assert(std::is_signed<distance_t>::value, "Distance must be a signed type, as we use the unary minus.");
 
-	using member_cref_t = member_cref_gt<vector_key_t>;
-	using member_ref_t = member_ref_gt<vector_key_t>;
+    using member_cref_t = member_cref_gt<vector_key_t>;
+    using member_ref_t = member_ref_gt<vector_key_t>;
 
-	template <typename ref_at, typename index_at>
-	class member_iterator_gt {
-		using ref_t = ref_at;
-		using index_t = index_at;
+    template <typename ref_at, typename index_at> class member_iterator_gt {
+        using ref_t = ref_at;
+        using index_t = index_at;
 
-		friend class index_gt;
-		member_iterator_gt() noexcept {
-		}
-		member_iterator_gt(index_t *index, std::size_t slot) noexcept : index_(index), slot_(slot) {
-		}
+        friend class index_gt;
+        member_iterator_gt() noexcept {}
+        member_iterator_gt(index_t* index, compressed_slot_t slot) noexcept : index_(index), slot_(slot) {}
 
-		index_t *index_ {};
-		std::size_t slot_ {};
+        template <int> ref_t call_key(std::true_type) const noexcept {
+            return ref_t{index_->node_at_(slot_).ckey(), slot_};
+        }
+        template <int> ref_t call_key(std::false_type) const noexcept {
+            return ref_t{index_->node_at_(slot_).key(), slot_};
+        }
 
-	public:
-		using iterator_category = std::random_access_iterator_tag;
-		using value_type = ref_t;
-		using difference_type = std::ptrdiff_t;
-		using pointer = void;
-		using reference = ref_t;
+        index_t* index_{};
+        compressed_slot_t slot_{};
 
-		reference operator*() const noexcept {
-			return {index_->node_at_(slot_).key(), slot_};
-		}
-		vector_key_t key() const noexcept {
-			return index_->node_at_(slot_).key();
-		}
+      public:
+        using iterator_category = std::random_access_iterator_tag;
+        using value_type = ref_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = void;
+        using reference = ref_t;
 
-		friend inline std::size_t get_slot(member_iterator_gt const &it) noexcept {
-			return it.slot_;
-		}
-		friend inline vector_key_t get_key(member_iterator_gt const &it) noexcept {
-			return it.key();
-		}
+        reference operator*() const noexcept { return call_key<0>(std::is_const<index_t>()); }
+        vector_key_t key() const noexcept { return index_->node_at_(slot_).ckey(); }
 
-		member_iterator_gt operator++(int) noexcept {
-			return member_iterator_gt(index_, slot_ + 1);
-		}
-		member_iterator_gt operator--(int) noexcept {
-			return member_iterator_gt(index_, slot_ - 1);
-		}
-		member_iterator_gt operator+(difference_type d) noexcept {
-			return member_iterator_gt(index_, slot_ + d);
-		}
-		member_iterator_gt operator-(difference_type d) noexcept {
-			return member_iterator_gt(index_, slot_ - d);
-		}
+        friend inline compressed_slot_t get_slot(member_iterator_gt const& it) noexcept { return it.slot_; }
+        friend inline vector_key_t get_key(member_iterator_gt const& it) noexcept { return it.key(); }
 
-		// clang-format off
-        member_iterator_gt& operator++() noexcept { slot_ += 1; return *this; }
-        member_iterator_gt& operator--() noexcept { slot_ -= 1; return *this; }
-        member_iterator_gt& operator+=(difference_type d) noexcept { slot_ += d; return *this; }
-        member_iterator_gt& operator-=(difference_type d) noexcept { slot_ -= d; return *this; }
+        // clang-format off
+        member_iterator_gt operator++(int) noexcept { member_iterator_gt old(index_, slot_); ++(*this); return old; }
+        member_iterator_gt operator--(int) noexcept { member_iterator_gt old(index_, slot_); --(*this); return old; }
+        member_iterator_gt operator+(difference_type d) noexcept { return member_iterator_gt(index_, static_cast<compressed_slot_t>(static_cast<std::size_t>(slot_) + d)); }
+        member_iterator_gt operator-(difference_type d) noexcept { return member_iterator_gt(index_, static_cast<compressed_slot_t>(static_cast<std::size_t>(slot_) - d)); }
+        member_iterator_gt& operator++() noexcept { slot_ = static_cast<compressed_slot_t>(static_cast<std::size_t>(slot_) + 1); return *this; }
+        member_iterator_gt& operator--() noexcept { slot_ = static_cast<compressed_slot_t>(static_cast<std::size_t>(slot_) - 1); return *this; }
+        member_iterator_gt& operator+=(difference_type d) noexcept { slot_ = static_cast<compressed_slot_t>(static_cast<std::size_t>(slot_) + d); return *this; }
+        member_iterator_gt& operator-=(difference_type d) noexcept { slot_ = static_cast<compressed_slot_t>(static_cast<std::size_t>(slot_) - d); return *this; }
         bool operator==(member_iterator_gt const& other) const noexcept { return index_ == other.index_ && slot_ == other.slot_; }
         bool operator!=(member_iterator_gt const& other) const noexcept { return index_ != other.index_ || slot_ != other.slot_; }
-		// clang-format on
-	};
+        // clang-format on
+    };
 
-	using member_iterator_t = member_iterator_gt<member_ref_t, index_gt>;
-	using member_citerator_t = member_iterator_gt<member_cref_t, index_gt const>;
+    using member_iterator_t = member_iterator_gt<member_ref_t, index_gt>;
+    using member_citerator_t = member_iterator_gt<member_cref_t, index_gt const>;
 
-	// STL compatibility:
-	using value_type = vector_key_t;
-	using allocator_type = dynamic_allocator_t;
-	using size_type = std::size_t;
-	using difference_type = std::ptrdiff_t;
-	using reference = member_ref_t;
-	using const_reference = member_cref_t;
-	using pointer = void;
-	using const_pointer = void;
-	using iterator = member_iterator_t;
-	using const_iterator = member_citerator_t;
-	using reverse_iterator = std::reverse_iterator<member_iterator_t>;
-	using reverse_const_iterator = std::reverse_iterator<member_citerator_t>;
+    // STL compatibility:
+    using value_type = vector_key_t;
+    using allocator_type = dynamic_allocator_t;
+    using size_type = std::size_t;
+    using difference_type = std::ptrdiff_t;
+    using reference = member_ref_t;
+    using const_reference = member_cref_t;
+    using pointer = void;
+    using const_pointer = void;
+    using iterator = member_iterator_t;
+    using const_iterator = member_citerator_t;
+    using reverse_iterator = std::reverse_iterator<member_iterator_t>;
+    using reverse_const_iterator = std::reverse_iterator<member_citerator_t>;
 
-	using dynamic_allocator_traits_t = std::allocator_traits<dynamic_allocator_t>;
-	using byte_t = typename dynamic_allocator_t::value_type;
-	static_assert(           //
-	    sizeof(byte_t) == 1, //
-	    "Primary allocator must allocate separate addressable bytes");
+    using dynamic_allocator_traits_t = std::allocator_traits<dynamic_allocator_t>;
+    using byte_t = typename dynamic_allocator_t::value_type;
+    static_assert(           //
+        sizeof(byte_t) == 1, //
+        "Primary allocator must allocate separate addressable bytes");
 
-	using tape_allocator_traits_t = std::allocator_traits<tape_allocator_t>;
-	static_assert(                                                 //
-	    sizeof(typename tape_allocator_traits_t::value_type) == 1, //
-	    "Tape allocator must allocate separate addressable bytes");
+    using tape_allocator_traits_t = std::allocator_traits<tape_allocator_t>;
+    static_assert(                                                 //
+        sizeof(typename tape_allocator_traits_t::value_type) == 1, //
+        "Tape allocator must allocate separate addressable bytes");
 
-private:
-	/**
-	 *  @brief  Integer for the number of node neighbors at a specific level of the
-	 *          multi-level graph. It's selected to be `std::uint32_t` to improve the
-	 *          alignment in most common cases.
-	 */
-	using neighbors_count_t = std::uint32_t;
-	using level_t = std::int16_t;
+  private:
+    /**
+     *  @brief  Integer for the number of node neighbors at a specific level of the
+     *          multi-level graph. It's selected to be `std::uint32_t` to improve the
+     *          alignment in most common cases.
+     */
+    using neighbors_count_t = std::uint32_t;
+    using level_t = std::int16_t;
 
-	/**
-	 *  @brief  How many bytes of memory are needed to form the "head" of the node.
-	 */
-	static constexpr std::size_t node_head_bytes_() {
-		return sizeof(vector_key_t) + sizeof(level_t);
-	}
+    /**
+     *  @brief  How many bytes of memory are needed to form the "head" of the node.
+     */
+    static constexpr std::size_t node_head_bytes_() { return sizeof(vector_key_t) + sizeof(level_t); }
 
-	using nodes_mutexes_t = bitset_gt<dynamic_allocator_t>;
+    using nodes_mutexes_t = striped_locks_gt<dynamic_allocator_t>;
 
-	using visits_hash_set_t = growing_hash_set_gt<compressed_slot_t, hash_gt<compressed_slot_t>, dynamic_allocator_t>;
+    using visits_hash_set_t = growing_hash_set_gt<compressed_slot_t, hash_gt<compressed_slot_t>, dynamic_allocator_t>;
 
-	struct precomputed_constants_t {
-		double inverse_log_connectivity {};
-		std::size_t neighbors_bytes {};
-		std::size_t neighbors_base_bytes {};
-	};
-	/// @brief A space-efficient internal data-structure used in graph traversal queues.
-	struct candidate_t {
-		distance_t distance;
-		compressed_slot_t slot;
-		inline bool operator<(candidate_t other) const noexcept {
-			return distance < other.distance;
-		}
-	};
+    struct precomputed_constants_t {
+        double inverse_log_connectivity{};
+        std::size_t neighbors_bytes{};
+        std::size_t neighbors_base_bytes{};
+    };
+    /// @brief A space-efficient internal data-structure used in graph traversal queues.
+    struct candidate_t {
+        distance_t distance;
+        compressed_slot_t slot;
+        inline bool operator<(candidate_t other) const noexcept { return distance < other.distance; }
+    };
 
-	using candidates_view_t = span_gt<candidate_t const>;
-	using candidates_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<candidate_t>;
-	using top_candidates_t = sorted_buffer_gt<candidate_t, std::less<candidate_t>, candidates_allocator_t>;
-	using next_candidates_t = max_heap_gt<candidate_t, std::less<candidate_t>, candidates_allocator_t>;
+    using candidates_view_t = span_gt<candidate_t const>;
+    using candidates_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<candidate_t>;
+    using top_candidates_t = sorted_buffer_gt<candidate_t, std::less<candidate_t>, candidates_allocator_t>;
+    using next_candidates_t = max_heap_gt<candidate_t, std::less<candidate_t>, candidates_allocator_t>;
 
-	/**
-	 *  @brief  A loosely-structured handle for every node. One such node is created for every member.
-	 *          To minimize memory usage and maximize the number of entries per cache-line, it only
-	 *          stores to pointers. The internal tape starts with a `vector_key_t` @b key, then
-	 *          a `level_t` for the number of graph @b levels in which this member appears,
-	 *          then the { `neighbors_count_t`, `compressed_slot_t`, `compressed_slot_t` ... } sequences
-	 *          for @b each-level.
-	 */
-	class node_t {
-		byte_t *tape_ {};
+    /**
+     *  @brief  A loosely-structured handle for every node. One such node is created for every member.
+     *          To minimize memory usage and maximize the number of entries per cache-line, it only
+     *          stores to pointers. The internal tape starts with a `vector_key_t` @b key, then
+     *          a `level_t` for the number of graph @b levels in which this member appears,
+     *          then the { `neighbors_count_t`, `compressed_slot_t`, `compressed_slot_t` ... } sequences
+     *          for @b each-level.
+     */
+    class node_t {
+        byte_t* tape_{};
 
-	public:
-		explicit node_t(byte_t *tape) noexcept : tape_(tape) {
-		}
-		byte_t *tape() const noexcept {
-			return tape_;
-		}
-		byte_t *neighbors_tape() const noexcept {
-			return tape_ + node_head_bytes_();
-		}
-		explicit operator bool() const noexcept {
-			return tape_;
-		}
+      public:
+        explicit node_t(byte_t* tape) noexcept : tape_(tape) {}
+        byte_t* tape() const noexcept { return tape_; }
+        byte_t* neighbors_tape() const noexcept { return tape_ + node_head_bytes_(); }
+        explicit operator bool() const noexcept { return tape_; }
 
-		node_t() = default;
-		node_t(node_t const &) = default;
-		node_t &operator=(node_t const &) = default;
+        node_t() = default;
+        node_t(node_t const&) = default;
+        node_t& operator=(node_t const&) = default;
 
-		misaligned_ref_gt<vector_key_t const> ckey() const noexcept {
-			return {tape_};
-		}
-		misaligned_ref_gt<vector_key_t> key() const noexcept {
-			return {tape_};
-		}
-		misaligned_ref_gt<level_t> level() const noexcept {
-			return {tape_ + sizeof(vector_key_t)};
-		}
+        misaligned_ref_gt<vector_key_t const> ckey() const noexcept { return {tape_}; }
+        misaligned_ref_gt<vector_key_t const> ckey() noexcept { return {tape_}; }
+        misaligned_ref_gt<vector_key_t const> key() const noexcept { return {tape_}; }
+        misaligned_ref_gt<vector_key_t> key() noexcept { return {tape_}; }
+        misaligned_ref_gt<level_t> level() noexcept { return {tape_ + sizeof(vector_key_t)}; }
 
-		void key(vector_key_t v) noexcept {
-			return misaligned_store<vector_key_t>(tape_, v);
-		}
-		void level(level_t v) noexcept {
-			return misaligned_store<level_t>(tape_ + sizeof(vector_key_t), v);
-		}
-	};
+        void key(vector_key_t v) noexcept { return misaligned_store<vector_key_t>(tape_, v); }
+        void level(level_t v) noexcept { return misaligned_store<level_t>(tape_ + sizeof(vector_key_t), v); }
+    };
 
-	static_assert(std::is_trivially_copy_constructible<node_t>::value, "Nodes must be light!");
-	static_assert(std::is_trivially_destructible<node_t>::value, "Nodes must be light!");
+    static_assert(std::is_trivially_copy_constructible<node_t>::value, "Nodes must be light!");
+    static_assert(std::is_trivially_destructible<node_t>::value, "Nodes must be light!");
 
-	/**
-	 *  @brief  A slice of the node's tape, containing a the list of neighbors
-	 *          for a node in a single graph level. It's pre-allocated to fit
-	 *          as many neighbors "slots", as may be needed at the target level,
-	 *          and starts with a single integer `neighbors_count_t` counter.
-	 */
-	class neighbors_ref_t {
-		byte_t *tape_;
+    /**
+     *  @brief  A slice of the node's tape, containing a the list of neighbors
+     *          for a node in a single graph level. It's pre-allocated to fit
+     *          as many neighbors "slots", as may be needed at the target level,
+     *          and starts with a single integer `neighbors_count_t` counter.
+     */
+    class neighbors_ref_t {
+        byte_t* tape_;
 
-		static constexpr std::size_t shift(std::size_t i = 0) {
-			return sizeof(neighbors_count_t) + sizeof(compressed_slot_t) * i;
-		}
+        static constexpr std::size_t shift(std::size_t i = 0) noexcept {
+            return sizeof(neighbors_count_t) + sizeof(compressed_slot_t) * i;
+        }
 
-	public:
-		neighbors_ref_t(byte_t *tape) noexcept : tape_(tape) {
-		}
-		misaligned_ptr_gt<compressed_slot_t> begin() noexcept {
-			return tape_ + shift();
-		}
-		misaligned_ptr_gt<compressed_slot_t> end() noexcept {
-			return begin() + size();
-		}
-		misaligned_ptr_gt<compressed_slot_t const> begin() const noexcept {
-			return tape_ + shift();
-		}
-		misaligned_ptr_gt<compressed_slot_t const> end() const noexcept {
-			return begin() + size();
-		}
-		compressed_slot_t operator[](std::size_t i) const noexcept {
-			return misaligned_load<compressed_slot_t>(tape_ + shift(i));
-		}
-		std::size_t size() const noexcept {
-			return misaligned_load<neighbors_count_t>(tape_);
-		}
-		void clear() noexcept {
-			neighbors_count_t n = misaligned_load<neighbors_count_t>(tape_);
-			std::memset(tape_, 0, shift(n));
-			// misaligned_store<neighbors_count_t>(tape_, 0);
-		}
-		void push_back(compressed_slot_t slot) noexcept {
-			neighbors_count_t n = misaligned_load<neighbors_count_t>(tape_);
-			misaligned_store<compressed_slot_t>(tape_ + shift(n), slot);
-			misaligned_store<neighbors_count_t>(tape_, n + 1);
-		}
-	};
+      public:
+        using iterator = misaligned_ptr_gt<compressed_slot_t>;
+        using const_iterator = misaligned_ptr_gt<compressed_slot_t const>;
+        using value_type = compressed_slot_t;
 
-	/**
-	 *  @brief  A package of all kinds of temporary data-structures, that the threads
-	 *          would reuse to process requests. Similar to having all of those as
-	 *          separate `thread_local` global variables.
-	 */
-	struct usearch_align_m context_t {
-		top_candidates_t top_candidates {};
-		next_candidates_t next_candidates {};
-		visits_hash_set_t visits {};
-		std::default_random_engine level_generator {};
-		std::size_t iteration_cycles {};
-		std::size_t computed_distances_count {};
+        neighbors_ref_t(byte_t* tape) noexcept : tape_(tape) {}
+        misaligned_ptr_gt<compressed_slot_t> begin() noexcept { return tape_ + shift(); }
+        misaligned_ptr_gt<compressed_slot_t> end() noexcept { return begin() + size(); }
+        misaligned_ptr_gt<compressed_slot_t const> begin() const noexcept { return tape_ + shift(); }
+        misaligned_ptr_gt<compressed_slot_t const> end() const noexcept { return begin() + size(); }
+        misaligned_ptr_gt<compressed_slot_t const> cbegin() noexcept { return tape_ + shift(); }
+        misaligned_ptr_gt<compressed_slot_t const> cend() noexcept { return cbegin() + size(); }
+        compressed_slot_t operator[](std::size_t i) const noexcept {
+            return misaligned_load<compressed_slot_t>(tape_ + shift(i));
+        }
+        std::size_t size() const noexcept { return misaligned_load<neighbors_count_t>(tape_); }
+        void clear() noexcept {
+            neighbors_count_t n = misaligned_load<neighbors_count_t>(tape_);
+            std::memset(tape_, 0, shift(n));
+            misaligned_store<neighbors_count_t>(tape_, 0);
+        }
+        void push_back(compressed_slot_t slot) noexcept {
+            neighbors_count_t n = misaligned_load<neighbors_count_t>(tape_);
+            misaligned_store<compressed_slot_t>(tape_ + shift(n), slot);
+            misaligned_store<neighbors_count_t>(tape_, n + 1);
+        }
+        template <typename allow_slot_at> std::size_t erase_if(allow_slot_at&& allow_slot) noexcept {
+            std::size_t old_count = misaligned_load<neighbors_count_t>(tape_);
+            std::size_t removed_count = 0;
+            for (std::size_t i = 0; i < old_count; ++i) {
+                compressed_slot_t slot = misaligned_load<compressed_slot_t>(tape_ + shift(i));
+                if (allow_slot(slot)) {
+                    removed_count++;
+                } else {
+                    misaligned_store<compressed_slot_t>(tape_ + shift(i - removed_count), slot);
+                }
+            }
+            misaligned_store<neighbors_count_t>(tape_, static_cast<neighbors_count_t>(old_count - removed_count));
+            return removed_count;
+        }
+    };
 
-		template <typename value_at, typename metric_at, typename entry_at> //
-		inline distance_t measure(value_at const &first, entry_at const &second, metric_at &&metric) noexcept {
-			static_assert( //
-			    std::is_same<entry_at, member_cref_t>::value || std::is_same<entry_at, member_citerator_t>::value,
-			    "Unexpected type");
+    /**
+     *  @brief  A package of all kinds of temporary data-structures, that the threads
+     *          would reuse to process requests. Similar to having all of those as
+     *          separate `thread_local` global variables.
+     */
+    struct usearch_align_m context_t {
+        top_candidates_t top_candidates{};
+        top_candidates_t top_for_refine{};
+        next_candidates_t next_candidates{};
+        visits_hash_set_t visits{};
+        std::default_random_engine level_generator{};
+        std::size_t iteration_cycles{};
+        std::size_t computed_distances{};
+        std::size_t computed_distances_in_refines{};
+        std::size_t computed_distances_in_reverse_refines{};
 
-			computed_distances_count++;
-			return metric(first, second);
-		}
+        /// @brief Heterogeneous distance calculation.
+        template <typename value_at, typename metric_at, typename entry_at> //
+        inline distance_t measure(value_at const& first, entry_at const& second, metric_at&& metric) noexcept {
+            static_assert( //
+                std::is_same<entry_at, member_cref_t>::value || std::is_same<entry_at, member_citerator_t>::value,
+                "Unexpected type");
 
-		template <typename metric_at, typename entry_at> //
-		inline distance_t measure(entry_at const &first, entry_at const &second, metric_at &&metric) noexcept {
-			static_assert( //
-			    std::is_same<entry_at, member_cref_t>::value || std::is_same<entry_at, member_citerator_t>::value,
-			    "Unexpected type");
+            computed_distances++;
+            return metric(first, second);
+        }
 
-			computed_distances_count++;
-			return metric(first, second);
-		}
-	};
+        /// @brief Homogeneous distance calculation.
+        template <typename metric_at, typename entry_at> //
+        inline distance_t measure(entry_at const& first, entry_at const& second, metric_at&& metric) noexcept {
+            static_assert( //
+                std::is_same<entry_at, member_cref_t>::value || std::is_same<entry_at, member_citerator_t>::value,
+                "Unexpected type");
 
-	index_config_t config_ {};
-	index_limits_t limits_ {};
+            computed_distances++;
+            return metric(first, second);
+        }
 
-	mutable dynamic_allocator_t dynamic_allocator_ {};
-	tape_allocator_t tape_allocator_ {};
+        /// @brief Heterogeneous batch distance calculation.
+        template <typename value_at, typename metric_at, typename entries_at, typename candidate_allowed_at,
+                  typename transform_at,
+                  typename callback_at> //
+        inline void measure_batch(value_at const& first, entries_at const& second_entries, metric_at&& metric,
+                                  candidate_allowed_at&& candidate_allowed, transform_at&& transform,
+                                  callback_at&& callback) noexcept {
 
-	precomputed_constants_t pre_ {};
-	memory_mapped_file_t viewed_file_ {};
+            using entry_t = typename std::remove_reference<decltype(second_entries[0])>::type;
+            metric.batch(first, second_entries, candidate_allowed, transform,
+                         [&](entry_t const& entry, distance_t distance) {
+                             callback(entry, distance);
+                             computed_distances++;
+                         });
+        }
+    };
 
-	/// @brief  Number of "slots" available for `node_t` objects. Equals to @b `limits_.members`.
-	usearch_align_m mutable std::atomic<std::size_t> nodes_capacity_ {};
+    /// @brief  Number of "slots" available for `node_t` objects. Equals to @b `limits_.members`.
+    mutable std::atomic<std::size_t> nodes_capacity_{};
 
-	/// @brief  Number of "slots" already storing non-null nodes.
-	usearch_align_m mutable std::atomic<std::size_t> nodes_count_ {};
+    /// @brief  Number of "slots" already storing non-null nodes.
+    mutable std::atomic<std::size_t> nodes_count_{};
 
-	/// @brief  Controls access to `max_level_` and `entry_slot_`.
-	///         If any thread is updating those values, no other threads can `add()` or `search()`.
-	std::mutex global_mutex_ {};
+    index_config_t config_{};
+    index_limits_t limits_{};
 
-	/// @brief  The level of the top-most graph in the index. Grows as the logarithm of size, starts from zero.
-	level_t max_level_ {};
+    mutable dynamic_allocator_t dynamic_allocator_{};
+    tape_allocator_t tape_allocator_{};
 
-	/// @brief  The slot in which the only node of the top-level graph is stored.
-	std::size_t entry_slot_ {};
+    precomputed_constants_t pre_{};
+    memory_mapped_file_t viewed_file_{};
 
-	using nodes_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<node_t>;
+    /// @brief  Controls access to `max_level_` and `entry_slot_`.
+    ///         If any thread is updating those values, no other threads can `add()` or `search()`.
+    std::mutex global_mutex_{};
 
-	/// @brief  C-style array of `node_t` smart-pointers.
-	buffer_gt<node_t, nodes_allocator_t> nodes_ {};
+    /// @brief  The level of the top-most graph in the index. Grows as the logarithm of size, starts from zero.
+    level_t max_level_{};
 
-	/// @brief  Mutex, that limits concurrent access to `nodes_`.
-	mutable nodes_mutexes_t nodes_mutexes_ {};
+    /// @brief  The slot in which the only node of the top-level graph is stored.
+    std::size_t entry_slot_{};
 
-	using contexts_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<context_t>;
+    using nodes_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<node_t>;
 
-	/// @brief  Array of thread-specific buffers for temporary data.
-	mutable buffer_gt<context_t, contexts_allocator_t> contexts_ {};
+    /// @brief  C-style array of `node_t` smart-pointers. Use `compressed_slot_t` for indexing.
+    buffer_gt<node_t, nodes_allocator_t> nodes_{};
 
-public:
-	std::size_t connectivity() const noexcept {
-		return config_.connectivity;
-	}
-	std::size_t capacity() const noexcept {
-		return nodes_capacity_;
-	}
-	std::size_t size() const noexcept {
-		return nodes_count_;
-	}
-	std::size_t max_level() const noexcept {
-		return nodes_count_ ? static_cast<std::size_t>(max_level_) : 0;
-	}
-	index_config_t const &config() const noexcept {
-		return config_;
-	}
-	index_limits_t const &limits() const noexcept {
-		return limits_;
-	}
-	bool is_immutable() const noexcept {
-		return bool(viewed_file_);
-	}
+    /// @brief  Mutex, that limits concurrent access to `nodes_`.
+    mutable nodes_mutexes_t nodes_mutexes_{};
 
-	/**
-	 *  @section Exceptions
-	 *      Doesn't throw, unless the ::metric's and ::allocators's throw on copy-construction.
-	 */
-	explicit index_gt( //
-	    index_config_t config = {}, dynamic_allocator_t dynamic_allocator = {},
-	    tape_allocator_t tape_allocator = {}) noexcept
-	    : config_(config), limits_(0, 0), dynamic_allocator_(std::move(dynamic_allocator)),
-	      tape_allocator_(std::move(tape_allocator)), pre_(precompute_(config)), nodes_count_(0u), max_level_(-1),
-	      entry_slot_(0u), nodes_(), nodes_mutexes_(), contexts_() {
-	}
+    using contexts_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<context_t>;
 
-	/**
-	 *  @brief  Clones the structure with the same hyper-parameters, but without contents.
-	 */
-	index_gt fork() noexcept {
-		return index_gt {config_, dynamic_allocator_, tape_allocator_};
-	}
+    /// @brief  Array of thread-specific buffers for temporary data.
+    mutable buffer_gt<context_t, contexts_allocator_t> contexts_{};
 
-	~index_gt() noexcept {
-		reset();
-	}
+  public:
+    std::size_t connectivity() const noexcept { return config_.connectivity; }
+    std::size_t capacity() const noexcept { return nodes_capacity_; }
+    std::size_t size() const noexcept { return nodes_count_; }
+    std::size_t max_level() const noexcept { return nodes_count_ ? static_cast<std::size_t>(max_level_) : 0; }
+    index_config_t const& config() const noexcept { return config_; }
+    index_limits_t const& limits() const noexcept { return limits_; }
+    bool is_immutable() const noexcept { return bool(viewed_file_); }
+    explicit operator bool() const noexcept { return config_.is_valid(); }
 
-	index_gt(index_gt &&other) noexcept {
-		swap(other);
-	}
+    /**
+     *  @brief Default index constructor, suitable only for stateless allocators.
+     *  @warning Consider `index_gt::make` instead, or explicitly convert to `bool` to check if the index is valid.
+     *  @section Exceptions
+     *      Doesn't throw, unless the ::dynamic_allocator's and ::tape_allocator's throw on move-construction.
+     */
+    explicit index_gt( //
+        dynamic_allocator_t dynamic_allocator = {}, tape_allocator_t tape_allocator = {}) noexcept(false)
+        : nodes_capacity_(0u), nodes_count_(0u), config_(), limits_(0, 0),
+          dynamic_allocator_(std::move(dynamic_allocator)), tape_allocator_(std::move(tape_allocator)),
+          pre_(precompute_({})), max_level_(-1), entry_slot_(0u), nodes_(), nodes_mutexes_(), contexts_() {}
 
-	index_gt &operator=(index_gt &&other) noexcept {
-		swap(other);
-		return *this;
-	}
+    /**
+     *  @brief Default index constructor, suitable only for stateless allocators.
+     *  @warning Consider `index_gt::make` instead, or explicitly convert to `bool` to check if the index is valid.
+     *  @section Exceptions
+     *      Doesn't throw, unless the ::dynamic_allocator's and ::tape_allocator's throw on move-construction.
+     */
+    explicit index_gt(index_config_t config, dynamic_allocator_t dynamic_allocator = {},
+                      tape_allocator_t tape_allocator = {}) noexcept(false)
+        : index_gt(dynamic_allocator, tape_allocator) {
+        config.validate();
+        config_ = config;
+        pre_ = precompute_(config);
+    }
 
-	struct copy_result_t {
-		error_t error;
-		index_gt index;
+    /**
+     *  @brief  Clones the structure with the same hyper-parameters, but without contents.
+     */
+    index_gt fork() noexcept { return index_gt{config_, dynamic_allocator_, tape_allocator_}; }
 
-		explicit operator bool() const noexcept {
-			return !error;
-		}
-		copy_result_t failed(error_t message) noexcept {
-			error = std::move(message);
-			return std::move(*this);
-		}
-	};
+    ~index_gt() noexcept { reset(); }
 
-	copy_result_t copy(index_copy_config_t config = {}) const noexcept {
-		copy_result_t result;
-		index_gt &other = result.index;
-		other = index_gt(config_, dynamic_allocator_, tape_allocator_);
-		if (!other.reserve(limits_))
-			return result.failed("Failed to reserve the contexts");
+    index_gt(index_gt&& other) noexcept { swap(other); }
 
-		// Now all is left - is to allocate new `node_t` instances and populate
-		// the `other.nodes_` array into it.
-		for (std::size_t i = 0; i != nodes_count_; ++i)
-			other.nodes_[i] = other.node_make_copy_(node_bytes_(nodes_[i]));
+    index_gt& operator=(index_gt&& other) noexcept {
+        swap(other);
+        return *this;
+    }
 
-		other.nodes_count_ = nodes_count_.load();
-		other.max_level_ = max_level_;
-		other.entry_slot_ = entry_slot_;
+    struct state_result_t {
+        index_gt index;
+        error_t error;
 
-		// This controls nothing for now :)
-		(void)config;
-		return result;
-	}
+        explicit operator bool() const noexcept { return !error; }
+        state_result_t failed(error_t message) noexcept { return {std::move(index), std::move(message)}; }
+        operator index_gt&&() && {
+            if (error)
+                usearch_raise_runtime_error(error.what());
+            return std::move(index);
+        }
+    };
+    using copy_result_t = state_result_t;
 
-	member_citerator_t cbegin() const noexcept {
-		return {this, 0};
-	}
-	member_citerator_t cend() const noexcept {
-		return {this, size()};
-	}
-	member_citerator_t begin() const noexcept {
-		return {this, 0};
-	}
-	member_citerator_t end() const noexcept {
-		return {this, size()};
-	}
-	member_iterator_t begin() noexcept {
-		return {this, 0};
-	}
-	member_iterator_t end() noexcept {
-		return {this, size()};
-	}
+    /**
+     *  @brief  The recommended way to initialize the index, as unlike the constructor,
+     *          it can fail with an error message, without raising an exception.
+     *
+     *  @param[in] config The configuration specs of the index.
+     *  @param[in] dynamic_allocator The allocator for temporary buffers and thread contexts, like priority queues.
+     *  @param[in] tape_allocator The allocator for the primary allocations of nodes and vectors.
+     */
+    static state_result_t make( //
+        index_config_t config = {}, dynamic_allocator_t dynamic_allocator = {},
+        tape_allocator_t tape_allocator = {}) noexcept {
 
-	member_ref_t at(std::size_t slot) noexcept {
-		return {nodes_[slot].key(), slot};
-	}
-	member_cref_t at(std::size_t slot) const noexcept {
-		return {nodes_[slot].ckey(), slot};
-	}
-	member_iterator_t iterator_at(std::size_t slot) noexcept {
-		return {this, slot};
-	}
-	member_citerator_t citerator_at(std::size_t slot) const noexcept {
-		return {this, slot};
-	}
+        state_result_t result;
+        result.error = config.validate();
+        if (result.error)
+            return result;
 
-	dynamic_allocator_t const &dynamic_allocator() const noexcept {
-		return dynamic_allocator_;
-	}
-	tape_allocator_t const &tape_allocator() const noexcept {
-		return tape_allocator_;
-	}
+        index_gt index;
+        index.config_ = std::move(config);
+        index.dynamic_allocator_ = std::move(dynamic_allocator);
+        index.tape_allocator_ = std::move(tape_allocator);
+        index.pre_ = precompute_(index.config_);
+        index.nodes_count_ = 0u;
+        index.max_level_ = -1;
+        index.entry_slot_ = 0u;
 
+        result.index = std::move(index);
+        return result;
+    }
+
+    /**
+     *  @brief  The recommended way to copy the index, as unlike the copy-constructor,
+     *          it can fail with an error message, without raising an exception.
+     *
+     *  @param[in] config The configuration specs for the copy-operation. Currently unused.
+     */
+    copy_result_t copy(index_copy_config_t config = {}) const noexcept {
+        copy_result_t result;
+        index_gt& other = result.index;
+        other = index_gt(config_, dynamic_allocator_, tape_allocator_);
+        if (!other.reserve(limits_))
+            return result.failed("Failed to reserve the contexts");
+
+        // Now all is left - is to allocate new `node_t` instances and populate
+        // the `other.nodes_` array into it.
+        for (std::size_t i = 0; i != nodes_count_; ++i)
+            other.nodes_[i] = other.node_make_copy_(node_bytes_(nodes_[i]));
+
+        other.nodes_count_ = nodes_count_.load();
+        other.max_level_ = max_level_;
+        other.entry_slot_ = entry_slot_;
+
+        // This controls nothing for now :)
+        (void)config;
+        return result;
+    }
+
+    member_citerator_t cbegin() const noexcept { return {this, static_cast<compressed_slot_t>(0u)}; }
+    member_citerator_t cend() const noexcept { return {this, static_cast<compressed_slot_t>(size())}; }
+    member_citerator_t begin() const noexcept { return {this, static_cast<compressed_slot_t>(0u)}; }
+    member_citerator_t end() const noexcept { return {this, static_cast<compressed_slot_t>(size())}; }
+    member_iterator_t begin() noexcept { return {this, static_cast<compressed_slot_t>(0u)}; }
+    member_iterator_t end() noexcept { return {this, static_cast<compressed_slot_t>(size())}; }
+
+    member_ref_t at(compressed_slot_t slot) noexcept { return {nodes_[slot].key(), slot}; }
+    member_cref_t at(compressed_slot_t slot) const noexcept { return {nodes_[slot].ckey(), slot}; }
+    member_iterator_t iterator_at(compressed_slot_t slot) noexcept { return {this, slot}; }
+    member_citerator_t citerator_at(compressed_slot_t slot) const noexcept { return {this, slot}; }
+
+    dynamic_allocator_t const& dynamic_allocator() const noexcept { return dynamic_allocator_; }
+    tape_allocator_t const& tape_allocator() const noexcept { return tape_allocator_; }
+
+#if defined(USEARCH_USE_PRAGMA_REGION)
 #pragma region Adjusting Configuration
+#endif
 
-	/**
-	 *  @brief Erases all the vectors from the index.
-	 *
-	 *  Will change `size()` to zero, but will keep the same `capacity()`.
-	 *  Will keep the number of available threads/contexts the same as it was.
-	 */
-	void clear() noexcept {
-		if (!has_reset<tape_allocator_t>()) {
-			std::size_t n = nodes_count_;
-			for (std::size_t i = 0; i != n; ++i)
-				node_free_(i);
-		} else
-			tape_allocator_.deallocate(nullptr, 0);
-		nodes_count_ = 0;
-		max_level_ = -1;
-		entry_slot_ = 0u;
-	}
+    /**
+     *  @brief Erases all the vectors from the index.
+     *
+     *  Will change `size()` to zero, but will keep the same `capacity()`.
+     *  Will keep the number of available threads/contexts the same as it was.
+     */
+    void clear() noexcept {
+        if (!has_reset<tape_allocator_t>()) {
+            std::size_t n = nodes_count_;
+            for (std::size_t i = 0; i != n; ++i)
+                node_free_(i);
+        } else
+            tape_allocator_.deallocate(nullptr, 0);
+        nodes_count_ = 0;
+        max_level_ = -1;
+        entry_slot_ = 0u;
+    }
 
-	/**
-	 *  @brief Erases all members from index, closing files, and returning RAM to OS.
-	 *
-	 *  Will change both `size()` and `capacity()` to zero.
-	 *  Will deallocate all threads/contexts.
-	 *  If the index is memory-mapped - releases the mapping and the descriptor.
-	 */
-	void reset() noexcept {
-		clear();
+    /**
+     *  @brief Erases all members from index, closing files, and returning RAM to OS.
+     *
+     *  Will change both `size()` and `capacity()` to zero.
+     *  Will deallocate all threads/contexts.
+     *  If the index is memory-mapped - releases the mapping and the descriptor.
+     */
+    void reset() noexcept {
+        clear();
 
-		nodes_ = {};
-		contexts_ = {};
-		nodes_mutexes_ = {};
-		limits_ = index_limits_t {0, 0};
-		nodes_capacity_ = 0;
-		viewed_file_ = memory_mapped_file_t {};
-		tape_allocator_ = {};
-	}
+        nodes_ = {};
+        contexts_ = {};
+        nodes_mutexes_ = {};
+        limits_ = index_limits_t{0, 0};
+        nodes_capacity_ = 0;
+        viewed_file_ = memory_mapped_file_t{};
+        tape_allocator_ = {};
+    }
 
-	/**
-	 *  @brief  Swaps the underlying memory buffers and thread contexts.
-	 */
-	void swap(index_gt &other) noexcept {
-		std::swap(config_, other.config_);
-		std::swap(limits_, other.limits_);
-		std::swap(dynamic_allocator_, other.dynamic_allocator_);
-		std::swap(tape_allocator_, other.tape_allocator_);
-		std::swap(pre_, other.pre_);
-		std::swap(viewed_file_, other.viewed_file_);
-		std::swap(max_level_, other.max_level_);
-		std::swap(entry_slot_, other.entry_slot_);
-		std::swap(nodes_, other.nodes_);
-		std::swap(nodes_mutexes_, other.nodes_mutexes_);
-		std::swap(contexts_, other.contexts_);
+    /**
+     *  @brief  Swaps the underlying memory buffers and thread contexts.
+     */
+    void swap(index_gt& other) noexcept {
+        std::swap(config_, other.config_);
+        std::swap(limits_, other.limits_);
+        std::swap(dynamic_allocator_, other.dynamic_allocator_);
+        std::swap(tape_allocator_, other.tape_allocator_);
+        std::swap(pre_, other.pre_);
+        std::swap(viewed_file_, other.viewed_file_);
+        std::swap(max_level_, other.max_level_);
+        std::swap(entry_slot_, other.entry_slot_);
+        std::swap(nodes_, other.nodes_);
+        std::swap(nodes_mutexes_, other.nodes_mutexes_);
+        std::swap(contexts_, other.contexts_);
 
-		// Non-atomic parts.
-		std::size_t capacity_copy = nodes_capacity_;
-		std::size_t count_copy = nodes_count_;
-		nodes_capacity_ = other.nodes_capacity_.load();
-		nodes_count_ = other.nodes_count_.load();
-		other.nodes_capacity_ = capacity_copy;
-		other.nodes_count_ = count_copy;
-	}
+        // Non-atomic parts.
+        std::size_t capacity_copy = nodes_capacity_;
+        std::size_t count_copy = nodes_count_;
+        nodes_capacity_ = other.nodes_capacity_.load();
+        nodes_count_ = other.nodes_count_.load();
+        other.nodes_capacity_ = capacity_copy;
+        other.nodes_count_ = count_copy;
+    }
 
-	/**
-	 *  @brief  Increases the `capacity()` of the index to allow adding more vectors.
-	 *  @return `true` on success, `false` on memory allocation errors.
-	 */
-	bool reserve(index_limits_t limits) usearch_noexcept_m {
+    /**
+     *  @brief  Increases the `capacity()` of the index to allow adding more vectors.
+     *  @return `true` on success, `false` on memory allocation errors.
+     */
+    bool try_reserve(index_limits_t limits) usearch_noexcept_m {
 
-		if (limits.threads_add <= limits_.threads_add          //
-		    && limits.threads_search <= limits_.threads_search //
-		    && limits.members <= limits_.members)
-			return true;
+        if (limits.threads_add <= limits_.threads_add          //
+            && limits.threads_search <= limits_.threads_search //
+            && limits.members <= limits_.members)
+            return true;
 
-		nodes_mutexes_t new_mutexes(limits.members);
-		buffer_gt<node_t, nodes_allocator_t> new_nodes(limits.members);
-		buffer_gt<context_t, contexts_allocator_t> new_contexts(limits.threads());
-		if (!new_nodes || !new_contexts || !new_mutexes)
-			return false;
+        // In some cases, we don't want to update the number of members,
+        // just want to make sure that future reserves use the new thread limits.
+        if (!limits.members && !size()) {
+            limits_ = limits;
+            return true;
+        }
 
-		// Move the nodes info, and deallocate previous buffers.
-		if (nodes_)
-			std::memcpy(new_nodes.data(), nodes_.data(), sizeof(node_t) * size());
+        std::size_t connectivity_max = (std::max)(config_.connectivity_base, config_.connectivity);
+        nodes_mutexes_t new_mutexes(limits.threads(), connectivity_max);
+        buffer_gt<node_t, nodes_allocator_t> new_nodes(limits.members);
+        buffer_gt<context_t, contexts_allocator_t> new_contexts(limits.threads());
+        if (!new_nodes || !new_contexts || !new_mutexes)
+            return false;
 
-		limits_ = limits;
-		nodes_capacity_ = limits.members;
-		nodes_ = std::move(new_nodes);
-		contexts_ = std::move(new_contexts);
-		nodes_mutexes_ = std::move(new_mutexes);
-		return true;
-	}
+        // Move the nodes info, and deallocate previous buffers.
+        if (nodes_)
+            std::memcpy(new_nodes.data(), nodes_.data(), sizeof(node_t) * size());
+        for (std::size_t i = 0; i != new_contexts.size(); ++i)
+            if (!new_contexts[i].top_for_refine.reserve(connectivity_max + 1))
+                return false;
 
+        limits_ = limits;
+        nodes_capacity_ = limits.members;
+        nodes_ = std::move(new_nodes);
+        contexts_ = std::move(new_contexts);
+        nodes_mutexes_ = std::move(new_mutexes);
+        return true;
+    }
+
+    /**
+     *  @brief Increases the `capacity()` of the index to allow adding more vectors.
+     *  @warning Unlike STL, won't throw exceptions on memory allocations, so check the return value.
+     *  @return `true` on success, `false` on memory allocation errors.
+     */
+    bool reserve(index_limits_t limits) usearch_noexcept_m { return try_reserve(limits); }
+
+#if defined(USEARCH_USE_PRAGMA_REGION)
 #pragma endregion
 
 #pragma region Construction and Search
+#endif
 
-	struct add_result_t {
-		error_t error {};
-		std::size_t new_size {};
-		std::size_t visited_members {};
-		std::size_t computed_distances {};
-		std::size_t slot {};
+    struct add_result_t {
+        error_t error{};
+        std::size_t new_size{};
+        std::size_t visited_members{};
+        std::size_t computed_distances{};
+        std::size_t computed_distances_in_refines{};
+        std::size_t computed_distances_in_reverse_refines{};
+        compressed_slot_t slot{};
 
-		explicit operator bool() const noexcept {
-			return !error;
-		}
-		add_result_t failed(error_t message) noexcept {
-			error = std::move(message);
-			return std::move(*this);
-		}
-	};
+        explicit operator bool() const noexcept { return !error; }
+        add_result_t failed(error_t message) noexcept {
+            error = std::move(message);
+            return std::move(*this);
+        }
+    };
 
-	/// @brief  Describes a matched search result, augmenting `member_cref_t`
-	///         contents with `distance` to the query object.
-	struct match_t {
-		member_cref_t member;
-		distance_t distance;
+    /// @brief  Describes a matched search result, augmenting `member_cref_t`
+    ///         contents with `distance` to the query object.
+    struct match_t {
+        member_cref_t member;
+        distance_t distance;
 
-		inline match_t() noexcept : member({nullptr, 0}), distance(std::numeric_limits<distance_t>::max()) {
-		}
+        inline match_t() noexcept : member({nullptr, 0}), distance((std::numeric_limits<distance_t>::max)()) {}
 
-		inline match_t(member_cref_t member, distance_t distance) noexcept : member(member), distance(distance) {
-		}
+        inline match_t(member_cref_t member, distance_t distance) noexcept : member(member), distance(distance) {}
 
-		inline match_t(match_t &&other) noexcept
-		    : member({other.member.key.ptr(), other.member.slot}), distance(other.distance) {
-		}
+        inline match_t(match_t&& other) noexcept
+            : member({other.member.key.ptr(), other.member.slot}), distance(other.distance) {}
 
-		inline match_t(match_t const &other) noexcept
-		    : member({other.member.key.ptr(), other.member.slot}), distance(other.distance) {
-		}
+        inline match_t(match_t const& other) noexcept
+            : member({other.member.key.ptr(), other.member.slot}), distance(other.distance) {}
 
-		inline match_t &operator=(match_t const &other) noexcept {
-			member.key.reset(other.member.key.ptr());
-			member.slot = other.member.slot;
-			distance = other.distance;
-			return *this;
-		}
+        inline match_t& operator=(match_t const& other) noexcept {
+            member.key.reset(other.member.key.ptr());
+            member.slot = other.member.slot;
+            distance = other.distance;
+            return *this;
+        }
 
-		inline match_t &operator=(match_t &&other) noexcept {
-			member.key.reset(other.member.key.ptr());
-			member.slot = other.member.slot;
-			distance = other.distance;
-			return *this;
-		}
-	};
+        inline match_t& operator=(match_t&& other) noexcept {
+            member.key.reset(other.member.key.ptr());
+            member.slot = other.member.slot;
+            distance = other.distance;
+            return *this;
+        }
+    };
 
-	class search_result_t {
-		node_t const *nodes_ {};
-		top_candidates_t const *top_ {};
+    class search_result_t {
+        node_t const* nodes_{};
+        top_candidates_t const* top_{};
 
-		friend class index_gt;
-		inline search_result_t(index_gt const &index, top_candidates_t &top) noexcept
-		    : nodes_(index.nodes_), top_(&top) {
-		}
+        friend class index_gt;
+        inline search_result_t(index_gt const& index, top_candidates_t const* top) noexcept
+            : nodes_(index.nodes_), top_(top) {}
 
-	public:
-		/** @brief  Number of search results found. */
-		std::size_t count {};
-		/** @brief  Number of graph nodes traversed. */
-		std::size_t visited_members {};
-		/** @brief  Number of times the distances were computed. */
-		std::size_t computed_distances {};
-		error_t error {};
+      public:
+        /**  @brief  Number of search results found. */
+        std::size_t count{};
+        /**  @brief  Number of graph nodes traversed. */
+        std::size_t visited_members{};
+        /**  @brief  Number of times the distances were computed. */
+        std::size_t computed_distances{};
+        error_t error{};
 
-		inline search_result_t() noexcept {
-		}
-		inline search_result_t(search_result_t &&) = default;
-		inline search_result_t &operator=(search_result_t &&) = default;
+        inline search_result_t() noexcept {}
+        inline search_result_t(search_result_t&&) = default;
+        inline search_result_t& operator=(search_result_t&&) = default;
 
-		explicit operator bool() const noexcept {
-			return !error;
-		}
-		search_result_t failed(error_t message) noexcept {
-			error = std::move(message);
-			return std::move(*this);
-		}
+        explicit operator bool() const noexcept { return !error; }
+        search_result_t failed(error_t message) noexcept {
+            error = std::move(message);
+            return std::move(*this);
+        }
 
-		inline operator std::size_t() const noexcept {
-			return count;
-		}
-		inline std::size_t size() const noexcept {
-			return count;
-		}
-		inline bool empty() const noexcept {
-			return !count;
-		}
-		inline match_t operator[](std::size_t i) const noexcept {
-			return at(i);
-		}
-		inline match_t front() const noexcept {
-			return at(0);
-		}
-		inline match_t back() const noexcept {
-			return at(count - 1);
-		}
-		inline bool contains(vector_key_t key) const noexcept {
-			for (std::size_t i = 0; i != count; ++i)
-				if (at(i).member.key == key)
-					return true;
-			return false;
-		}
-		inline match_t at(std::size_t i) const noexcept {
-			candidate_t const *top_ordered = top_->data();
-			candidate_t candidate = top_ordered[i];
-			node_t node = nodes_[candidate.slot];
-			return {member_cref_t {node.ckey(), candidate.slot}, candidate.distance};
-		}
-		inline std::size_t merge_into(                 //
-		    vector_key_t *keys, distance_t *distances, //
-		    std::size_t old_count, std::size_t max_count) const noexcept {
+        inline operator std::size_t() const noexcept { return count; }
+        inline std::size_t size() const noexcept { return count; }
+        inline bool empty() const noexcept { return !count; }
+        inline match_t operator[](std::size_t i) const noexcept { return at(i); }
+        inline match_t front() const noexcept { return at(0); }
+        inline match_t back() const noexcept {
+            usearch_assert_m(count > 0, "Can't call back() on an empty result set");
+            return at(count - 1);
+        }
+        inline bool contains(vector_key_t key) const noexcept {
+            for (std::size_t i = 0; i != count; ++i)
+                if (at(i).member.key == key)
+                    return true;
+            return false;
+        }
+        inline match_t at(std::size_t i) const noexcept {
+            candidate_t const* top_ordered = top_->data();
+            candidate_t candidate = top_ordered[i];
+            node_t node = nodes_[candidate.slot];
+            return {member_cref_t{node.ckey(), candidate.slot}, candidate.distance};
+        }
 
-			std::size_t merged_count = old_count;
-			for (std::size_t i = 0; i != count; ++i) {
-				match_t result = operator[](i);
-				distance_t *merged_end = distances + merged_count;
-				std::size_t offset = std::lower_bound(distances, merged_end, result.distance) - distances;
-				if (offset == max_count)
-					continue;
+        /**
+         *  @brief  Extracts the search results into a user-provided buffer, that unlike `dump_to`,
+         *          may already contain some data, so the new and old results are merged together.
+         *  @return The number of results stored in the buffer.
+         *  @param[in] keys The buffer to store the keys of the search results.
+         *  @param[in] distances The buffer to store the distances to the search results.
+         *  @param[in] old_count The number of results already stored in the buffers.
+         *  @param[in] max_count The maximum number of results that can be stored in the buffers.
+         */
+        inline std::size_t merge_into(                 //
+            vector_key_t* keys, distance_t* distances, //
+            std::size_t old_count, std::size_t max_count) const noexcept {
 
-				std::size_t count_worse = merged_count - offset - (max_count == merged_count);
-				std::memmove(keys + offset + 1, keys + offset, count_worse * sizeof(vector_key_t));
-				std::memmove(distances + offset + 1, distances + offset, count_worse * sizeof(distance_t));
-				keys[offset] = result.member.key;
-				distances[offset] = result.distance;
-				merged_count += merged_count != max_count;
-			}
-			return merged_count;
-		}
-		inline std::size_t dump_to(vector_key_t *keys, distance_t *distances) const noexcept {
-			for (std::size_t i = 0; i != count; ++i) {
-				match_t result = operator[](i);
-				keys[i] = result.member.key;
-				distances[i] = result.distance;
-			}
-			return count;
-		}
-		inline std::size_t dump_to(vector_key_t *keys) const noexcept {
-			for (std::size_t i = 0; i != count; ++i) {
-				match_t result = operator[](i);
-				keys[i] = result.member.key;
-			}
-			return count;
-		}
-	};
+            std::size_t merged_count = old_count;
+            for (std::size_t i = 0; i != count; ++i) {
+                match_t result = operator[](i);
+                distance_t* merged_end = distances + merged_count;
+                std::size_t offset = std::lower_bound(distances, merged_end, result.distance) - distances;
+                if (offset == max_count)
+                    continue;
 
-	struct cluster_result_t {
-		error_t error {};
-		std::size_t visited_members {};
-		std::size_t computed_distances {};
-		match_t cluster {};
+                std::size_t count_worse = merged_count - offset - (max_count == merged_count);
+                std::memmove(keys + offset + 1, keys + offset, count_worse * sizeof(vector_key_t));
+                std::memmove(distances + offset + 1, distances + offset, count_worse * sizeof(distance_t));
+                keys[offset] = result.member.key;
+                distances[offset] = result.distance;
+                merged_count += merged_count != max_count;
+            }
+            return merged_count;
+        }
 
-		explicit operator bool() const noexcept {
-			return !error;
-		}
-		cluster_result_t failed(error_t message) noexcept {
-			error = std::move(message);
-			return std::move(*this);
-		}
-	};
+        /**
+         *  @brief  Extracts the search results into a user-provided buffer.
+         *  @return The number of results stored in the buffer.
+         *  @param[in] keys The buffer to store the keys of the search results.
+         *  @param[in] distances The buffer to store the distances to the search results.
+         */
+        inline std::size_t dump_to(vector_key_t* keys, distance_t* distances) const noexcept {
+            for (std::size_t i = 0; i != count; ++i) {
+                match_t result = operator[](i);
+                keys[i] = result.member.key;
+                distances[i] = result.distance;
+            }
+            return count;
+        }
 
-	/**
-	 *  @brief  Inserts a new entry into the index. Thread-safe. Supports @b heterogeneous lookups.
-	 *          Expects needed capacity to be reserved ahead of time: `size() < capacity()`.
-	 *
-	 *  @tparam metric_at
-	 *      A function responsible for computing the distance @b (dis-similarity) between two objects.
-	 *      It should be callable into distinctly different scenarios:
-	 *          - `distance_t operator() (value_at, entry_at)` - from new object to existing entries.
-	 *          - `distance_t operator() (entry_at, entry_at)` - between existing entries.
-	 *      Where any possible `entry_at` has both two interfaces: `std::size_t slot()`, `vector_key_t key()`.
-	 *
-	 *  @param[in] key External identifier/name/descriptor for the new entry.
-	 *  @param[in] value Content that will be compared against other entries to index.
-	 *  @param[in] metric Callable object measuring distance between ::value and present objects.
-	 *  @param[in] config Configuration options for this specific operation.
-	 *  @param[in] callback On-success callback, executed while the `member_ref_t` is still under lock.
-	 */
-	template <                                   //
-	    typename value_at,                       //
-	    typename metric_at,                      //
-	    typename callback_at = dummy_callback_t, //
-	    typename prefetch_at = dummy_prefetch_t  //
-	    >
-	add_result_t add(                                           //
-	    vector_key_t key, value_at &&value, metric_at &&metric, //
-	    index_update_config_t config = {},                      //
-	    callback_at &&callback = callback_at {},                //
-	    prefetch_at &&prefetch = prefetch_at {}) usearch_noexcept_m {
+        /**
+         *  @brief  Extracts the search results into a user-provided buffer.
+         *  @return The number of results stored in the buffer.
+         *  @param[in] keys The buffer to store the keys of the search results.
+         */
+        inline std::size_t dump_to(vector_key_t* keys) const noexcept {
+            for (std::size_t i = 0; i != count; ++i) {
+                match_t result = operator[](i);
+                keys[i] = result.member.key;
+            }
+            return count;
+        }
 
-		add_result_t result;
-		if (is_immutable())
-			return result.failed("Can't add to an immutable index");
+        /**
+         *  @brief  Extracts the search results into a user-provided buffer.
+         *  @return The number of results stored in the buffer.
+         *  @param[in] keys The buffer to store the keys of the search results.
+         *  @param[in] distances The buffer to store the distances to the search results.
+         *  @param[in] capacity The maximum number of results that can be stored in the buffers.
+         */
+        inline std::size_t dump_to(vector_key_t* keys, distance_t* distances, std::size_t capacity) const noexcept {
+            std::size_t i = 0;
+            std::size_t initialized_count = (std::min)(count, capacity);
+            for (; i != initialized_count; ++i) {
+                match_t result = operator[](i);
+                keys[i] = result.member.key;
+                distances[i] = result.distance;
+            }
+            for (; i != capacity; ++i) {
+                keys[i] = vector_key_t{};
+                distances[i] = std::numeric_limits<distance_t>::has_signaling_NaN
+                                   ? std::numeric_limits<distance_t>::signaling_NaN()
+                                   : (std::numeric_limits<distance_t>::max)();
+            }
+            return initialized_count;
+        }
 
-		// Make sure we have enough local memory to perform this request
-		context_t &context = contexts_[config.thread];
-		top_candidates_t &top = context.top_candidates;
-		next_candidates_t &next = context.next_candidates;
-		top.clear();
-		next.clear();
+        /**
+         *  @brief  Extracts the search results into a user-provided buffer.
+         *  @return The number of results stored in the buffer.
+         *  @param[in] keys The buffer to store the keys of the search results.
+         *  @param[in] capacity The maximum number of results that can be stored in the buffers.
+         */
+        inline std::size_t dump_to(vector_key_t* keys, std::size_t capacity) const noexcept {
+            std::size_t i = 0;
+            std::size_t initialized_count = (std::min)(this->count, capacity);
+            for (; i != initialized_count; ++i) {
+                match_t result = operator[](i);
+                keys[i] = result.member.key;
+            }
+            for (; i != capacity; ++i)
+                keys[i] = vector_key_t{};
 
-		// The top list needs one more slot than the connectivity of the base level
-		// for the heuristic, that tries to squeeze one more element into saturated list.
-		std::size_t connectivity_max = (std::max)(config_.connectivity_base, config_.connectivity);
-		std::size_t top_limit = (std::max)(connectivity_max + 1, config.expansion);
-		if (!top.reserve(top_limit))
-			return result.failed("Out of memory!");
-		if (!next.reserve(config.expansion))
-			return result.failed("Out of memory!");
+            return initialized_count;
+        }
+    };
 
-		// Determining how much memory to allocate for the node depends on the target level
-		std::unique_lock<std::mutex> new_level_lock(global_mutex_);
-		level_t max_level_copy = max_level_;      // Copy under lock
-		std::size_t entry_idx_copy = entry_slot_; // Copy under lock
-		level_t target_level = choose_random_level_(context.level_generator);
+    struct cluster_result_t {
+        error_t error{};
+        std::size_t visited_members{};
+        std::size_t computed_distances{};
+        match_t cluster{};
 
-		// Make sure we are not overflowing
-		std::size_t capacity = nodes_capacity_.load();
-		std::size_t new_slot = nodes_count_.fetch_add(1);
-		if (new_slot >= capacity) {
-			nodes_count_.fetch_sub(1);
-			return result.failed("Reserve capacity ahead of insertions!");
-		}
+        explicit operator bool() const noexcept { return !error; }
+        cluster_result_t failed(error_t message) noexcept {
+            error = std::move(message);
+            return std::move(*this);
+        }
+    };
 
-		// Allocate the neighbors
-		node_t node = node_make_(key, target_level);
-		if (!node) {
-			nodes_count_.fetch_sub(1);
-			return result.failed("Out of memory!");
-		}
-		if (target_level <= max_level_copy)
-			new_level_lock.unlock();
+    /**
+     *  @brief  Inserts a new entry into the index. Thread-safe. Supports @b heterogeneous lookups.
+     *          Expects needed capacity to be reserved ahead of time: `size() < capacity()`.
+     *
+     *  @tparam metric_at
+     *      A function responsible for computing the distance @b (dis-similarity) between two objects.
+     *      It should be callable into distinctly different scenarios:
+     *          - `distance_t operator() (value_at, entry_at)` - from new object to existing entries.
+     *          - `distance_t operator() (entry_at, entry_at)` - between existing entries.
+     *      Where any possible `entry_at` has both two interfaces: `std::size_t slot()`, `vector_key_t key()`.
+     *
+     *  @param[in] key External identifier/name/descriptor for the new entry.
+     *  @param[in] value Content that will be compared against other entries to index.
+     *  @param[in] metric Callable object measuring distance between ::value and present objects.
+     *  @param[in] config Configuration options for this specific operation.
+     *  @param[in] callback On-success callback, executed while the `member_ref_t` is still under lock.
+     */
+    template <                                   //
+        typename value_at,                       //
+        typename metric_at,                      //
+        typename callback_at = dummy_callback_t, //
+        typename prefetch_at = dummy_prefetch_t  //
+        >
+    add_result_t add(                                           //
+        vector_key_t key, value_at&& value, metric_at&& metric, //
+        index_update_config_t config = {},                      //
+        callback_at&& callback = callback_at{},                 //
+        prefetch_at&& prefetch = prefetch_at{}) usearch_noexcept_m {
 
-		nodes_[new_slot] = node;
-		result.new_size = new_slot + 1;
-		result.slot = new_slot;
-		callback(at(new_slot));
-		node_lock_t new_lock = node_lock_(new_slot);
+        // Zero expansion is meaningless, fall back to default
+        if (!config.expansion)
+            config.expansion = default_expansion_add();
 
-		// Do nothing for the first element
-		if (!new_slot) {
-			entry_slot_ = new_slot;
-			max_level_ = target_level;
-			return result;
-		}
+        add_result_t result;
+        if (is_immutable())
+            return result.failed("Can't add to an immutable index");
 
-		// Pull stats
-		result.computed_distances = context.computed_distances_count;
-		result.visited_members = context.iteration_cycles;
+        // Make sure we have enough local memory to perform this request
+        context_t& context = contexts_[config.thread];
+        top_candidates_t& top = context.top_candidates;
+        next_candidates_t& next = context.next_candidates;
+        top.clear();
+        next.clear();
 
-		connect_node_across_levels_(                                //
-		    value, metric, prefetch,                                //
-		    new_slot, entry_idx_copy, max_level_copy, target_level, //
-		    config, context);
+        // The top list needs one more slot than the connectivity of the base level
+        // for the heuristic, that tries to squeeze one more element into saturated list.
+        std::size_t connectivity_max = (std::max)(config_.connectivity_base, config_.connectivity);
+        std::size_t top_limit = (std::max)(connectivity_max + 1, config.expansion);
+        if (!top.reserve(top_limit))
+            return result.failed("Out of memory!");
+        if (!next.reserve(config.expansion))
+            return result.failed("Out of memory!");
 
-		// Normalize stats
-		result.computed_distances = context.computed_distances_count - result.computed_distances;
-		result.visited_members = context.iteration_cycles - result.visited_members;
+        // Determining how much memory to allocate for the node depends on the target level
+        std::unique_lock<std::mutex> new_level_lock(global_mutex_);
+        level_t max_level_copy = max_level_;                                             // Copy under lock
+        compressed_slot_t entry_slot_copy = static_cast<compressed_slot_t>(entry_slot_); // Copy under lock
+        level_t new_target_level = choose_random_level_(context.level_generator);
 
-		// Updating the entry point if needed
-		if (target_level > max_level_copy) {
-			entry_slot_ = new_slot;
-			max_level_ = target_level;
-		}
-		return result;
-	}
+        // Make sure we are not overflowing
+        std::size_t capacity = nodes_capacity_.load();
+        std::size_t old_size = nodes_count_.fetch_add(1);
+        if (old_size >= capacity) {
+            nodes_count_.fetch_sub(1);
+            return result.failed("Reserve capacity ahead of insertions!");
+        }
 
-	/**
-	 *  @brief  Update an existing entry. Thread-safe. Supports @b heterogeneous lookups.
-	 *
-	 *  @tparam metric_at
-	 *      A function responsible for computing the distance @b (dis-similarity) between two objects.
-	 *      It should be callable into distinctly different scenarios:
-	 *          - `distance_t operator() (value_at, entry_at)` - from new object to existing entries.
-	 *          - `distance_t operator() (entry_at, entry_at)` - between existing entries.
-	 *      For any possible `entry_at` following interfaces will work:
-	 *          - `std::size_t get_slot(entry_at const &)`
-	 *          - `vector_key_t get_key(entry_at const &)`
-	 *
-	 *  @param[in] iterator Iterator pointing to an existing entry to be replaced.
-	 *  @param[in] key External identifier/name/descriptor for the entry.
-	 *  @param[in] value Content that will be compared against other entries in the index.
-	 *  @param[in] metric Callable object measuring distance between ::value and present objects.
-	 *  @param[in] config Configuration options for this specific operation.
-	 *  @param[in] callback On-success callback, executed while the `member_ref_t` is still under lock.
-	 */
-	template <                                   //
-	    typename value_at,                       //
-	    typename metric_at,                      //
-	    typename callback_at = dummy_callback_t, //
-	    typename prefetch_at = dummy_prefetch_t  //
-	    >
-	add_result_t update(                         //
-	    member_iterator_t iterator,              //
-	    vector_key_t key,                        //
-	    value_at &&value,                        //
-	    metric_at &&metric,                      //
-	    index_update_config_t config = {},       //
-	    callback_at &&callback = callback_at {}, //
-	    prefetch_at &&prefetch = prefetch_at {}) usearch_noexcept_m {
+        // Allocate the neighbors
+        node_t new_node = node_make_(key, new_target_level);
+        if (!new_node) {
+            nodes_count_.fetch_sub(1);
+            return result.failed("Out of memory!");
+        }
+        if (new_target_level <= max_level_copy)
+            new_level_lock.unlock();
 
-		// Someone is gonna fuzz this, so let's make sure we cover the basics
-		if (!config.expansion)
-			config.expansion = default_expansion_add();
+        nodes_[old_size] = new_node;
+        result.new_size = old_size + 1;
+        compressed_slot_t new_slot = result.slot = static_cast<compressed_slot_t>(old_size);
+        callback(at(result.slot));
 
-		usearch_assert_m(!is_immutable(), "Can't add to an immutable index");
-		add_result_t result;
-		std::size_t old_slot = iterator.slot_;
+        // Do nothing for the first element
+        if (!old_size) {
+            entry_slot_ = result.slot;
+            max_level_ = new_target_level;
+            return result;
+        }
 
-		// Make sure we have enough local memory to perform this request
-		context_t &context = contexts_[config.thread];
-		top_candidates_t &top = context.top_candidates;
-		next_candidates_t &next = context.next_candidates;
-		top.clear();
-		next.clear();
+        // Pull stats
+        result.computed_distances = context.computed_distances;
+        result.computed_distances_in_refines = context.computed_distances_in_refines;
+        result.computed_distances_in_reverse_refines = context.computed_distances_in_reverse_refines;
+        result.visited_members = context.iteration_cycles;
 
-		// The top list needs one more slot than the connectivity of the base level
-		// for the heuristic, that tries to squeeze one more element into saturated list.
-		std::size_t connectivity_max = (std::max)(config_.connectivity_base, config_.connectivity);
-		std::size_t top_limit = (std::max)(connectivity_max + 1, config.expansion);
-		if (!top.reserve(top_limit))
-			return result.failed("Out of memory!");
-		if (!next.reserve(config.expansion))
-			return result.failed("Out of memory!");
+        // Go down the level, tracking only the closest match
+        compressed_slot_t closest_slot = search_for_one_( //
+            value, metric, prefetch,                      //
+            entry_slot_copy, max_level_copy, new_target_level, context);
 
-		node_lock_t new_lock = node_lock_(old_slot);
-		node_t node = node_at_(old_slot);
+        // From `new_target_level` down - perform proper extensive search
+        for (level_t level = (std::min)(new_target_level, max_level_copy); level >= 0; --level) {
+            // TODO: Handle out of memory conditions
+            search_to_insert_(value, metric, prefetch, closest_slot, level, config.expansion, context);
+            candidates_view_t closest_view;
+            {
+                node_lock_t new_lock = node_lock_(new_slot);
+                neighbors_(new_node, level).clear();
+                closest_view = form_links_to_closest_(metric, new_slot, level, context);
+                closest_slot = closest_view[0].slot;
+            }
+            form_reverse_links_(metric, new_slot, closest_view, value, level, context);
+        }
 
-		level_t node_level = node.level();
-		span_bytes_t node_bytes = node_bytes_(node);
-		std::memset(node_bytes.data(), 0, node_bytes.size());
-		node.level(node_level);
+        // Normalize stats
+        result.computed_distances = context.computed_distances - result.computed_distances;
+        result.computed_distances_in_refines =
+            context.computed_distances_in_refines - result.computed_distances_in_refines;
+        result.computed_distances_in_reverse_refines =
+            context.computed_distances_in_reverse_refines - result.computed_distances_in_reverse_refines;
+        result.visited_members = context.iteration_cycles - result.visited_members;
 
-		// Pull stats
-		result.computed_distances = context.computed_distances_count;
-		result.visited_members = context.iteration_cycles;
+        // Updating the entry point if needed
+        if (new_target_level > max_level_copy) {
+            entry_slot_ = new_slot;
+            max_level_ = new_target_level;
+        }
+        return result;
+    }
 
-		connect_node_across_levels_(                       //
-		    value, metric, prefetch,                       //
-		    old_slot, entry_slot_, max_level_, node_level, //
-		    config, context);
-		node.key(key);
+    /**
+     *  @brief  Update an existing entry. Thread-safe. Supports @b heterogeneous lookups.
+     *
+     *  ! It's assumed that different threads aren't updating the same entry at the same time.
+     *  ! The state won't be corrupted, but no transactional guarantees are provided and the
+     *  ! resulting value & neighbors list may be inconsistent.
+     *
+     *  @tparam metric_at
+     *      A function responsible for computing the distance @b (dis-similarity) between two objects.
+     *      It should be callable into distinctly different scenarios:
+     *          - `distance_t operator() (value_at, entry_at)` - from new object to existing entries.
+     *          - `distance_t operator() (entry_at, entry_at)` - between existing entries.
+     *      For any possible `entry_at` following interfaces will work:
+     *          - `std::size_t get_slot(entry_at const &)`
+     *          - `vector_key_t get_key(entry_at const &)`
+     *
+     *  @param[in] iterator Iterator pointing to an existing entry to be replaced.
+     *  @param[in] key External identifier/name/descriptor for the entry.
+     *  @param[in] value Content that will be compared against other entries in the index.
+     *  @param[in] metric Callable object measuring distance between ::value and present objects.
+     *  @param[in] config Configuration options for this specific operation.
+     *  @param[in] callback On-success callback, executed while the `member_ref_t` is still under lock.
+     */
+    template <                                   //
+        typename value_at,                       //
+        typename metric_at,                      //
+        typename callback_at = dummy_callback_t, //
+        typename prefetch_at = dummy_prefetch_t  //
+        >
+    add_result_t update(                        //
+        member_iterator_t iterator,             //
+        vector_key_t key,                       //
+        value_at&& value,                       //
+        metric_at&& metric,                     //
+        index_update_config_t config = {},      //
+        callback_at&& callback = callback_at{}, //
+        prefetch_at&& prefetch = prefetch_at{}) usearch_noexcept_m {
 
-		// Normalize stats
-		result.computed_distances = context.computed_distances_count - result.computed_distances;
-		result.visited_members = context.iteration_cycles - result.visited_members;
-		result.slot = old_slot;
+        // Someone is gonna fuzz this, so let's make sure we cover the basics
+        if (!config.expansion)
+            config.expansion = default_expansion_add();
 
-		callback(at(old_slot));
-		return result;
-	}
+        usearch_assert_m(!is_immutable(), "Can't add to an immutable index");
+        add_result_t result;
+        compressed_slot_t updated_slot = iterator.slot_;
 
-	/**
-	 *  @brief Searches for the closest elements to the given ::query. Thread-safe.
-	 *
-	 *  @param[in] query Content that will be compared against other entries in the index.
-	 *  @param[in] wanted The upper bound for the number of results to return.
-	 *  @param[in] config Configuration options for this specific operation.
-	 *  @param[in] predicate Optional filtering predicate for `member_cref_t`.
-	 *  @return Smart object referencing temporary memory. Valid until next `search()`, `add()`, or `cluster()`.
-	 */
-	template <                                     //
-	    typename value_at,                         //
-	    typename metric_at,                        //
-	    typename predicate_at = dummy_predicate_t, //
-	    typename prefetch_at = dummy_prefetch_t    //
-	    >
-	search_result_t search(                         //
-	    value_at &&query,                           //
-	    std::size_t wanted,                         //
-	    metric_at &&metric,                         //
-	    index_search_config_t config = {},          //
-	    predicate_at &&predicate = predicate_at {}, //
-	    prefetch_at &&prefetch = prefetch_at {}) const usearch_noexcept_m {
+        // Make sure we have enough local memory to perform this request
+        context_t& context = contexts_[config.thread];
+        top_candidates_t& top = context.top_candidates;
+        next_candidates_t& next = context.next_candidates;
+        top.clear();
+        next.clear();
 
-		// Someone is gonna fuzz this, so let's make sure we cover the basics
-		if (!wanted)
-			return search_result_t {};
+        // The top list needs one more slot than the connectivity of the base level
+        // for the heuristic, that tries to squeeze one more element into saturated list.
+        std::size_t connectivity_max = (std::max)(config_.connectivity_base, config_.connectivity);
+        std::size_t top_limit = (std::max)(connectivity_max + 1, config.expansion);
+        if (!top.reserve(top_limit))
+            return result.failed("Out of memory!");
+        if (!next.reserve(config.expansion))
+            return result.failed("Out of memory!");
 
-		// Expansion factor set to zero is equivalent to the default value
-		if (!config.expansion)
-			config.expansion = default_expansion_search();
+        node_t updated_node = node_at_(updated_slot);
+        level_t updated_node_level = updated_node.level();
 
-		context_t &context = contexts_[config.thread];
-		top_candidates_t &top = context.top_candidates;
-		search_result_t result {*this, top};
-		if (!nodes_count_)
-			return result;
+        // Copy entry coordinates under locks
+        level_t max_level_copy;
+        compressed_slot_t entry_slot_copy;
+        {
+            std::unique_lock<std::mutex> new_level_lock(global_mutex_);
+            max_level_copy = max_level_;                                   // Copy under lock
+            entry_slot_copy = static_cast<compressed_slot_t>(entry_slot_); // Copy under lock
+        }
 
-		// Go down the level, tracking only the closest match
-		result.computed_distances = context.computed_distances_count;
-		result.visited_members = context.iteration_cycles;
+        // Pull stats
+        result.computed_distances = context.computed_distances;
+        result.visited_members = context.iteration_cycles;
 
-		if (config.exact) {
-			if (!top.reserve(wanted))
-				return result.failed("Out of memory!");
-			search_exact_(query, metric, predicate, wanted, context);
-		} else {
-			next_candidates_t &next = context.next_candidates;
-			std::size_t expansion = (std::max)(config.expansion, wanted);
-			usearch_assert_m(expansion > 0, "Expansion factor can't be a zero!");
-			if (!next.reserve(expansion))
-				return result.failed("Out of memory!");
-			if (!top.reserve(expansion))
-				return result.failed("Out of memory!");
+        // Go down the level, tracking only the closest match;
+        // It may even be equal to the `updated_slot`
+        compressed_slot_t closest_slot =
+            // If we are updating the entry node itself, it won't contain any neighbors,
+            // so we should traverse a level down to find the closest match.
+            updated_node_level == max_level_copy //
+                ? entry_slot_copy
+                : search_for_one_(             //
+                      value, metric, prefetch, //
+                      entry_slot_copy, max_level_copy, updated_node_level, context);
 
-			std::size_t closest_slot = search_for_one_(query, metric, prefetch, entry_slot_, max_level_, 0, context);
+        // From `updated_node_level` down - perform proper extensive search
+        for (level_t level = (std::min)(updated_node_level, max_level_copy); level >= 0; --level) {
+            if (!search_to_update_(value, metric, prefetch, closest_slot, updated_slot, level, config.expansion,
+                                   context))
+                return result.failed("Out of memory!");
 
-			// For bottom layer we need a more optimized procedure
-			if (!search_to_find_in_base_(query, metric, predicate, prefetch, closest_slot, expansion, context))
-				return result.failed("Out of memory!");
-		}
+            candidates_view_t closest_view;
+            {
+                node_lock_t updated_lock = node_lock_(updated_slot);
+                // TODO: Go through existing neighbors removing reverse links
+                // for (compressed_slot_t slot : neighbors_(updated_node, level))
+                //     remove_link_(slot, updated_slot, level);
+                neighbors_(updated_node, level).clear();
+                closest_view = form_links_to_closest_(metric, updated_slot, level, context);
+                if (closest_view.size())
+                    closest_slot = closest_view[0].slot;
+            }
+            form_reverse_links_(metric, updated_slot, closest_view, value, level, context);
+        }
+        if (static_cast<vector_key_t>(updated_node.key()) != key)
+            updated_node.key(key);
 
-		top.sort_ascending();
-		top.shrink(wanted);
+        // Normalize stats
+        result.computed_distances = context.computed_distances - result.computed_distances;
+        result.visited_members = context.iteration_cycles - result.visited_members;
+        result.slot = updated_slot;
 
-		// Normalize stats
-		result.computed_distances = context.computed_distances_count - result.computed_distances;
-		result.visited_members = context.iteration_cycles - result.visited_members;
-		result.count = top.size();
-		return result;
-	}
+        callback(at(updated_slot));
+        return result;
+    }
 
-	/**
-	 *  @brief Identifies the closest cluster to the given ::query. Thread-safe.
-	 *
-	 *  @param[in] query Content that will be compared against other entries in the index.
-	 *  @param[in] level The index level to target. Higher means lower resolution.
-	 *  @param[in] config Configuration options for this specific operation.
-	 *  @param[in] predicate Optional filtering predicate for `member_cref_t`.
-	 *  @return Smart object referencing temporary memory. Valid until next `search()`, `add()`, or `cluster()`.
-	 */
-	template <                                     //
-	    typename value_at,                         //
-	    typename metric_at,                        //
-	    typename predicate_at = dummy_predicate_t, //
-	    typename prefetch_at = dummy_prefetch_t    //
-	    >
-	cluster_result_t cluster(                       //
-	    value_at &&query,                           //
-	    std::size_t level,                          //
-	    metric_at &&metric,                         //
-	    index_cluster_config_t config = {},         //
-	    predicate_at &&predicate = predicate_at {}, //
-	    prefetch_at &&prefetch = prefetch_at {}) const noexcept {
+    /**
+     *  @brief Searches for the closest elements to the given ::query. Thread-safe.
+     *
+     *  @param[in] query Content that will be compared against other entries in the index.
+     *  @param[in] wanted The upper bound for the number of results to return.
+     *  @param[in] config Configuration options for this specific operation.
+     *  @param[in] predicate Optional filtering predicate for `member_cref_t`.
+     *  @return Smart object referencing temporary memory. Valid until next `search()`, `add()`, or `cluster()`.
+     */
+    template <                                     //
+        typename value_at,                         //
+        typename metric_at,                        //
+        typename predicate_at = dummy_predicate_t, //
+        typename prefetch_at = dummy_prefetch_t    //
+        >
+    search_result_t search(                        //
+        value_at&& query,                          //
+        std::size_t wanted,                        //
+        metric_at&& metric,                        //
+        index_search_config_t config = {},         //
+        predicate_at&& predicate = predicate_at{}, //
+        prefetch_at&& prefetch = prefetch_at{}) const usearch_noexcept_m {
 
-		context_t &context = contexts_[config.thread];
-		cluster_result_t result;
-		if (!nodes_count_)
-			return result.failed("No clusters to identify");
+        // Someone is gonna fuzz this, so let's make sure we cover the basics
+        if (!wanted)
+            return search_result_t{};
 
-		// Go down the level, tracking only the closest match
-		result.computed_distances = context.computed_distances_count;
-		result.visited_members = context.iteration_cycles;
+        // Expansion factor set to zero is equivalent to the default value
+        if (!config.expansion)
+            config.expansion = default_expansion_search();
 
-		next_candidates_t &next = context.next_candidates;
-		std::size_t expansion = config.expansion;
-		if (!next.reserve(expansion))
-			return result.failed("Out of memory!");
+        // Using references is cleaner, but would result in UBSan false positives
+        context_t* context_ptr = contexts_.data() ? contexts_.data() + config.thread : nullptr;
+        top_candidates_t* top_ptr = context_ptr ? &context_ptr->top_candidates : nullptr;
+        search_result_t result{*this, top_ptr};
+        if (!nodes_count_.load(std::memory_order_relaxed))
+            return result;
 
-		result.cluster.member = at(search_for_one_(query, metric, prefetch, entry_slot_, max_level_,
-		                                           static_cast<level_t>(level - 1), context));
-		result.cluster.distance = context.measure(query, result.cluster.member, metric);
+        usearch_assert_m(contexts_.size() > config.thread, "Thread index out of bounds");
+        context_t& context = *context_ptr;
+        top_candidates_t& top = *top_ptr;
+        // Go down the level, tracking only the closest match
+        result.computed_distances = context.computed_distances;
+        result.visited_members = context.iteration_cycles;
 
-		// Normalize stats
-		result.computed_distances = context.computed_distances_count - result.computed_distances;
-		result.visited_members = context.iteration_cycles - result.visited_members;
+        if (config.exact) {
+            if (!top.reserve(wanted))
+                return result.failed("Out of memory!");
+            search_exact_(query, metric, predicate, wanted, context);
+        } else {
+            next_candidates_t& next = context.next_candidates;
+            std::size_t expansion = (std::max)(config.expansion, wanted);
+            usearch_assert_m(expansion > 0, "Expansion factor can't be a zero!");
+            if (!next.reserve(expansion))
+                return result.failed("Out of memory!");
+            if (!top.reserve(expansion))
+                return result.failed("Out of memory!");
 
-		(void)predicate;
-		return result;
-	}
+            compressed_slot_t closest_slot = search_for_one_(
+                query, metric, prefetch, static_cast<compressed_slot_t>(entry_slot_), max_level_, 0, context);
 
+            // For bottom layer we need a more optimized procedure
+            if (!search_to_find_in_base_(query, metric, predicate, prefetch, closest_slot, expansion, context))
+                return result.failed("Out of memory!");
+        }
+
+        top.sort_ascending();
+        top.shrink(wanted);
+
+        // Normalize stats
+        result.computed_distances = context.computed_distances - result.computed_distances;
+        result.visited_members = context.iteration_cycles - result.visited_members;
+        result.count = top.size();
+        return result;
+    }
+
+    /**
+     *  @brief Identifies the closest cluster to the given ::query. Thread-safe.
+     *
+     *  @param[in] query Content that will be compared against other entries in the index.
+     *  @param[in] level The index level to target. Higher means lower resolution.
+     *  @param[in] config Configuration options for this specific operation.
+     *  @param[in] predicate Optional filtering predicate for `member_cref_t`.
+     *  @return Smart object referencing temporary memory. Valid until next `search()`, `add()`, or `cluster()`.
+     */
+    template <                                     //
+        typename value_at,                         //
+        typename metric_at,                        //
+        typename predicate_at = dummy_predicate_t, //
+        typename prefetch_at = dummy_prefetch_t    //
+        >
+    cluster_result_t cluster(                      //
+        value_at&& query,                          //
+        std::size_t level,                         //
+        metric_at&& metric,                        //
+        index_cluster_config_t config = {},        //
+        predicate_at&& predicate = predicate_at{}, //
+        prefetch_at&& prefetch = prefetch_at{}) const noexcept {
+
+        if (!config.expansion)
+            config.expansion = default_expansion_search();
+
+        context_t& context = contexts_[config.thread];
+        cluster_result_t result;
+        if (!nodes_count_)
+            return result.failed("No clusters to identify");
+
+        // Go down the level, tracking only the closest match
+        result.computed_distances = context.computed_distances;
+        result.visited_members = context.iteration_cycles;
+
+        next_candidates_t& next = context.next_candidates;
+        std::size_t expansion = config.expansion;
+        if (!next.reserve(expansion))
+            return result.failed("Out of memory!");
+
+        result.cluster.member =
+            at(search_for_one_(query, metric, prefetch, static_cast<compressed_slot_t>(entry_slot_), max_level_,
+                               static_cast<level_t>(level <= 0 ? 0 : level - 1), context));
+        result.cluster.distance = context.measure(query, result.cluster.member, metric);
+
+        // Normalize stats
+        result.computed_distances = context.computed_distances - result.computed_distances;
+        result.visited_members = context.iteration_cycles - result.visited_members;
+
+        (void)predicate;
+        return result;
+    }
+
+#if defined(USEARCH_USE_PRAGMA_REGION)
 #pragma endregion
 
 #pragma region Metadata
+#endif
 
-	struct stats_t {
-		std::size_t nodes {};
-		std::size_t edges {};
-		std::size_t max_edges {};
-		std::size_t allocated_bytes {};
-	};
+    struct stats_t {
+        std::size_t nodes{};
+        std::size_t edges{};
+        std::size_t max_edges{};
+        std::size_t allocated_bytes{};
+    };
 
-	stats_t stats() const noexcept {
-		stats_t result {};
+    /**
+     *  @brief  Aggregates stats on the number of nodes, edges, and memory usage across all levels.
+     */
+    stats_t stats() const noexcept {
+        stats_t result{};
 
-		for (std::size_t i = 0; i != size(); ++i) {
-			node_t node = node_at_(i);
-			std::size_t max_edges = node.level() * config_.connectivity + config_.connectivity_base;
-			std::size_t edges = 0;
-			for (level_t level = 0; level <= node.level(); ++level)
-				edges += neighbors_(node, level).size();
+        for (std::size_t i = 0; i != size(); ++i) {
+            node_t node = node_at_(i);
+            std::size_t max_edges = node.level() * config_.connectivity + config_.connectivity_base;
+            std::size_t edges = 0;
+            for (level_t level = 0; level <= node.level(); ++level)
+                edges += neighbors_(node, level).size();
 
-			++result.nodes;
-			result.allocated_bytes += node_bytes_(node).size();
-			result.edges += edges;
-			result.max_edges += max_edges;
-		}
-		return result;
-	}
+            ++result.nodes;
+            result.allocated_bytes += node_bytes_(node).size();
+            result.edges += edges;
+            result.max_edges += max_edges;
+        }
+        return result;
+    }
 
-	stats_t stats(std::size_t level) const noexcept {
-		stats_t result {};
+    /**
+     *  @brief  Aggregates stats on the number of nodes, edges, and memory usage up to a specific level.
+     *
+     *  The `level` parameter is zero-based, where `0` is the base level.
+     *  For example, `level=1` will include the base level and the first level of connections.
+     */
+    stats_t stats(std::size_t level) const noexcept {
+        stats_t result{};
+        std::size_t neighbors_bytes = !level ? pre_.neighbors_base_bytes : pre_.neighbors_bytes;
+        std::size_t max_edges_per_node = !level ? config_.connectivity_base : config_.connectivity;
 
-		std::size_t neighbors_bytes = !level ? pre_.neighbors_base_bytes : pre_.neighbors_bytes;
-		for (std::size_t i = 0; i != size(); ++i) {
-			node_t node = node_at_(i);
-			if (static_cast<std::size_t>(node.level()) < level)
-				continue;
+        for (std::size_t i = 0; i != size(); ++i) {
+            node_t node = node_at_(i);
+            if (static_cast<std::size_t>(node.level()) < level)
+                continue;
 
-			++result.nodes;
-			result.edges += neighbors_(node, level).size();
-			result.allocated_bytes += node_head_bytes_() + neighbors_bytes;
-		}
+            ++result.nodes;
+            result.edges += neighbors_(node, static_cast<level_t>(level)).size();
+            result.allocated_bytes += node_head_bytes_() + neighbors_bytes;
+        }
 
-		std::size_t max_edges_per_node = level ? config_.connectivity_base : config_.connectivity;
-		result.max_edges = result.nodes * max_edges_per_node;
-		return result;
-	}
+        result.max_edges = result.nodes * max_edges_per_node;
+        return result;
+    }
 
-	stats_t stats(stats_t *stats_per_level, std::size_t max_level) const noexcept {
+    /**
+     *  @brief  Aggregates stats on the number of nodes, edges, and memory usage up to a specific level,
+     *          simultaneously exporting the stats for each level into the `stats_per_level` C-style array.
+     *
+     *  The `max_level` parameter is zero-based, where `0` is the base level.
+     *  For example, `max_level=1` will include the base level and the first level of connections.
+     */
+    stats_t stats(stats_t* stats_per_level, std::size_t max_level) const noexcept {
 
-		std::size_t head_bytes = node_head_bytes_();
-		for (std::size_t i = 0; i != size(); ++i) {
-			node_t node = node_at_(i);
+        std::size_t head_bytes = node_head_bytes_();
+        for (std::size_t i = 0; i != size(); ++i) {
+            node_t node = node_at_(i);
 
-			stats_per_level[0].nodes++;
-			stats_per_level[0].edges += neighbors_(node, 0).size();
-			stats_per_level[0].allocated_bytes += pre_.neighbors_base_bytes + head_bytes;
+            stats_per_level[0].nodes++;
+            stats_per_level[0].edges += neighbors_(node, 0).size();
+            stats_per_level[0].allocated_bytes += pre_.neighbors_base_bytes + head_bytes;
 
-			level_t node_level = static_cast<level_t>(node.level());
-			for (level_t l = 1; l <= (std::min)(node_level, static_cast<level_t>(max_level)); ++l) {
-				stats_per_level[l].nodes++;
-				stats_per_level[l].edges += neighbors_(node, l).size();
-				stats_per_level[l].allocated_bytes += pre_.neighbors_bytes;
-			}
-		}
+            level_t node_level = static_cast<level_t>(node.level());
+            for (level_t l = 1; l <= (std::min)(node_level, static_cast<level_t>(max_level)); ++l) {
+                stats_per_level[l].nodes++;
+                stats_per_level[l].edges += neighbors_(node, l).size();
+                stats_per_level[l].allocated_bytes += pre_.neighbors_bytes;
+            }
+        }
 
-		// The `max_edges` parameter can be inferred from `nodes`
-		stats_per_level[0].max_edges = stats_per_level[0].nodes * config_.connectivity_base;
-		for (std::size_t l = 1; l <= max_level; ++l)
-			stats_per_level[l].max_edges = stats_per_level[l].nodes * config_.connectivity;
+        // The `max_edges` parameter can be inferred from `nodes`
+        stats_per_level[0].max_edges = stats_per_level[0].nodes * config_.connectivity_base;
+        for (std::size_t l = 1; l <= max_level; ++l)
+            stats_per_level[l].max_edges = stats_per_level[l].nodes * config_.connectivity;
 
-		// Aggregate stats across levels
-		stats_t result {};
-		for (std::size_t l = 0; l <= max_level; ++l)
-			result.nodes += stats_per_level[l].nodes,                         //
-			    result.edges += stats_per_level[l].edges,                     //
-			    result.allocated_bytes += stats_per_level[l].allocated_bytes, //
-			    result.max_edges += stats_per_level[l].max_edges;             //
+        // Aggregate stats across levels
+        stats_t result{};
+        for (std::size_t l = 0; l <= max_level; ++l)
+            result.nodes += stats_per_level[l].nodes,                         //
+                result.edges += stats_per_level[l].edges,                     //
+                result.allocated_bytes += stats_per_level[l].allocated_bytes, //
+                result.max_edges += stats_per_level[l].max_edges;             //
 
-		return result;
-	}
+        return result;
+    }
 
-	/**
-	 *  @brief  A relatively accurate lower bound on the amount of memory consumed by the system.
-	 *          In practice it's error will be below 10%.
-	 *
-	 *  @see    `serialized_length` for the length of the binary serialized representation.
-	 */
-	std::size_t memory_usage(std::size_t allocator_entry_bytes = default_allocator_entry_bytes()) const noexcept {
-		std::size_t total = 0;
-		if (!viewed_file_) {
-			stats_t s = stats();
-			total += s.allocated_bytes;
-			total += s.nodes * allocator_entry_bytes;
-		}
+    /**
+     *  @brief  A relatively accurate lower bound on the amount of memory consumed by the system.
+     *          In practice it's error will be below 10%.
+     *
+     *  @see    `serialized_length` for the length of the binary serialized representation.
+     */
+    std::size_t memory_usage(std::size_t allocator_entry_bytes = default_allocator_entry_bytes()) const noexcept {
+        std::size_t total = 0;
+        if (!viewed_file_) {
+            stats_t s = stats();
+            total += s.allocated_bytes;
+            total += s.nodes * allocator_entry_bytes;
+        }
 
-		// Temporary data-structures, proportional to the number of nodes:
-		total += limits_.members * sizeof(node_t) + allocator_entry_bytes;
+        // Temporary data-structures, proportional to the number of nodes:
+        total += limits_.members * sizeof(node_t) + allocator_entry_bytes;
 
-		// Temporary data-structures, proportional to the number of threads:
-		total += limits_.threads() * sizeof(context_t) + allocator_entry_bytes * 3;
-		return total;
-	}
+        // Temporary data-structures, proportional to the number of threads:
+        total += limits_.threads() * sizeof(context_t) + allocator_entry_bytes * 3;
+        return total;
+    }
 
-	std::size_t memory_usage_per_node(level_t level) const noexcept {
-		return node_bytes_(level);
-	}
+    std::size_t memory_usage_per_node(level_t level) const noexcept { return node_bytes_(level); }
 
+    double inverse_log_connectivity() const { return pre_.inverse_log_connectivity; }
+
+    std::size_t neighbors_base_bytes() const { return pre_.neighbors_base_bytes; }
+
+    std::size_t neighbors_bytes() const { return pre_.neighbors_bytes; }
+
+#if defined(USEARCH_USE_PRAGMA_REGION)
 #pragma endregion
 
 #pragma region Serialization
+#endif
 
-	/**
-	 *  @brief  Estimate the binary length (in bytes) of the serialized index.
-	 */
-	std::size_t serialized_length() const noexcept {
-		std::size_t neighbors_length = 0;
-		for (std::size_t i = 0; i != size(); ++i)
-			neighbors_length += node_bytes_(node_at_(i).level()) + sizeof(level_t);
-		return sizeof(index_serialized_header_t) + neighbors_length;
-	}
+    /**
+     *  @brief  Estimate the binary length (in bytes) of the serialized index.
+     */
+    std::size_t serialized_length() const noexcept {
+        std::size_t neighbors_length = 0;
+        for (std::size_t i = 0; i != size(); ++i)
+            neighbors_length += node_bytes_(node_at_(i).level()) + sizeof(level_t);
+        return sizeof(index_serialized_header_t) + neighbors_length;
+    }
 
-	/**
-	 *  @brief  Saves serialized binary index representation to a stream.
-	 */
-	template <typename output_callback_at, typename progress_at = dummy_progress_t>
-	serialization_result_t save_to_stream(output_callback_at &&output, progress_at &&progress = {}) const noexcept {
+    /**
+     *  @brief  Saves serialized binary index representation to a stream.
+     */
+    template <typename output_callback_at, typename progress_at = dummy_progress_t>
+    serialization_result_t save_to_stream(output_callback_at&& output, progress_at&& progress = {}) const noexcept {
 
-		serialization_result_t result;
+        serialization_result_t result;
 
-		// Export some basic metadata
-		index_serialized_header_t header;
-		header.size = nodes_count_;
-		header.connectivity = config_.connectivity;
-		header.connectivity_base = config_.connectivity_base;
-		header.max_level = max_level_;
-		header.entry_slot = entry_slot_;
-		if (!output(&header, sizeof(header)))
-			return result.failed("Failed to serialize the header into stream");
+        // Export some basic metadata
+        index_serialized_header_t header;
+        header.size = nodes_count_;
+        header.connectivity = config_.connectivity;
+        header.connectivity_base = config_.connectivity_base;
+        header.max_level = max_level_;
+        header.entry_slot = entry_slot_;
+        if (!output(&header, sizeof(header)))
+            return result.failed("Failed to serialize the header into stream");
 
-		// Progress status
-		std::size_t processed = 0;
-		std::size_t const total = 2 * header.size;
+        // Progress status
+        std::size_t processed = 0;
+        std::size_t const total = 2 * header.size;
 
-		// Export the number of levels per node
-		// That is both enough to estimate the overall memory consumption,
-		// and to be able to estimate the offsets of every entry in the file.
-		for (std::size_t i = 0; i != header.size; ++i) {
-			node_t node = node_at_(i);
-			level_t level = node.level();
-			if (!output(&level, sizeof(level)))
-				return result.failed("Failed to serialize into stream");
-			if (!progress(++processed, total))
-				return result.failed("Terminated by user");
-		}
+        // Export the number of levels per node
+        // That is both enough to estimate the overall memory consumption,
+        // and to be able to estimate the offsets of every entry in the file.
+        for (std::size_t i = 0; i != header.size; ++i) {
+            node_t node = node_at_(i);
+            level_t level = node.level();
+            if (!output(&level, sizeof(level)))
+                return result.failed("Failed to serialize into stream");
+            if (!progress(++processed, total))
+                return result.failed("Terminated by user");
+        }
 
-		// After that dump the nodes themselves
-		for (std::size_t i = 0; i != header.size; ++i) {
-			span_bytes_t node_bytes = node_bytes_(node_at_(i));
-			if (!output(node_bytes.data(), node_bytes.size()))
-				return result.failed("Failed to serialize into stream");
-			if (!progress(++processed, total))
-				return result.failed("Terminated by user");
-		}
+        // After that dump the nodes themselves
+        for (std::size_t i = 0; i != header.size; ++i) {
+            span_bytes_t node_bytes = node_bytes_(node_at_(i));
+            if (!output(node_bytes.data(), node_bytes.size()))
+                return result.failed("Failed to serialize into stream");
+            if (!progress(++processed, total))
+                return result.failed("Terminated by user");
+        }
 
-		return {};
-	}
+        return {};
+    }
 
-	/**
-	 *  @brief  Symmetric to `save_from_stream`, pulls data from a stream.
-	 */
-	template <typename input_callback_at, typename progress_at = dummy_progress_t>
-	serialization_result_t load_from_stream(input_callback_at &&input, progress_at &&progress = {}) noexcept {
+    /**
+     *  @brief  Symmetric to `save_from_stream`, pulls data from a stream.
+     */
+    template <typename input_callback_at, typename progress_at = dummy_progress_t>
+    serialization_result_t load_from_stream(input_callback_at&& input, progress_at&& progress = {}) noexcept {
 
-		serialization_result_t result;
+        serialization_result_t result;
 
-		// Remove previously stored objects
-		reset();
+        // Remove previously stored objects
+        index_limits_t old_limits = limits_;
+        reset();
 
-		// Pull basic metadata
-		index_serialized_header_t header;
-		if (!input(&header, sizeof(header)))
-			return result.failed("Failed to pull the header from the stream");
+        // Pull basic metadata
+        index_serialized_header_t header;
+        if (!input(&header, sizeof(header)))
+            return result.failed("Failed to pull the header from the stream");
 
-		// We are loading an empty index, no more work to do
-		if (!header.size) {
-			reset();
-			return result;
-		}
+        // We are loading an empty index, no more work to do
+        if (!header.size) {
+            reset();
+            return result;
+        }
 
-		// Allocate some dynamic memory to read all the levels
-		using levels_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<level_t>;
-		buffer_gt<level_t, levels_allocator_t> levels(header.size);
-		if (!levels)
-			return result.failed("Out of memory");
-		if (!input(levels, header.size * sizeof(level_t)))
-			return result.failed("Failed to pull nodes levels from the stream");
+        // Allocate some dynamic memory to read all the levels
+        using levels_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<level_t>;
+        buffer_gt<level_t, levels_allocator_t> levels(header.size);
+        if (!levels)
+            return result.failed("Out of memory");
+        if (!input(levels, header.size * sizeof(level_t)))
+            return result.failed("Failed to pull nodes levels from the stream");
 
-		// Submit metadata
-		config_.connectivity = header.connectivity;
-		config_.connectivity_base = header.connectivity_base;
-		pre_ = precompute_(config_);
-		index_limits_t limits;
-		limits.members = header.size;
-		if (!reserve(limits)) {
-			reset();
-			return result.failed("Out of memory");
-		}
-		nodes_count_ = header.size;
-		max_level_ = static_cast<level_t>(header.max_level);
-		entry_slot_ = static_cast<compressed_slot_t>(header.entry_slot);
+        // Submit metadata
+        config_.connectivity = header.connectivity;
+        config_.connectivity_base = header.connectivity_base;
+        error_t error = config_.validate();
+        if (error)
+            return result.failed(std::move(error));
 
-		// Load the nodes
-		for (std::size_t i = 0; i != header.size; ++i) {
-			span_bytes_t node_bytes = node_malloc_(levels[i]);
-			if (!input(node_bytes.data(), node_bytes.size())) {
-				reset();
-				return result.failed("Failed to pull nodes from the stream");
-			}
-			nodes_[i] = node_t {node_bytes.data()};
-			if (!progress(i + 1, header.size))
-				return result.failed("Terminated by user");
-		}
-		return {};
-	}
+        pre_ = precompute_(config_);
+        index_limits_t limits;
+        limits.members = header.size;
+        limits.threads_add = (std::max<std::size_t>)(1, old_limits.threads_add);
+        limits.threads_search = (std::max<std::size_t>)(1, old_limits.threads_search);
+        if (!reserve(limits)) {
+            reset();
+            return result.failed("Out of memory");
+        }
+        nodes_count_ = header.size;
+        max_level_ = static_cast<level_t>(header.max_level);
+        entry_slot_ = static_cast<compressed_slot_t>(header.entry_slot);
 
-	template <typename progress_at = dummy_progress_t>
-	serialization_result_t save(char const *file_path, progress_at &&progress = {}) const noexcept {
-		return save(output_file_t(file_path), std::forward<progress_at>(progress));
-	}
+        // Load the nodes
+        for (std::size_t i = 0; i != header.size; ++i) {
+            span_bytes_t node_bytes = node_malloc_(levels[i]);
+            if (!input(node_bytes.data(), node_bytes.size())) {
+                reset();
+                return result.failed("Failed to pull nodes from the stream");
+            }
+            nodes_[i] = node_t{node_bytes.data()};
+            if (!progress(i + 1, header.size))
+                return result.failed("Terminated by user");
+        }
+        return {};
+    }
 
-	template <typename progress_at = dummy_progress_t>
-	serialization_result_t load(char const *file_path, progress_at &&progress = {}) noexcept {
-		return load(input_file_t(file_path), std::forward<progress_at>(progress));
-	}
+    template <typename progress_at = dummy_progress_t>
+    serialization_result_t save(char const* file_path, progress_at&& progress = {}) const noexcept {
+        return save(output_file_t(file_path), std::forward<progress_at>(progress));
+    }
 
-	/**
-	 *  @brief  Saves serialized binary index representation to a file, generally on disk.
-	 */
-	template <typename progress_at = dummy_progress_t>
-	serialization_result_t save(output_file_t file, progress_at &&progress = {}) const noexcept {
+    template <typename progress_at = dummy_progress_t>
+    serialization_result_t load(char const* file_path, progress_at&& progress = {}) noexcept {
+        return load(input_file_t(file_path), std::forward<progress_at>(progress));
+    }
 
-		serialization_result_t io_result = file.open_if_not();
-		if (!io_result)
-			return io_result;
+    /**
+     *  @brief  Saves serialized binary index representation to a file, generally on disk.
+     */
+    template <typename progress_at = dummy_progress_t>
+    serialization_result_t save(output_file_t file, progress_at&& progress = {}) const noexcept {
 
-		serialization_result_t stream_result = save_to_stream(
-		    [&](void *buffer, std::size_t length) {
-			    io_result = file.write(buffer, length);
-			    return !!io_result;
-		    },
-		    std::forward<progress_at>(progress));
+        serialization_result_t io_result = file.open_if_not();
+        if (!io_result)
+            return io_result;
 
-		if (!stream_result)
-			return stream_result;
-		return io_result;
-	}
+        serialization_result_t stream_result = save_to_stream(
+            [&](void* buffer, std::size_t length) {
+                io_result = file.write(buffer, length);
+                return !!io_result;
+            },
+            std::forward<progress_at>(progress));
 
-	/**
-	 *  @brief  Memory-maps the serialized binary index representation from disk,
-	 *          @b without copying data into RAM, and fetching it on-demand.
-	 */
-	template <typename progress_at = dummy_progress_t>
-	serialization_result_t save(memory_mapped_file_t file, std::size_t offset = 0,
-	                            progress_at &&progress = {}) const noexcept {
+        if (!stream_result) {
+            // Drop generic messages like "end of file reached" in favor
+            // of more specific messages from the stream
+            io_result.error.release();
+            return stream_result;
+        }
+        return io_result;
+    }
 
-		serialization_result_t io_result = file.open_if_not();
-		if (!io_result)
-			return io_result;
+    /**
+     *  @brief  Memory-maps the serialized binary index representation from disk,
+     *          @b without copying data into RAM, and fetching it on-demand.
+     */
+    template <typename progress_at = dummy_progress_t>
+    serialization_result_t save(memory_mapped_file_t file, std::size_t offset = 0,
+                                progress_at&& progress = {}) const noexcept {
 
-		serialization_result_t stream_result = save_to_stream(
-		    [&](void *buffer, std::size_t length) {
-			    if (offset + length > file.size())
-				    return false;
-			    std::memcpy(file.data() + offset, buffer, length);
-			    offset += length;
-			    return true;
-		    },
-		    std::forward<progress_at>(progress));
+        serialization_result_t io_result = file.open_if_not();
+        if (!io_result)
+            return io_result;
 
-		return stream_result;
-	}
+        serialization_result_t stream_result = save_to_stream(
+            [&](void* buffer, std::size_t length) {
+                if (offset + length > file.size())
+                    return false;
+                std::memcpy(file.data() + offset, buffer, length);
+                offset += length;
+                return true;
+            },
+            std::forward<progress_at>(progress));
 
-	/**
-	 *  @brief  Loads the serialized binary index representation from disk to RAM.
-	 *          Adjusts the configuration properties of the constructed index to
-	 *          match the settings in the file.
-	 */
-	template <typename progress_at = dummy_progress_t>
-	serialization_result_t load(input_file_t file, progress_at &&progress = {}) noexcept {
+        return stream_result;
+    }
 
-		serialization_result_t io_result = file.open_if_not();
-		if (!io_result)
-			return io_result;
+    /**
+     *  @brief  Loads the serialized binary index representation from disk to RAM.
+     *          Adjusts the configuration properties of the constructed index to
+     *          match the settings in the file.
+     */
+    template <typename progress_at = dummy_progress_t>
+    serialization_result_t load(input_file_t file, progress_at&& progress = {}) noexcept {
 
-		serialization_result_t stream_result = load_from_stream(
-		    [&](void *buffer, std::size_t length) {
-			    io_result = file.read(buffer, length);
-			    return !!io_result;
-		    },
-		    std::forward<progress_at>(progress));
+        serialization_result_t io_result = file.open_if_not();
+        if (!io_result)
+            return io_result;
 
-		if (!stream_result)
-			return stream_result;
-		return io_result;
-	}
+        serialization_result_t stream_result = load_from_stream(
+            [&](void* buffer, std::size_t length) {
+                io_result = file.read(buffer, length);
+                return !!io_result;
+            },
+            std::forward<progress_at>(progress));
 
-	/**
-	 *  @brief  Loads the serialized binary index representation from disk to RAM.
-	 *          Adjusts the configuration properties of the constructed index to
-	 *          match the settings in the file.
-	 */
-	template <typename progress_at = dummy_progress_t>
-	serialization_result_t load(memory_mapped_file_t file, std::size_t offset = 0,
-	                            progress_at &&progress = {}) noexcept {
+        if (!stream_result) {
+            // Drop generic messages like "end of file reached" in favor
+            // of more specific messages from the stream
+            io_result.error.release();
+            return stream_result;
+        }
+        return io_result;
+    }
 
-		serialization_result_t io_result = file.open_if_not();
-		if (!io_result)
-			return io_result;
+    /**
+     *  @brief  Loads the serialized binary index representation from disk to RAM.
+     *          Adjusts the configuration properties of the constructed index to
+     *          match the settings in the file.
+     */
+    template <typename progress_at = dummy_progress_t>
+    serialization_result_t load(memory_mapped_file_t file, std::size_t offset = 0,
+                                progress_at&& progress = {}) noexcept {
 
-		serialization_result_t stream_result = load_from_stream(
-		    [&](void *buffer, std::size_t length) {
-			    if (offset + length > file.size())
-				    return false;
-			    std::memcpy(buffer, file.data() + offset, length);
-			    offset += length;
-			    return true;
-		    },
-		    std::forward<progress_at>(progress));
+        serialization_result_t io_result = file.open_if_not();
+        if (!io_result)
+            return io_result;
 
-		return stream_result;
-	}
+        serialization_result_t stream_result = load_from_stream(
+            [&](void* buffer, std::size_t length) {
+                if (offset + length > file.size())
+                    return false;
+                std::memcpy(buffer, file.data() + offset, length);
+                offset += length;
+                return true;
+            },
+            std::forward<progress_at>(progress));
 
-	/**
-	 *  @brief  Memory-maps the serialized binary index representation from disk,
-	 *          @b without copying data into RAM, and fetching it on-demand.
-	 */
-	template <typename progress_at = dummy_progress_t>
-	serialization_result_t view(memory_mapped_file_t file, std::size_t offset = 0,
-	                            progress_at &&progress = {}) noexcept {
+        return stream_result;
+    }
 
-		// Remove previously stored objects
-		reset();
+    /**
+     *  @brief  Memory-maps the serialized binary index representation from disk,
+     *          @b without copying data into RAM, and fetching it on-demand.
+     */
+    template <typename progress_at = dummy_progress_t>
+    serialization_result_t view(memory_mapped_file_t file, std::size_t offset = 0,
+                                progress_at&& progress = {}) noexcept {
 
-		serialization_result_t result = file.open_if_not();
-		if (!result)
-			return result;
+        // Remove previously stored objects
+        index_limits_t old_limits = limits_;
+        reset();
 
-		// Pull basic metadata
-		index_serialized_header_t header;
-		if (file.size() - offset < sizeof(header))
-			return result.failed("File is corrupted and lacks a header");
-		std::memcpy(&header, file.data() + offset, sizeof(header));
+        serialization_result_t result = file.open_if_not();
+        if (!result)
+            return result;
 
-		if (!header.size) {
-			reset();
-			return result;
-		}
+        // Pull basic metadata
+        index_serialized_header_t header;
+        if (file.size() - offset < sizeof(header))
+            return result.failed("File is corrupted and lacks a header");
+        std::memcpy(&header, file.data() + offset, sizeof(header));
 
-		// Precompute offsets of every node, but before that we need to update the configs
-		// This could have been done with `std::exclusive_scan`, but it's only available from C++17.
-		using offsets_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<std::size_t>;
-		buffer_gt<std::size_t, offsets_allocator_t> offsets(header.size);
-		if (!offsets)
-			return result.failed("Out of memory");
+        if (!header.size) {
+            reset();
+            return result;
+        }
 
-		config_.connectivity = header.connectivity;
-		config_.connectivity_base = header.connectivity_base;
-		pre_ = precompute_(config_);
-		misaligned_ptr_gt<level_t> levels {(byte_t *)file.data() + offset + sizeof(header)};
-		offsets[0u] = offset + sizeof(header) + sizeof(level_t) * header.size;
-		for (std::size_t i = 1; i < header.size; ++i)
-			offsets[i] = offsets[i - 1] + node_bytes_(levels[i - 1]);
+        // Precompute offsets of every node, but before that we need to update the configs
+        // This could have been done with `std::exclusive_scan`, but it's only available from C++17.
+        using offsets_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<std::size_t>;
+        buffer_gt<std::size_t, offsets_allocator_t> offsets(header.size);
+        if (!offsets)
+            return result.failed("Out of memory");
 
-		std::size_t total_bytes = offsets[header.size - 1] + node_bytes_(levels[header.size - 1]);
-		if (file.size() < total_bytes) {
-			reset();
-			return result.failed("File is corrupted and can't fit all the nodes");
-		}
+        config_.connectivity = header.connectivity;
+        config_.connectivity_base = header.connectivity_base;
+        error_t error = config_.validate();
+        if (error)
+            return result.failed(std::move(error));
 
-		// Submit metadata and reserve memory
-		index_limits_t limits;
-		limits.members = header.size;
-		if (!reserve(limits)) {
-			reset();
-			return result.failed("Out of memory");
-		}
-		nodes_count_ = header.size;
-		max_level_ = static_cast<level_t>(header.max_level);
-		entry_slot_ = static_cast<compressed_slot_t>(header.entry_slot);
+        pre_ = precompute_(config_);
+        misaligned_ptr_gt<level_t> levels{(byte_t*)file.data() + offset + sizeof(header)};
+        offsets[0u] = offset + sizeof(header) + sizeof(level_t) * header.size;
+        for (std::size_t i = 1; i < header.size; ++i)
+            offsets[i] = offsets[i - 1] + node_bytes_(levels[i - 1]);
 
-		// Rapidly address all the nodes
-		for (std::size_t i = 0; i != header.size; ++i) {
-			nodes_[i] = node_t {(byte_t *)file.data() + offsets[i]};
-			if (!progress(i + 1, header.size))
-				return result.failed("Terminated by user");
-		}
-		viewed_file_ = std::move(file);
-		return {};
-	}
+        std::size_t total_bytes = offsets[header.size - 1] + node_bytes_(levels[header.size - 1]);
+        if (file.size() < total_bytes) {
+            reset();
+            return result.failed("File is corrupted and can't fit all the nodes");
+        }
 
+        // Submit metadata and reserve memory
+        index_limits_t limits;
+        limits.members = header.size;
+        limits.threads_add = (std::max<std::size_t>)(1, old_limits.threads_add);
+        limits.threads_search = (std::max<std::size_t>)(1, old_limits.threads_search);
+        if (!reserve(limits)) {
+            reset();
+            return result.failed("Out of memory");
+        }
+        nodes_count_ = header.size;
+        max_level_ = static_cast<level_t>(header.max_level);
+        entry_slot_ = static_cast<compressed_slot_t>(header.entry_slot);
+
+        // Rapidly address all the nodes
+        for (std::size_t i = 0; i != header.size; ++i) {
+            nodes_[i] = node_t{(byte_t*)file.data() + offsets[i]};
+            if (!progress(i + 1, header.size))
+                return result.failed("Terminated by user");
+        }
+        viewed_file_ = std::move(file);
+        return {};
+    }
+
+#if defined(USEARCH_USE_PRAGMA_REGION)
 #pragma endregion
-
-	/**
-	 *  @brief  Performs compaction on the whole HNSW index, purging some entries
-	 *          and links to them, while also generating a more efficient mapping,
-	 *          putting the more frequently used entries closer together.
-	 *
-	 *
-	 * Scans the whole collection, removing the links leading towards
-	 *          banned entries. This essentially isolates some nodes from the rest
-	 *          of the graph, while keeping their outgoing links, in case the node
-	 *          is structurally relevant and has a crucial role in the index.
-	 *          It won't reclaim the memory.
-	 *
-	 *  @param[in] allow_member Predicate to mark nodes for isolation.
-	 *  @param[in] executor Thread-pool to execute the job in parallel.
-	 *  @param[in] progress Callback to report the execution progress.
-	 */
-	template <typename values_at, typename metric_at,                   //
-	          typename slot_transition_at = dummy_key_to_key_mapping_t, //
-	          typename executor_at = dummy_executor_t,                  //
-	          typename progress_at = dummy_progress_t,                  //
-	          typename prefetch_at = dummy_prefetch_t>
-	void compact(                             //
-	    values_at &&values,                   //
-	    metric_at &&metric,                   //
-	    slot_transition_at &&slot_transition, //
-
-	    executor_at &&executor = executor_at {}, //
-	    progress_at &&progress = progress_at {}, //
-	    prefetch_at &&prefetch = prefetch_at {}) noexcept {
-
-		// Export all the keys, slots, and levels.
-		// Partition them with the predicate.
-		// Sort the allowed entries in descending order of their level.
-		// Create a new array mapping old slots to the new ones (INT_MAX for deleted items).
-		struct slot_level_t {
-			compressed_slot_t old_slot;
-			compressed_slot_t cluster;
-			level_t level;
-		};
-		using slot_level_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<slot_level_t>;
-		buffer_gt<slot_level_t, slot_level_allocator_t> slots_and_levels(size());
-
-		// Progress status
-		std::atomic<bool> do_tasks {true};
-		std::atomic<std::size_t> processed {0};
-		std::size_t const total = 3 * slots_and_levels.size();
-
-		// For every bottom level node, determine its parent cluster
-		executor.dynamic(slots_and_levels.size(), [&](std::size_t thread_idx, std::size_t old_slot) {
-			context_t &context = contexts_[thread_idx];
-			std::size_t cluster = search_for_one_( //
-			    values[citerator_at(old_slot)],    //
-			    metric, prefetch,                  //
-			    entry_slot_, max_level_, 0, context);
-			slots_and_levels[old_slot] = {                                          //
-			                              static_cast<compressed_slot_t>(old_slot), //
-			                              static_cast<compressed_slot_t>(cluster),  //
-			                              node_at_(old_slot).level()};
-			++processed;
-			if (thread_idx == 0)
-				do_tasks = progress(processed.load(), total);
-			return do_tasks.load();
-		});
-		if (!do_tasks.load())
-			return;
-
-		// Where the actual permutation happens:
-		std::sort(slots_and_levels.begin(), slots_and_levels.end(), [](slot_level_t const &a, slot_level_t const &b) {
-			return a.level == b.level ? a.cluster < b.cluster : a.level > b.level;
-		});
-
-		using size_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<std::size_t>;
-		buffer_gt<std::size_t, size_allocator_t> old_slot_to_new(slots_and_levels.size());
-		for (std::size_t new_slot = 0; new_slot != slots_and_levels.size(); ++new_slot)
-			old_slot_to_new[slots_and_levels[new_slot].old_slot] = new_slot;
-
-		// Erase all the incoming links
-		buffer_gt<node_t, nodes_allocator_t> reordered_nodes(slots_and_levels.size());
-		tape_allocator_t reordered_tape;
-
-		for (std::size_t new_slot = 0; new_slot != slots_and_levels.size(); ++new_slot) {
-			std::size_t old_slot = slots_and_levels[new_slot].old_slot;
-			node_t old_node = node_at_(old_slot);
-
-			std::size_t node_bytes = node_bytes_(old_node.level());
-			byte_t *new_data = (byte_t *)reordered_tape.allocate(node_bytes);
-			node_t new_node {new_data};
-			std::memcpy(new_data, old_node.tape(), node_bytes);
-
-			for (level_t level = 0; level <= old_node.level(); ++level)
-				for (misaligned_ref_gt<compressed_slot_t> neighbor : neighbors_(new_node, level))
-					neighbor = static_cast<compressed_slot_t>(old_slot_to_new[compressed_slot_t(neighbor)]);
-
-			reordered_nodes[new_slot] = new_node;
-			if (!progress(++processed, total))
-				return;
-		}
-
-		for (std::size_t new_slot = 0; new_slot != slots_and_levels.size(); ++new_slot) {
-			std::size_t old_slot = slots_and_levels[new_slot].old_slot;
-			slot_transition(node_at_(old_slot).ckey(),                //
-			                static_cast<compressed_slot_t>(old_slot), //
-			                static_cast<compressed_slot_t>(new_slot));
-			if (!progress(++processed, total))
-				return;
-		}
-
-		nodes_ = std::move(reordered_nodes);
-		tape_allocator_ = std::move(reordered_tape);
-		entry_slot_ = old_slot_to_new[entry_slot_];
-	}
-
-	/**
-	 *  @brief  Scans the whole collection, removing the links leading towards
-	 *          banned entries. This essentially isolates some nodes from the rest
-	 *          of the graph, while keeping their outgoing links, in case the node
-	 *          is structurally relevant and has a crucial role in the index.
-	 *          It won't reclaim the memory.
-	 *
-	 *  @param[in] allow_member Predicate to mark nodes for isolation.
-	 *  @param[in] executor Thread-pool to execute the job in parallel.
-	 *  @param[in] progress Callback to report the execution progress.
-	 */
-	template <                                        //
-	    typename allow_member_at = dummy_predicate_t, //
-	    typename executor_at = dummy_executor_t,      //
-	    typename progress_at = dummy_progress_t       //
-	    >
-	void isolate(                                //
-	    allow_member_at &&allow_member,          //
-	    executor_at &&executor = executor_at {}, //
-	    progress_at &&progress = progress_at {}) noexcept {
-
-		// Progress status
-		std::atomic<bool> do_tasks {true};
-		std::atomic<std::size_t> processed {0};
-
-		// Erase all the incoming links
-		std::size_t nodes_count = size();
-		executor.dynamic(nodes_count, [&](std::size_t thread_idx, std::size_t node_idx) {
-			node_t node = node_at_(node_idx);
-			for (level_t level = 0; level <= node.level(); ++level) {
-				neighbors_ref_t neighbors = neighbors_(node, level);
-				std::size_t old_size = neighbors.size();
-				neighbors.clear();
-				for (std::size_t i = 0; i != old_size; ++i) {
-					compressed_slot_t neighbor_slot = neighbors[i];
-					node_t neighbor = node_at_(neighbor_slot);
-					if (allow_member(member_cref_t {neighbor.ckey(), neighbor_slot}))
-						neighbors.push_back(neighbor_slot);
-				}
-			}
-			++processed;
-			if (thread_idx == 0)
-				do_tasks = progress(processed.load(), nodes_count);
-			return do_tasks.load();
-		});
-
-		// At the end report the latest numbers, because the reporter thread may be finished earlier
-		progress(processed.load(), nodes_count);
-	}
-
-private:
-	inline static precomputed_constants_t precompute_(index_config_t const &config) noexcept {
-		precomputed_constants_t pre;
-		pre.inverse_log_connectivity = 1.0 / std::log(static_cast<double>(config.connectivity));
-		pre.neighbors_bytes = config.connectivity * sizeof(compressed_slot_t) + sizeof(neighbors_count_t);
-		pre.neighbors_base_bytes = config.connectivity_base * sizeof(compressed_slot_t) + sizeof(neighbors_count_t);
-		return pre;
-	}
-
-	using span_bytes_t = span_gt<byte_t>;
-
-	inline span_bytes_t node_bytes_(node_t node) const noexcept {
-		return {node.tape(), node_bytes_(node.level())};
-	}
-	inline std::size_t node_bytes_(level_t level) const noexcept {
-		return node_head_bytes_() + node_neighbors_bytes_(level);
-	}
-	inline std::size_t node_neighbors_bytes_(node_t node) const noexcept {
-		return node_neighbors_bytes_(node.level());
-	}
-	inline std::size_t node_neighbors_bytes_(level_t level) const noexcept {
-		return pre_.neighbors_base_bytes + pre_.neighbors_bytes * level;
-	}
-
-	span_bytes_t node_malloc_(level_t level) noexcept {
-		std::size_t node_bytes = node_bytes_(level);
-		byte_t *data = (byte_t *)tape_allocator_.allocate(node_bytes);
-		return data ? span_bytes_t {data, node_bytes} : span_bytes_t {};
-	}
-
-	node_t node_make_(vector_key_t key, level_t level) noexcept {
-		span_bytes_t node_bytes = node_malloc_(level);
-		if (!node_bytes)
-			return {};
-
-		std::memset(node_bytes.data(), 0, node_bytes.size());
-		node_t node {(byte_t *)node_bytes.data()};
-		node.key(key);
-		node.level(level);
-		return node;
-	}
-
-	node_t node_make_copy_(span_bytes_t old_bytes) noexcept {
-		byte_t *data = (byte_t *)tape_allocator_.allocate(old_bytes.size());
-		if (!data)
-			return {};
-		std::memcpy(data, old_bytes.data(), old_bytes.size());
-		return node_t {data};
-	}
-
-	void node_free_(std::size_t idx) noexcept {
-		if (viewed_file_)
-			return;
-
-		node_t &node = nodes_[idx];
-		tape_allocator_.deallocate(node.tape(), node_bytes_(node).size());
-		node = node_t {};
-	}
-
-	inline node_t node_at_(std::size_t idx) const noexcept {
-		return nodes_[idx];
-	}
-	inline neighbors_ref_t neighbors_base_(node_t node) const noexcept {
-		return {node.neighbors_tape()};
-	}
-
-	inline neighbors_ref_t neighbors_non_base_(node_t node, level_t level) const noexcept {
-		return {node.neighbors_tape() + pre_.neighbors_base_bytes + (level - 1) * pre_.neighbors_bytes};
-	}
-
-	inline neighbors_ref_t neighbors_(node_t node, level_t level) const noexcept {
-		return level ? neighbors_non_base_(node, level) : neighbors_base_(node);
-	}
-
-	struct node_lock_t {
-		nodes_mutexes_t &mutexes;
-		std::size_t slot;
-		inline ~node_lock_t() noexcept {
-			mutexes.atomic_reset(slot);
-		}
-	};
-
-	inline node_lock_t node_lock_(std::size_t slot) const noexcept {
-		while (nodes_mutexes_.atomic_set(slot))
-			;
-		return {nodes_mutexes_, slot};
-	}
-
-	template <typename value_at, typename metric_at, typename prefetch_at>
-	void connect_node_across_levels_(                                                           //
-	    value_at &&value, metric_at &&metric, prefetch_at &&prefetch,                           //
-	    std::size_t node_slot, std::size_t entry_slot, level_t max_level, level_t target_level, //
-	    index_update_config_t const &config, context_t &context) usearch_noexcept_m {
-
-		// Go down the level, tracking only the closest match
-		std::size_t closest_slot = search_for_one_( //
-		    value, metric, prefetch,                //
-		    entry_slot, max_level, target_level, context);
-
-		// From `target_level` down perform proper extensive search
-		for (level_t level = (std::min)(target_level, max_level); level >= 0; --level) {
-			// TODO: Handle out of memory conditions
-			search_to_insert_(value, metric, prefetch, closest_slot, node_slot, level, config.expansion, context);
-			closest_slot = connect_new_node_(metric, node_slot, level, context);
-			reconnect_neighbor_nodes_(metric, node_slot, value, level, context);
-		}
-	}
-
-	template <typename metric_at>
-	std::size_t connect_new_node_( //
-	    metric_at &&metric, std::size_t new_slot, level_t level, context_t &context) usearch_noexcept_m {
-
-		node_t new_node = node_at_(new_slot);
-		top_candidates_t &top = context.top_candidates;
-
-		// Outgoing links from `new_slot`:
-		neighbors_ref_t new_neighbors = neighbors_(new_node, level);
-		{
-			usearch_assert_m(!new_neighbors.size(), "The newly inserted element should have blank link list");
-			candidates_view_t top_view = refine_(metric, config_.connectivity, top, context);
-
-			for (std::size_t idx = 0; idx != top_view.size(); idx++) {
-				usearch_assert_m(!new_neighbors[idx], "Possible memory corruption");
-				usearch_assert_m(level <= node_at_(top_view[idx].slot).level(), "Linking to missing level");
-				new_neighbors.push_back(top_view[idx].slot);
-			}
-		}
-
-		return new_neighbors[0];
-	}
-
-	template <typename value_at, typename metric_at>
-	void reconnect_neighbor_nodes_( //
-	    metric_at &&metric, std::size_t new_slot, value_at &&value, level_t level,
-	    context_t &context) usearch_noexcept_m {
-
-		node_t new_node = node_at_(new_slot);
-		top_candidates_t &top = context.top_candidates;
-		neighbors_ref_t new_neighbors = neighbors_(new_node, level);
-
-		// Reverse links from the neighbors:
-		std::size_t const connectivity_max = level ? config_.connectivity : config_.connectivity_base;
-		for (compressed_slot_t close_slot : new_neighbors) {
-			if (close_slot == new_slot)
-				continue;
-			node_lock_t close_lock = node_lock_(close_slot);
-			node_t close_node = node_at_(close_slot);
-
-			neighbors_ref_t close_header = neighbors_(close_node, level);
-			usearch_assert_m(close_header.size() <= connectivity_max, "Possible corruption");
-			usearch_assert_m(close_slot != new_slot, "Self-loops are impossible");
-			usearch_assert_m(level <= close_node.level(), "Linking to missing level");
-
-			// If `new_slot` is already present in the neighboring connections of `close_slot`
-			// then no need to modify any connections or run the heuristics.
-			if (close_header.size() < connectivity_max) {
-				close_header.push_back(static_cast<compressed_slot_t>(new_slot));
-				continue;
-			}
-
-			// To fit a new connection we need to drop an existing one.
-			top.clear();
-			usearch_assert_m((top.reserve(close_header.size() + 1)), "The memory must have been reserved in `add`");
-			top.insert_reserved(
-			    {context.measure(value, citerator_at(close_slot), metric), static_cast<compressed_slot_t>(new_slot)});
-			for (compressed_slot_t successor_slot : close_header)
-				top.insert_reserved(
-				    {context.measure(citerator_at(close_slot), citerator_at(successor_slot), metric), successor_slot});
-
-			// Export the results:
-			close_header.clear();
-			candidates_view_t top_view = refine_(metric, connectivity_max, top, context);
-			for (std::size_t idx = 0; idx != top_view.size(); idx++)
-				close_header.push_back(top_view[idx].slot);
-		}
-	}
-
-	level_t choose_random_level_(std::default_random_engine &level_generator) const noexcept {
-		std::uniform_real_distribution<double> distribution(0.0, 1.0);
-		double r = -std::log(distribution(level_generator)) * pre_.inverse_log_connectivity;
-		return (level_t)r;
-	}
-
-	struct candidates_range_t;
-	class candidates_iterator_t {
-		friend struct candidates_range_t;
-
-		index_gt const &index_;
-		neighbors_ref_t neighbors_;
-		visits_hash_set_t &visits_;
-		std::size_t current_;
-
-		candidates_iterator_t &skip_missing() noexcept {
-			if (!visits_.size())
-				return *this;
-			while (current_ != neighbors_.size()) {
-				compressed_slot_t neighbor_slot = neighbors_[current_];
-				if (visits_.test(neighbor_slot))
-					current_++;
-				else
-					break;
-			}
-			return *this;
-		}
-
-	public:
-		using element_t = compressed_slot_t;
-		using iterator_category = std::forward_iterator_tag;
-		using value_type = element_t;
-		using difference_type = std::ptrdiff_t;
-		using pointer = misaligned_ptr_gt<element_t>;
-		using reference = misaligned_ref_gt<element_t>;
-
-		reference operator*() const noexcept {
-			return slot();
-		}
-		candidates_iterator_t(index_gt const &index, neighbors_ref_t neighbors, visits_hash_set_t &visits,
-		                      std::size_t progress) noexcept
-		    : index_(index), neighbors_(neighbors), visits_(visits), current_(progress) {
-		}
-		candidates_iterator_t operator++(int) noexcept {
-			return candidates_iterator_t(index_, visits_, neighbors_, current_ + 1).skip_missing();
-		}
-		candidates_iterator_t &operator++() noexcept {
-			++current_;
-			skip_missing();
-			return *this;
-		}
-		bool operator==(candidates_iterator_t const &other) noexcept {
-			return current_ == other.current_;
-		}
-		bool operator!=(candidates_iterator_t const &other) noexcept {
-			return current_ != other.current_;
-		}
-
-		vector_key_t key() const noexcept {
-			return index_.node_at_(slot()).key();
-		}
-		compressed_slot_t slot() const noexcept {
-			return neighbors_[current_];
-		}
-		friend inline std::size_t get_slot(candidates_iterator_t const &it) noexcept {
-			return it.slot();
-		}
-		friend inline vector_key_t get_key(candidates_iterator_t const &it) noexcept {
-			return it.key();
-		}
-	};
-
-	struct candidates_range_t {
-		index_gt const &index;
-		neighbors_ref_t neighbors;
-		visits_hash_set_t &visits;
-
-		candidates_iterator_t begin() const noexcept {
-			return candidates_iterator_t {index, neighbors, visits, 0}.skip_missing();
-		}
-		candidates_iterator_t end() const noexcept {
-			return {index, neighbors, visits, neighbors.size()};
-		}
-	};
-
-	template <typename value_at, typename metric_at, typename prefetch_at = dummy_prefetch_t>
-	std::size_t search_for_one_(                                      //
-	    value_at &&query, metric_at &&metric, prefetch_at &&prefetch, //
-	    std::size_t closest_slot, level_t begin_level, level_t end_level, context_t &context) const noexcept {
-
-		visits_hash_set_t &visits = context.visits;
-		visits.clear();
-
-		// Optional prefetching
-		if (!is_dummy<prefetch_at>())
-			prefetch(citerator_at(closest_slot), citerator_at(closest_slot + 1));
-
-		distance_t closest_dist = context.measure(query, citerator_at(closest_slot), metric);
-		for (level_t level = begin_level; level > end_level; --level) {
-			bool changed;
-			do {
-				changed = false;
-				node_lock_t closest_lock = node_lock_(closest_slot);
-				neighbors_ref_t closest_neighbors = neighbors_non_base_(node_at_(closest_slot), level);
-
-				// Optional prefetching
-				if (!is_dummy<prefetch_at>()) {
-					candidates_range_t missing_candidates {*this, closest_neighbors, visits};
-					prefetch(missing_candidates.begin(), missing_candidates.end());
-				}
-
-				// Actual traversal
-				for (compressed_slot_t candidate_slot : closest_neighbors) {
-					distance_t candidate_dist = context.measure(query, citerator_at(candidate_slot), metric);
-					if (candidate_dist < closest_dist) {
-						closest_dist = candidate_dist;
-						closest_slot = candidate_slot;
-						changed = true;
-					}
-				}
-				context.iteration_cycles++;
-			} while (changed);
-		}
-		return closest_slot;
-	}
-
-	/**
-	 *  @brief  Traverses a layer of a graph, to find the best place to insert a new node.
-	 *          Locks the nodes in the process, assuming other threads are updating neighbors lists.
-	 *  @return `true` if procedure succeeded, `false` if run out of memory.
-	 */
-	template <typename value_at, typename metric_at, typename prefetch_at = dummy_prefetch_t>
-	bool search_to_insert_(                                           //
-	    value_at &&query, metric_at &&metric, prefetch_at &&prefetch, //
-	    std::size_t start_slot, std::size_t new_slot, level_t level, std::size_t top_limit,
-	    context_t &context) noexcept {
-
-		visits_hash_set_t &visits = context.visits;
-		next_candidates_t &next = context.next_candidates; // pop min, push
-		top_candidates_t &top = context.top_candidates;    // pop max, push
-
-		visits.clear();
-		next.clear();
-		top.clear();
-		if (!visits.reserve(config_.connectivity_base + 1u))
-			return false;
-
-		// Optional prefetching
-		if (!is_dummy<prefetch_at>())
-			prefetch(citerator_at(start_slot), citerator_at(start_slot + 1));
-
-		distance_t radius = context.measure(query, citerator_at(start_slot), metric);
-		next.insert_reserved({-radius, static_cast<compressed_slot_t>(start_slot)});
-		top.insert_reserved({radius, static_cast<compressed_slot_t>(start_slot)});
-		visits.set(static_cast<compressed_slot_t>(start_slot));
-
-		while (!next.empty()) {
-
-			candidate_t candidacy = next.top();
-			if ((-candidacy.distance) > radius && top.size() == top_limit)
-				break;
-
-			next.pop();
-			context.iteration_cycles++;
-
-			compressed_slot_t candidate_slot = candidacy.slot;
-			if (new_slot == candidate_slot)
-				continue;
-			node_t candidate_ref = node_at_(candidate_slot);
-			node_lock_t candidate_lock = node_lock_(candidate_slot);
-			neighbors_ref_t candidate_neighbors = neighbors_(candidate_ref, level);
-
-			// Optional prefetching
-			if (!is_dummy<prefetch_at>()) {
-				candidates_range_t missing_candidates {*this, candidate_neighbors, visits};
-				prefetch(missing_candidates.begin(), missing_candidates.end());
-			}
-
-			// Assume the worst-case when reserving memory
-			if (!visits.reserve(visits.size() + candidate_neighbors.size()))
-				return false;
-
-			for (compressed_slot_t successor_slot : candidate_neighbors) {
-				if (visits.set(successor_slot))
-					continue;
-
-				// node_lock_t successor_lock = node_lock_(successor_slot);
-				distance_t successor_dist = context.measure(query, citerator_at(successor_slot), metric);
-				if (top.size() < top_limit || successor_dist < radius) {
-					// This can substantially grow our priority queue:
-					next.insert({-successor_dist, successor_slot});
-					// This will automatically evict poor matches:
-					top.insert({successor_dist, successor_slot}, top_limit);
-					radius = top.top().distance;
-				}
-			}
-		}
-		return true;
-	}
-
-	/**
-	 *  @brief  Traverses the @b base layer of a graph, to find a close match.
-	 *          Doesn't lock any nodes, assuming read-only simultaneous access.
-	 *  @return `true` if procedure succeeded, `false` if run out of memory.
-	 */
-	template <typename value_at, typename metric_at, typename predicate_at, typename prefetch_at>
-	bool search_to_find_in_base_(                                                               //
-	    value_at &&query, metric_at &&metric, predicate_at &&predicate, prefetch_at &&prefetch, //
-	    std::size_t start_slot, std::size_t expansion, context_t &context) const usearch_noexcept_m {
-
-		visits_hash_set_t &visits = context.visits;
-		next_candidates_t &next = context.next_candidates; // pop min, push
-		top_candidates_t &top = context.top_candidates;    // pop max, push
-		std::size_t const top_limit = expansion;
-
-		visits.clear();
-		next.clear();
-		top.clear();
-		if (!visits.reserve(config_.connectivity_base + 1u))
-			return false;
-
-		// Optional prefetching
-		if (!is_dummy<prefetch_at>())
-			prefetch(citerator_at(start_slot), citerator_at(start_slot + 1));
-
-		distance_t radius = context.measure(query, citerator_at(start_slot), metric);
-		usearch_assert_m(next.capacity(), "The `max_heap_gt` must have been reserved in the search entry point");
-		next.insert_reserved({-radius, static_cast<compressed_slot_t>(start_slot)});
-		visits.set(static_cast<compressed_slot_t>(start_slot));
-
-		// Don't populate the top list if the predicate is not satisfied
-		if (is_dummy<predicate_at>() || predicate(member_cref_t {node_at_(start_slot).ckey(), start_slot})) {
-			usearch_assert_m(top.capacity(),
-			                 "The `sorted_buffer_gt` must have been reserved in the search entry point");
-			top.insert_reserved({radius, static_cast<compressed_slot_t>(start_slot)});
-		}
-
-		while (!next.empty()) {
-
-			candidate_t candidate = next.top();
-			if ((-candidate.distance) > radius)
-				break;
-
-			next.pop();
-			context.iteration_cycles++;
-
-			neighbors_ref_t candidate_neighbors = neighbors_base_(node_at_(candidate.slot));
-
-			// Optional prefetching
-			if (!is_dummy<prefetch_at>()) {
-				candidates_range_t missing_candidates {*this, candidate_neighbors, visits};
-				prefetch(missing_candidates.begin(), missing_candidates.end());
-			}
-
-			// Assume the worst-case when reserving memory
-			if (!visits.reserve(visits.size() + candidate_neighbors.size()))
-				return false;
-
-			for (compressed_slot_t successor_slot : candidate_neighbors) {
-				if (visits.set(successor_slot))
-					continue;
-
-				distance_t successor_dist = context.measure(query, citerator_at(successor_slot), metric);
-				if (top.size() < top_limit || successor_dist < radius) {
-					// This can substantially grow our priority queue:
-					next.insert({-successor_dist, successor_slot});
-					if (is_dummy<predicate_at>() ||
-					    predicate(member_cref_t {node_at_(successor_slot).ckey(), successor_slot}))
-						top.insert({successor_dist, successor_slot}, top_limit);
-					radius = top.top().distance;
-				}
-			}
-		}
-
-		return true;
-	}
-
-	/**
-	 *  @brief  Iterates through all members, without actually touching the index.
-	 */
-	template <typename value_at, typename metric_at, typename predicate_at>
-	void search_exact_(                                                 //
-	    value_at &&query, metric_at &&metric, predicate_at &&predicate, //
-	    std::size_t count, context_t &context) const noexcept {
-
-		top_candidates_t &top = context.top_candidates;
-		top.clear();
-		top.reserve(count);
-		for (std::size_t i = 0; i != size(); ++i) {
-			if (!is_dummy<predicate_at>())
-				if (!predicate(at(i)))
-					continue;
-
-			distance_t distance = context.measure(query, citerator_at(i), metric);
-			top.insert(candidate_t {distance, static_cast<compressed_slot_t>(i)}, count);
-		}
-	}
-
-	/**
-	 *  @brief  This algorithm from the original paper implements a heuristic,
-	 *          that massively reduces the number of connections a point has,
-	 *          to keep only the neighbors, that are from each other.
-	 */
-	template <typename metric_at>
-	candidates_view_t refine_( //
-	    metric_at &&metric,    //
-	    std::size_t needed, top_candidates_t &top, context_t &context) const noexcept {
-
-		top.sort_ascending();
-		candidate_t *top_data = top.data();
-		std::size_t const top_count = top.size();
-		if (top_count < needed)
-			return {top_data, top_count};
-
-		std::size_t submitted_count = 1;
-		std::size_t consumed_count = 1; /// Always equal or greater than `submitted_count`.
-		while (submitted_count < needed && consumed_count < top_count) {
-			candidate_t candidate = top_data[consumed_count];
-			bool good = true;
-			for (std::size_t idx = 0; idx < submitted_count; idx++) {
-				candidate_t submitted = top_data[idx];
-				distance_t inter_result_dist = context.measure( //
-				    citerator_at(candidate.slot),               //
-				    citerator_at(submitted.slot),               //
-				    metric);
-				if (inter_result_dist < candidate.distance) {
-					good = false;
-					break;
-				}
-			}
-
-			if (good) {
-				top_data[submitted_count] = top_data[consumed_count];
-				submitted_count++;
-			}
-			consumed_count++;
-		}
-
-		top.shrink(submitted_count);
-		return {top_data, submitted_count};
-	}
+#endif
+
+    /**
+     *  @brief  Performs compaction on the whole HNSW index, purging some entries
+     *          and links to them, while also generating a more efficient mapping,
+     *          putting the more frequently used entries closer together.
+     *
+     *  @param[in] values A []-subscriptable object, providing access to the values.
+     *  @param[in] metric Callable object measuring distance between any ::values and present objects.
+     *  @param[in] slot_transition Callable object to inform changes in slot assignments.
+     *  @param[in] executor Thread-pool to execute the job in parallel.
+     *  @param[in] progress Callback to report the execution progress.
+     *  @param[in] prefetch Callable object to prefetch data into the cache.
+     */
+    template <typename values_at, typename metric_at,                   //
+              typename slot_transition_at = dummy_key_to_key_mapping_t, //
+              typename executor_at = dummy_executor_t,                  //
+              typename progress_at = dummy_progress_t,                  //
+              typename prefetch_at = dummy_prefetch_t>
+    void compact(                             //
+        values_at&& values,                   //
+        metric_at&& metric,                   //
+        slot_transition_at&& slot_transition, //
+
+        executor_at&& executor = executor_at{}, //
+        progress_at&& progress = progress_at{}, //
+        prefetch_at&& prefetch = prefetch_at{}) noexcept {
+
+        // Export all the keys, slots, and levels.
+        // Partition them with the predicate.
+        // Sort the allowed entries in descending order of their level.
+        // Create a new array mapping old slots to the new ones (INT_MAX for deleted items).
+        struct slot_level_t {
+            compressed_slot_t old_slot;
+            compressed_slot_t cluster;
+            level_t level;
+        };
+        using slot_level_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<slot_level_t>;
+        buffer_gt<slot_level_t, slot_level_allocator_t> slots_and_levels(size());
+
+        // Progress status
+        std::atomic<bool> do_tasks{true};
+        std::atomic<std::size_t> processed{0};
+        std::size_t const total = 3 * slots_and_levels.size();
+
+        // For every bottom level node, determine its parent cluster
+        executor.dynamic(slots_and_levels.size(), [&](std::size_t thread_idx, std::size_t old_slot_as_uint) {
+            context_t& context = contexts_[thread_idx];
+            compressed_slot_t old_slot = static_cast<compressed_slot_t>(old_slot_as_uint);
+            compressed_slot_t cluster = search_for_one_( //
+                values[citerator_at(old_slot)],          //
+                metric, prefetch,                        //
+                static_cast<compressed_slot_t>(entry_slot_), max_level_, 0, context);
+            slots_and_levels[old_slot] = {old_slot, cluster, node_at_(old_slot).level()};
+            ++processed;
+            if (thread_idx == 0)
+                do_tasks = progress(processed.load(), total);
+            return do_tasks.load();
+        });
+        if (!do_tasks.load())
+            return;
+
+        // Where the actual permutation happens:
+        std::sort(slots_and_levels.begin(), slots_and_levels.end(), [](slot_level_t const& a, slot_level_t const& b) {
+            return a.level == b.level ? a.cluster < b.cluster : a.level > b.level;
+        });
+
+        using size_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<std::size_t>;
+        buffer_gt<std::size_t, size_allocator_t> old_slot_to_new(slots_and_levels.size());
+        for (std::size_t new_slot = 0; new_slot != slots_and_levels.size(); ++new_slot)
+            old_slot_to_new[slots_and_levels[new_slot].old_slot] = new_slot;
+
+        // Erase all the incoming links
+        buffer_gt<node_t, nodes_allocator_t> reordered_nodes(slots_and_levels.size());
+        tape_allocator_t reordered_tape;
+
+        for (std::size_t new_slot = 0; new_slot != slots_and_levels.size(); ++new_slot) {
+            std::size_t old_slot = slots_and_levels[new_slot].old_slot;
+            node_t old_node = node_at_(old_slot);
+
+            std::size_t node_bytes = node_bytes_(old_node.level());
+            byte_t* new_data = (byte_t*)reordered_tape.allocate(node_bytes);
+            node_t new_node{new_data};
+            std::memcpy(new_data, old_node.tape(), node_bytes);
+
+            for (level_t level = 0; level <= old_node.level(); ++level)
+                for (misaligned_ref_gt<compressed_slot_t> neighbor : neighbors_(new_node, level))
+                    neighbor = static_cast<compressed_slot_t>(old_slot_to_new[compressed_slot_t(neighbor)]);
+
+            reordered_nodes[new_slot] = new_node;
+            if (!progress(++processed, total))
+                return;
+        }
+
+        for (std::size_t new_slot = 0; new_slot != slots_and_levels.size(); ++new_slot) {
+            std::size_t old_slot = slots_and_levels[new_slot].old_slot;
+            slot_transition(node_at_(old_slot).ckey(),                //
+                            static_cast<compressed_slot_t>(old_slot), //
+                            static_cast<compressed_slot_t>(new_slot));
+            if (!progress(++processed, total))
+                return;
+        }
+
+        nodes_ = std::move(reordered_nodes);
+        tape_allocator_ = std::move(reordered_tape);
+        entry_slot_ = old_slot_to_new[entry_slot_];
+    }
+
+    /**
+     *  @brief  Scans the whole collection, removing the links leading towards
+     *          banned entries. This essentially isolates some nodes from the rest
+     *          of the graph, while keeping their outgoing links, in case the node
+     *          is structurally relevant and has a crucial role in the index.
+     *          It won't reclaim the memory.
+     *
+     *  @param[in] allow_member Predicate to mark nodes for isolation.
+     *  @param[in] executor Thread-pool to execute the job in parallel.
+     *  @param[in] progress Callback to report the execution progress.
+     */
+    template <                                        //
+        typename allow_member_at = dummy_predicate_t, //
+        typename executor_at = dummy_executor_t,      //
+        typename progress_at = dummy_progress_t       //
+        >
+    void isolate(                               //
+        allow_member_at&& allow_member,         //
+        executor_at&& executor = executor_at{}, //
+        progress_at&& progress = progress_at{}) noexcept {
+
+        // Progress status
+        std::atomic<bool> do_tasks{true};
+        std::atomic<std::size_t> processed{0};
+
+        // Erase all the incoming links
+        std::size_t nodes_count = size();
+        executor.dynamic(nodes_count, [&](std::size_t thread_idx, std::size_t node_idx) {
+            node_t node = node_at_(node_idx);
+            for (level_t level = 0; level <= node.level(); ++level) {
+                neighbors_ref_t neighbors = neighbors_(node, level);
+                neighbors.erase_if([&](compressed_slot_t neighbor_slot) {
+                    node_t neighbor = node_at_(neighbor_slot);
+                    return !allow_member(member_cref_t{neighbor.ckey(), neighbor_slot});
+                });
+            }
+            ++processed;
+            if (thread_idx == 0)
+                do_tasks = progress(processed.load(), nodes_count);
+            return do_tasks.load();
+        });
+
+        // At the end report the latest numbers, because the reporter thread may be finished earlier
+        progress(processed.load(), nodes_count);
+    }
+
+  private:
+    inline static precomputed_constants_t precompute_(index_config_t const& config) noexcept {
+        precomputed_constants_t pre;
+        pre.inverse_log_connectivity = 1.0 / std::log(static_cast<double>(config.connectivity));
+        pre.neighbors_bytes = config.connectivity * sizeof(compressed_slot_t) + sizeof(neighbors_count_t);
+        pre.neighbors_base_bytes = config.connectivity_base * sizeof(compressed_slot_t) + sizeof(neighbors_count_t);
+        return pre;
+    }
+
+    using span_bytes_t = span_gt<byte_t>;
+
+    inline span_bytes_t node_bytes_(node_t node) const noexcept { return {node.tape(), node_bytes_(node.level())}; }
+    inline std::size_t node_bytes_(level_t level) const noexcept {
+        return node_head_bytes_() + node_neighbors_bytes_(level);
+    }
+    inline std::size_t node_neighbors_bytes_(node_t node) const noexcept { return node_neighbors_bytes_(node.level()); }
+    inline std::size_t node_neighbors_bytes_(level_t level) const noexcept {
+        return pre_.neighbors_base_bytes + pre_.neighbors_bytes * level;
+    }
+
+    span_bytes_t node_malloc_(level_t level) noexcept {
+        std::size_t node_bytes = node_bytes_(level);
+        byte_t* data = (byte_t*)tape_allocator_.allocate(node_bytes);
+        return data ? span_bytes_t{data, node_bytes} : span_bytes_t{};
+    }
+
+    node_t node_make_(vector_key_t key, level_t level) noexcept {
+        span_bytes_t node_bytes = node_malloc_(level);
+        if (!node_bytes)
+            return {};
+
+        std::memset(node_bytes.data(), 0, node_bytes.size());
+        node_t node{(byte_t*)node_bytes.data()};
+        node.key(key);
+        node.level(level);
+        return node;
+    }
+
+    node_t node_make_copy_(span_bytes_t old_bytes) noexcept {
+        byte_t* data = (byte_t*)tape_allocator_.allocate(old_bytes.size());
+        if (!data)
+            return {};
+        std::memcpy(data, old_bytes.data(), old_bytes.size());
+        return node_t{data};
+    }
+
+    void node_free_(std::size_t idx) noexcept {
+        if (viewed_file_)
+            return;
+
+        node_t& node = nodes_[idx];
+        tape_allocator_.deallocate(node.tape(), node_bytes_(node).size());
+        node = node_t{};
+    }
+
+    inline node_t node_at_(std::size_t idx) const noexcept { return nodes_[idx]; }
+    inline neighbors_ref_t neighbors_base_(node_t node) const noexcept { return {node.neighbors_tape()}; }
+
+    inline neighbors_ref_t neighbors_non_base_(node_t node, level_t level) const noexcept {
+        usearch_assert_m(level > 0 && level <= node.level(), "Linking to missing level");
+        return {node.neighbors_tape() + pre_.neighbors_base_bytes + (level - 1) * pre_.neighbors_bytes};
+    }
+
+    inline neighbors_ref_t neighbors_(node_t node, level_t level) const noexcept {
+        return level ? neighbors_non_base_(node, level) : neighbors_base_(node);
+    }
+
+    struct node_lock_t {
+        nodes_mutexes_t& mutexes;
+        std::size_t slot;
+        inline ~node_lock_t() noexcept { mutexes.unlock(slot); }
+    };
+
+    inline node_lock_t node_lock_(std::size_t slot) const noexcept {
+        nodes_mutexes_.lock(slot);
+        return {nodes_mutexes_, slot};
+    }
+
+    struct optional_node_lock_t {
+        nodes_mutexes_t& mutexes;
+        std::size_t slot;
+        inline ~optional_node_lock_t() noexcept {
+            if (slot != (std::numeric_limits<std::size_t>::max)())
+                mutexes.unlock(slot);
+        }
+    };
+
+    inline optional_node_lock_t optional_node_lock_(std::size_t slot, bool condition) const noexcept {
+        if (condition) {
+            nodes_mutexes_.lock(slot);
+            return {nodes_mutexes_, slot};
+        } else {
+            return {nodes_mutexes_, (std::numeric_limits<std::size_t>::max)()};
+        }
+    }
+
+    struct node_conditional_lock_t {
+        nodes_mutexes_t& mutexes;
+        std::size_t slot;
+        inline ~node_conditional_lock_t() noexcept {
+            if (slot != (std::numeric_limits<std::size_t>::max)())
+                mutexes.unlock(slot);
+        }
+    };
+
+    inline node_conditional_lock_t node_try_conditional_lock_(std::size_t slot, bool condition,
+                                                              bool& failed_to_acquire) const noexcept {
+        if (!condition) {
+            failed_to_acquire = false;
+            return {nodes_mutexes_, (std::numeric_limits<std::size_t>::max)()};
+        }
+        failed_to_acquire = nodes_mutexes_.atomic_set(slot);
+        return {nodes_mutexes_, failed_to_acquire ? (std::numeric_limits<std::size_t>::max)() : slot};
+    }
+
+    template <typename metric_at, bool require_non_empty_ak = false>
+    candidates_view_t form_links_to_closest_( //
+        metric_at&& metric, std::size_t new_slot, level_t level, context_t& context) usearch_noexcept_m {
+
+        node_t new_node = node_at_(new_slot);
+        top_candidates_t& top = context.top_candidates;
+        usearch_assert_m(top.size() || !require_non_empty_ak, "No candidates found");
+        candidates_view_t top_view =
+            refine_(metric, config_.connectivity, top, context, context.computed_distances_in_refines);
+        usearch_assert_m(top_view.size() || !require_non_empty_ak, "This would lead to isolated nodes");
+
+        // Outgoing links from `new_slot`:
+        neighbors_ref_t new_neighbors = neighbors_(new_node, level);
+        usearch_assert_m(!new_neighbors.size(), "The newly inserted element should have blank link list");
+        for (std::size_t idx = 0; idx != top_view.size(); idx++) {
+            usearch_assert_m(!new_neighbors[idx], "Possible memory corruption");
+            usearch_assert_m(level <= node_at_(top_view[idx].slot).level(), "Linking to missing level");
+            new_neighbors.push_back(top_view[idx].slot);
+        }
+
+        return top_view;
+    }
+
+    template <typename value_at, typename metric_at>
+    void form_reverse_links_( //
+        metric_at&& metric, compressed_slot_t new_slot, candidates_view_t new_neighbors, value_at&& value,
+        level_t level, context_t& context) usearch_noexcept_m {
+
+        top_candidates_t& top_for_refine = context.top_for_refine;
+        std::size_t const connectivity_max = level ? config_.connectivity : config_.connectivity_base;
+
+        // Reverse links from the neighbors:
+        for (auto new_neighbor : new_neighbors) {
+            compressed_slot_t close_slot = new_neighbor.slot;
+            if (close_slot == new_slot)
+                continue;
+            node_lock_t close_lock = node_lock_(close_slot);
+            node_t close_node = node_at_(close_slot);
+            neighbors_ref_t close_header = neighbors_(close_node, level);
+
+            // The node may have no neighbors only in one case, when it's the first one in the index,
+            // but that is problematic to track in multi-threaded environments, where the order of insertion
+            // is not guaranteed.
+            // usearch_assert_m(close_header.size() || new_slot == 1, "Possible corruption - isolated node");
+            usearch_assert_m(close_header.size() <= connectivity_max, "Possible corruption - overflow");
+            usearch_assert_m(close_slot != new_slot, "Self-loops are impossible");
+            usearch_assert_m(level <= close_node.level(), "Linking to missing level");
+
+            // Skip to prevent duplicate entries in the neighbor list.
+            if (std::find_if(close_header.begin(), close_header.end(),
+                             [new_slot](compressed_slot_t slot) { return slot == new_slot; }) != close_header.end()) {
+                continue;
+            }
+
+            if (close_header.size() < connectivity_max) {
+                close_header.push_back(new_slot);
+                continue;
+            }
+
+            top_for_refine.clear();
+            top_for_refine.insert_reserved({context.measure(value, citerator_at(close_slot), metric), new_slot});
+            for (compressed_slot_t successor_slot : close_header)
+                top_for_refine.insert_reserved(
+                    {context.measure(citerator_at(close_slot), citerator_at(successor_slot), metric), successor_slot});
+
+            // Export the results:
+            close_header.clear();
+            candidates_view_t top_view = refine_(metric, connectivity_max, top_for_refine, context,
+                                                 context.computed_distances_in_reverse_refines, new_slot, value);
+            usearch_assert_m(top_view.size(), "This would lead to isolated nodes");
+            for (std::size_t idx = 0; idx != top_view.size(); idx++)
+                close_header.push_back(top_view[idx].slot);
+        }
+    }
+
+    level_t choose_random_level_(std::default_random_engine& level_generator) const noexcept {
+        std::uniform_real_distribution<double> distribution(0.0, 1.0);
+        double r = -std::log(distribution(level_generator)) * pre_.inverse_log_connectivity;
+        return (level_t)r;
+    }
+
+    struct candidates_range_t;
+    class candidates_iterator_t {
+        friend struct candidates_range_t;
+
+        index_gt const& index_;
+        neighbors_ref_t neighbors_;
+        visits_hash_set_t& visits_;
+        std::size_t current_;
+
+        candidates_iterator_t& skip_missing() noexcept {
+            if (!visits_.size())
+                return *this;
+            while (current_ != neighbors_.size()) {
+                compressed_slot_t neighbor_slot = neighbors_[current_];
+                if (visits_.test(neighbor_slot))
+                    current_++;
+                else
+                    break;
+            }
+            return *this;
+        }
+
+      public:
+        using element_t = compressed_slot_t;
+        using iterator_category = std::forward_iterator_tag;
+        using value_type = element_t;
+        using difference_type = std::ptrdiff_t;
+        using pointer = misaligned_ptr_gt<element_t>;
+        using reference = misaligned_ref_gt<element_t>;
+
+        value_type operator*() const noexcept { return neighbors_[current_]; }
+        candidates_iterator_t(index_gt const& index, neighbors_ref_t neighbors, visits_hash_set_t& visits,
+                              std::size_t progress) noexcept
+            : index_(index), neighbors_(neighbors), visits_(visits), current_(progress) {}
+        candidates_iterator_t operator++(int) noexcept {
+            candidates_iterator_t old(index_, neighbors_, visits_, current_);
+            ++(*this);
+            return old;
+        }
+        candidates_iterator_t& operator++() noexcept {
+            ++current_;
+            skip_missing();
+            return *this;
+        }
+        bool operator==(candidates_iterator_t const& other) noexcept { return current_ == other.current_; }
+        bool operator!=(candidates_iterator_t const& other) noexcept { return current_ != other.current_; }
+
+        vector_key_t key() const noexcept { return index_.node_at_(slot()).key(); }
+        compressed_slot_t slot() const noexcept { return neighbors_[current_]; }
+        friend inline std::size_t get_slot(candidates_iterator_t const& it) noexcept { return it.slot(); }
+        friend inline vector_key_t get_key(candidates_iterator_t const& it) noexcept { return it.key(); }
+    };
+
+    struct candidates_range_t {
+        index_gt const& index;
+        neighbors_ref_t neighbors;
+        visits_hash_set_t& visits;
+
+        candidates_iterator_t begin() const noexcept {
+            return candidates_iterator_t{index, neighbors, visits, 0}.skip_missing();
+        }
+        candidates_iterator_t end() const noexcept { return {index, neighbors, visits, neighbors.size()}; }
+    };
+
+    template <typename value_at, typename metric_at, typename prefetch_at = dummy_prefetch_t>
+    compressed_slot_t search_for_one_(                                //
+        value_at&& query, metric_at&& metric, prefetch_at&& prefetch, //
+        compressed_slot_t closest_slot, level_t begin_level, level_t end_level, context_t& context) const noexcept {
+
+        visits_hash_set_t& visits = context.visits;
+        visits.clear();
+
+        // Optional prefetching
+        if (!is_dummy<prefetch_at>())
+            prefetch(citerator_at(closest_slot), citerator_at(closest_slot) + 1);
+
+        bool const need_lock = !is_immutable();
+        distance_t closest_dist = context.measure(query, citerator_at(closest_slot), metric);
+        for (level_t level = begin_level; level > end_level; --level) {
+            bool changed;
+            do {
+                changed = false;
+                optional_node_lock_t closest_lock = optional_node_lock_(closest_slot, need_lock);
+                neighbors_ref_t closest_neighbors = neighbors_non_base_(node_at_(closest_slot), level);
+
+                // Optional prefetching
+                if (!is_dummy<prefetch_at>()) {
+                    candidates_range_t missing_candidates{*this, closest_neighbors, visits};
+                    prefetch(missing_candidates.begin(), missing_candidates.end());
+                }
+
+                // Actual traversal
+                for (compressed_slot_t candidate_slot : closest_neighbors) {
+                    distance_t candidate_dist = context.measure(query, citerator_at(candidate_slot), metric);
+                    if (candidate_dist < closest_dist) {
+                        closest_dist = candidate_dist;
+                        closest_slot = candidate_slot;
+                        changed = true;
+                    }
+                }
+
+                context.iteration_cycles++;
+            } while (changed);
+        }
+        return closest_slot;
+    }
+
+    /**
+     *  @brief  Traverses a layer of a graph, to find the best place to insert a new node.
+     *          Locks the nodes in the process, assuming other threads are updating neighbors lists.
+     *  @return `true` if procedure succeeded, `false` if run out of memory.
+     */
+    template <typename value_at, typename metric_at, typename prefetch_at = dummy_prefetch_t>
+    bool search_to_insert_(                                           //
+        value_at&& query, metric_at&& metric, prefetch_at&& prefetch, //
+        compressed_slot_t start_slot, level_t level, std::size_t top_limit, context_t& context) noexcept {
+
+        visits_hash_set_t& visits = context.visits;
+        next_candidates_t& next = context.next_candidates; // pop min, push
+        top_candidates_t& top = context.top_candidates;    // pop max, push
+
+        visits.clear();
+        next.clear();
+        top.clear();
+
+        // At the very least we are going to explore the starting node and its neighbors
+        if (!visits.reserve(config_.connectivity_base + 1u))
+            return false;
+        if (!top.reserve(top_limit))
+            return false;
+        if (!next.reserve(top_limit))
+            return false;
+
+        // Optional prefetching
+        if (!is_dummy<prefetch_at>())
+            prefetch(citerator_at(start_slot), citerator_at(start_slot) + 1);
+
+        distance_t radius = context.measure(query, citerator_at(start_slot), metric);
+        next.insert_reserved({-radius, start_slot});
+        top.insert_reserved({radius, start_slot});
+        visits.set(start_slot);
+
+        // The primary loop of the graph traversal
+        while (!next.empty()) {
+
+            candidate_t candidacy = next.top();
+            if ((-candidacy.distance) > radius && top.size() == top_limit)
+                break;
+
+            next.pop();
+            context.iteration_cycles++;
+
+            compressed_slot_t candidate_slot = candidacy.slot;
+            node_t candidate_ref = node_at_(candidate_slot);
+            node_lock_t candidate_lock = node_lock_(candidate_slot);
+            neighbors_ref_t candidate_neighbors = neighbors_(candidate_ref, level);
+
+            // Optional prefetching
+            if (!is_dummy<prefetch_at>()) {
+                candidates_range_t missing_candidates{*this, candidate_neighbors, visits};
+                prefetch(missing_candidates.begin(), missing_candidates.end());
+            }
+
+            // Assume the worst-case when reserving memory
+            if (!visits.reserve(visits.size() + candidate_neighbors.size()))
+                return false;
+
+            for (compressed_slot_t successor_slot : candidate_neighbors) {
+                if (visits.set(successor_slot))
+                    continue;
+
+                // We don't access the neighbors of the `successor_slot` node,
+                // so we don't have to lock it.
+                // node_lock_t successor_lock = node_lock_(successor_slot);
+                distance_t successor_dist = context.measure(query, citerator_at(successor_slot), metric);
+                if (top.size() < top_limit || successor_dist < radius) {
+                    // This can substantially grow our priority queue:
+                    next.insert({-successor_dist, successor_slot});
+                    // This will automatically evict poor matches:
+                    top.insert({successor_dist, successor_slot}, top_limit);
+                    radius = top.top().distance;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     *  @brief  Traverses a layer of a graph, to find the best neighbors list for updated node.
+     *          Locks the nodes in the process, assuming other threads are updating neighbors lists.
+     *  @return `true` if procedure succeeded, `false` if run out of memory.
+     */
+    template <typename value_at, typename metric_at, typename prefetch_at = dummy_prefetch_t>
+    bool search_to_update_(                                           //
+        value_at&& query, metric_at&& metric, prefetch_at&& prefetch, //
+        compressed_slot_t start_slot, compressed_slot_t updated_slot, level_t level, std::size_t top_limit,
+        context_t& context) noexcept {
+
+        visits_hash_set_t& visits = context.visits;
+        next_candidates_t& next = context.next_candidates; // pop min, push
+        top_candidates_t& top = context.top_candidates;    // pop max, push
+
+        visits.clear();
+        next.clear();
+        top.clear();
+
+        // At the very least we are going to explore the starting node and its neighbors
+        if (!visits.reserve(config_.connectivity_base + 1u))
+            return false;
+        if (!top.reserve(top_limit))
+            return false;
+        if (!next.reserve(top_limit))
+            return false;
+
+        // Optional prefetching
+        if (!is_dummy<prefetch_at>())
+            prefetch(citerator_at(start_slot), citerator_at(start_slot) + 1);
+
+        distance_t radius = context.measure(query, citerator_at(start_slot), metric);
+        next.insert_reserved({-radius, start_slot});
+        visits.set(start_slot);
+        if (start_slot != updated_slot)
+            top.insert_reserved({radius, start_slot});
+
+        // The primary loop of the graph traversal
+        while (!next.empty()) {
+
+            candidate_t candidacy = next.top();
+            if ((-candidacy.distance) > radius && top.size() == top_limit)
+                break;
+
+            next.pop();
+            context.iteration_cycles++;
+
+            compressed_slot_t candidate_slot = candidacy.slot;
+            node_t candidate_ref = node_at_(candidate_slot);
+
+            // The trickiest part of update-heavy workloads is mitigating dead-locks
+            // in connected nodes during traversal. A "good enough" solution would be
+            // to skip concurrent access, assuming the other "close" node is gonna add
+            // this one when forming reverse connections.
+            bool failed_to_acquire = false;
+            node_conditional_lock_t candidate_lock =
+                node_try_conditional_lock_(candidate_slot, updated_slot != candidate_slot, failed_to_acquire);
+            if (failed_to_acquire)
+                continue;
+            auto optional_node_lock = optional_node_lock_(candidate_slot, updated_slot == candidate_slot);
+            neighbors_ref_t candidate_neighbors = neighbors_(candidate_ref, level);
+
+            // Optional prefetching
+            if (!is_dummy<prefetch_at>()) {
+                candidates_range_t missing_candidates{*this, candidate_neighbors, visits};
+                prefetch(missing_candidates.begin(), missing_candidates.end());
+            }
+
+            // Assume the worst-case when reserving memory
+            if (!visits.reserve(visits.size() + candidate_neighbors.size()))
+                return false;
+
+            for (compressed_slot_t successor_slot : candidate_neighbors) {
+                if (visits.set(successor_slot))
+                    continue;
+
+                // We don't access the neighbors of the `successor_slot` node,
+                // so we don't have to lock it.
+                // node_conditional_lock_t successor_lock =
+                //     node_try_conditional_lock_(successor_slot, updated_slot != successor_slot);
+                distance_t successor_dist = context.measure(query, citerator_at(successor_slot), metric);
+                if (top.size() < top_limit || successor_dist < radius) {
+                    // This can substantially grow our priority queue:
+                    next.insert({-successor_dist, successor_slot});
+                    // This will automatically evict poor matches:
+                    if (updated_slot != successor_slot)
+                        top.insert({successor_dist, successor_slot}, top_limit);
+                    radius = top.top().distance;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     *  @brief  Traverses the @b base layer of a graph, to find a close match.
+     *          Doesn't lock any nodes, assuming read-only simultaneous access.
+     *  @return `true` if procedure succeeded, `false` if run out of memory.
+     */
+    template <typename value_at, typename metric_at, typename predicate_at, typename prefetch_at>
+    bool search_to_find_in_base_(                                                               //
+        value_at&& query, metric_at&& metric, predicate_at&& predicate, prefetch_at&& prefetch, //
+        compressed_slot_t start_slot, std::size_t expansion, context_t& context) const usearch_noexcept_m {
+
+        visits_hash_set_t& visits = context.visits;
+        next_candidates_t& next = context.next_candidates; // pop min, push
+        top_candidates_t& top = context.top_candidates;    // pop max, push
+        std::size_t const top_limit = expansion;
+
+        visits.clear();
+        next.clear();
+        top.clear();
+        if (!visits.reserve(config_.connectivity_base + 1u))
+            return false;
+
+        // Optional prefetching
+        if (!is_dummy<prefetch_at>())
+            prefetch(citerator_at(start_slot), citerator_at(start_slot) + 1);
+
+        distance_t radius = context.measure(query, citerator_at(start_slot), metric);
+        usearch_assert_m(next.capacity(), "The `max_heap_gt` must have been reserved in the search entry point");
+        next.insert_reserved({-radius, start_slot});
+        visits.set(start_slot);
+
+        // Don't populate the top list if the predicate is not satisfied
+        if (is_dummy<predicate_at>() || predicate(member_cref_t{node_at_(start_slot).ckey(), start_slot})) {
+            usearch_assert_m(top.capacity(),
+                             "The `sorted_buffer_gt` must have been reserved in the search entry point");
+            top.insert_reserved({radius, start_slot});
+        }
+
+        while (!next.empty()) {
+
+            candidate_t candidate = next.top();
+            if ((-candidate.distance) > radius && top.size() == top_limit)
+                break;
+
+            next.pop();
+            context.iteration_cycles++;
+
+            neighbors_ref_t candidate_neighbors = neighbors_base_(node_at_(candidate.slot));
+
+            // Optional prefetching
+            if (!is_dummy<prefetch_at>()) {
+                candidates_range_t missing_candidates{*this, candidate_neighbors, visits};
+                prefetch(missing_candidates.begin(), missing_candidates.end());
+            }
+
+            // Assume the worst-case when reserving memory
+            if (!visits.reserve(visits.size() + candidate_neighbors.size()))
+                return false;
+
+            for (compressed_slot_t successor_slot : candidate_neighbors) {
+                if (visits.set(successor_slot))
+                    continue;
+
+                distance_t successor_dist = context.measure(query, citerator_at(successor_slot), metric);
+                if (top.size() < top_limit || successor_dist < radius) {
+                    // This can substantially grow our priority queue:
+                    next.insert({-successor_dist, successor_slot});
+                    if (is_dummy<predicate_at>() ||
+                        predicate(member_cref_t{node_at_(successor_slot).ckey(), successor_slot})) {
+                        top.insert({successor_dist, successor_slot}, top_limit);
+                        radius = top.top().distance;
+                    }
+                }
+            }
+        }
+
+        return true;
+    }
+
+    /**
+     *  @brief  Iterates through all members, without actually touching the index.
+     */
+    template <typename value_at, typename metric_at, typename predicate_at>
+    void search_exact_(                                                 //
+        value_at&& query, metric_at&& metric, predicate_at&& predicate, //
+        std::size_t count, context_t& context) const noexcept {
+
+        top_candidates_t& top = context.top_candidates;
+        top.clear();
+        top.reserve(count);
+        for (std::size_t i = 0; i != size(); ++i) {
+            auto slot = static_cast<compressed_slot_t>(i);
+            if (!is_dummy<predicate_at>())
+                if (!predicate(at(slot)))
+                    continue;
+
+            distance_t distance = context.measure(query, citerator_at(slot), metric);
+            top.insert(candidate_t{distance, slot}, count);
+        }
+    }
+
+    /// @brief  Helper for `refine_()`: computes inter-neighbor distance, substituting
+    ///         @p override_value when either slot matches @p override_slot.
+    ///         The `std::nullptr_t` overload below avoids instantiating the override
+    ///         branch when no override is provided, keeping the code C++11 compatible.
+    template <typename metric_at, typename override_value_at>
+    distance_t inter_neighbor_distance_(                                   //
+        candidate_t const& candidate, candidate_t const& submitted,        //
+        compressed_slot_t override_slot, override_value_at override_value, //
+        metric_at&& metric, context_t& context) const noexcept {
+        if (candidate.slot == override_slot)
+            return context.measure(override_value, citerator_at(submitted.slot), metric);
+        else if (submitted.slot == override_slot)
+            return context.measure(override_value, citerator_at(candidate.slot), metric);
+        else
+            return context.measure(citerator_at(candidate.slot), citerator_at(submitted.slot), metric);
+    }
+
+    template <typename metric_at>
+    distance_t inter_neighbor_distance_(                            //
+        candidate_t const& candidate, candidate_t const& submitted, //
+        compressed_slot_t, std::nullptr_t,                          //
+        metric_at&& metric, context_t& context) const noexcept {
+        return context.measure(citerator_at(candidate.slot), citerator_at(submitted.slot), metric);
+    }
+
+    /**
+     *  @brief  This algorithm from the original paper implements a heuristic,
+     *          that massively reduces the number of connections a point has,
+     *          to keep only the neighbors, that are from each other.
+     *
+     *  @param[in] override_slot  Optional slot whose stored vector is stale (e.g. during update,
+     *                            where the callback has not yet committed the new vector).
+     *                            When set, inter-result distances involving this slot will use
+     *                            @p override_value instead of reading from `citerator_at()`.
+     *  @param[in] override_value The up-to-date vector for @p override_slot. Only used when
+     *                            @p override_value_at is not `std::nullptr_t`.
+     */
+    template <typename metric_at, typename override_value_at = std::nullptr_t>
+    candidates_view_t refine_(                                         //
+        metric_at&& metric,                                            //
+        std::size_t needed, top_candidates_t& top, context_t& context, //
+        std::size_t& refines_counter,                                  //
+        compressed_slot_t override_slot = ((std::numeric_limits<compressed_slot_t>::max))(),
+        override_value_at override_value = {}) const noexcept {
+
+        // Avoid expensive computation, if the set is already small
+        candidate_t* top_data = top.data();
+        std::size_t const top_count = top.size();
+        if (top_count < needed)
+            return {top_data, top_count};
+
+        // Sort before processing
+        top.sort_ascending();
+
+        std::size_t submitted_count = 1;
+        std::size_t consumed_count = 1; /// Always equal or greater than `submitted_count`.
+        while (submitted_count < needed && consumed_count < top_count) {
+            candidate_t candidate = top_data[consumed_count];
+            bool good = true;
+            std::size_t idx = 0;
+            for (; idx < submitted_count; idx++) {
+                candidate_t submitted = top_data[idx];
+                distance_t inter_result_dist = inter_neighbor_distance_( //
+                    candidate, submitted, override_slot, override_value, metric, context);
+                if (inter_result_dist < candidate.distance) {
+                    good = false;
+                    break;
+                }
+            }
+            refines_counter += idx;
+
+            if (good) {
+                top_data[submitted_count] = top_data[consumed_count];
+                submitted_count++;
+            }
+            consumed_count++;
+        }
+
+        top.shrink(submitted_count);
+        return {top_data, submitted_count};
+    }
 };
 
 struct join_result_t {
-	error_t error {};
-	std::size_t intersection_size {};
-	std::size_t engagements {};
-	std::size_t visited_members {};
-	std::size_t computed_distances {};
+    error_t error{};
+    std::size_t intersection_size{};
+    std::size_t engagements{};
+    std::size_t visited_members{};
+    std::size_t computed_distances{};
 
-	explicit operator bool() const noexcept {
-		return !error;
-	}
-	join_result_t failed(error_t message) noexcept {
-		error = std::move(message);
-		return std::move(*this);
-	}
+    explicit operator bool() const noexcept { return !error; }
+    join_result_t failed(error_t message) noexcept {
+        error = std::move(message);
+        return std::move(*this);
+    }
 };
 
 /**
@@ -4104,188 +4561,189 @@ template < //
     typename progress_at = dummy_progress_t                //
     >
 static join_result_t join(               //
-    men_at const &men,                   //
-    women_at const &women,               //
-    men_values_at const &men_values,     //
-    women_values_at const &women_values, //
-    men_metric_at &&men_metric,          //
-    women_metric_at &&women_metric,      //
+    men_at const& men,                   //
+    women_at const& women,               //
+    men_values_at const& men_values,     //
+    women_values_at const& women_values, //
+    men_metric_at&& men_metric,          //
+    women_metric_at&& women_metric,      //
 
-    index_join_config_t config = {},                     //
-    man_to_woman_at &&man_to_woman = man_to_woman_at {}, //
-    woman_to_man_at &&woman_to_man = woman_to_man_at {}, //
-    executor_at &&executor = executor_at {},             //
-    progress_at &&progress = progress_at {}) noexcept {
+    index_join_config_t config = {},                    //
+    man_to_woman_at&& man_to_woman = man_to_woman_at{}, //
+    woman_to_man_at&& woman_to_man = woman_to_man_at{}, //
+    executor_at&& executor = executor_at{},             //
+    progress_at&& progress = progress_at{}) noexcept {
 
-	if (women.size() < men.size())
-		return unum::usearch::join(                                                               //
-		    women, men,                                                                           //
-		    women_values, men_values,                                                             //
-		    std::forward<women_metric_at>(women_metric), std::forward<men_metric_at>(men_metric), //
+    if (women.size() < men.size())
+        return unum::usearch::join(                                                               //
+            women, men,                                                                           //
+            women_values, men_values,                                                             //
+            std::forward<women_metric_at>(women_metric), std::forward<men_metric_at>(men_metric), //
 
-		    config,                                      //
-		    std::forward<woman_to_man_at>(woman_to_man), //
-		    std::forward<man_to_woman_at>(man_to_woman), //
-		    std::forward<executor_at>(executor),         //
-		    std::forward<progress_at>(progress));
+            config,                                      //
+            std::forward<woman_to_man_at>(woman_to_man), //
+            std::forward<man_to_woman_at>(man_to_woman), //
+            std::forward<executor_at>(executor),         //
+            std::forward<progress_at>(progress));
 
-	join_result_t result;
+    join_result_t result;
 
-	// Sanity checks and argument validation:
-	if (&men == &women)
-		return result.failed("Can't join with itself, consider copying");
+    // Sanity checks and argument validation:
+    if (&men == &women)
+        return result.failed("Can't join with itself, consider copying");
 
-	if (config.max_proposals == 0)
-		config.max_proposals = std::log(men.size()) + executor.size();
+    if (config.max_proposals == 0)
+        config.max_proposals = static_cast<std::size_t>(std::log(men.size())) + executor.size();
 
-	using proposals_count_t = std::uint16_t;
-	config.max_proposals = (std::min)(men.size(), config.max_proposals);
+    using proposals_count_t = std::uint16_t;
+    config.max_proposals = (std::min)(men.size(), config.max_proposals);
 
-	using distance_t = typename men_at::distance_t;
-	using dynamic_allocator_traits_t = typename men_at::dynamic_allocator_traits_t;
-	using man_key_t = typename men_at::vector_key_t;
-	using woman_key_t = typename women_at::vector_key_t;
+    using distance_t = typename men_at::distance_t;
+    using dynamic_allocator_traits_t = typename men_at::dynamic_allocator_traits_t;
+    using man_key_t = typename men_at::vector_key_t;
+    using woman_key_t = typename women_at::vector_key_t;
 
-	// Use the `compressed_slot_t` type of the larger collection
-	using compressed_slot_t = typename women_at::compressed_slot_t;
-	using compressed_slot_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<compressed_slot_t>;
-	using proposals_count_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<proposals_count_t>;
+    // Use the `compressed_slot_t` type of the larger collection
+    using compressed_slot_t = typename women_at::compressed_slot_t;
+    using compressed_slot_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<compressed_slot_t>;
+    using proposals_count_allocator_t = typename dynamic_allocator_traits_t::template rebind_alloc<proposals_count_t>;
 
-	// Create an atomic queue, as a ring structure, from/to which
-	// free men will be added/pulled.
-	std::mutex free_men_mutex {};
-	ring_gt<compressed_slot_t, compressed_slot_allocator_t> free_men;
-	free_men.reserve(men.size());
-	for (std::size_t i = 0; i != men.size(); ++i)
-		free_men.push(static_cast<compressed_slot_t>(i));
+    // Create an atomic queue, as a ring structure, from/to which
+    // free men will be added/pulled.
+    std::mutex free_men_mutex{};
+    ring_gt<compressed_slot_t, compressed_slot_allocator_t> free_men;
+    free_men.reserve(men.size());
+    for (std::size_t i = 0; i != men.size(); ++i)
+        free_men.push(static_cast<compressed_slot_t>(i));
 
-	// We are gonna need some temporary memory.
-	buffer_gt<proposals_count_t, proposals_count_allocator_t> proposal_counts(men.size());
-	buffer_gt<compressed_slot_t, compressed_slot_allocator_t> man_to_woman_slots(men.size());
-	buffer_gt<compressed_slot_t, compressed_slot_allocator_t> woman_to_man_slots(women.size());
-	if (!proposal_counts || !man_to_woman_slots || !woman_to_man_slots)
-		return result.failed("Can't temporary mappings");
+    // We are gonna need some temporary memory.
+    buffer_gt<proposals_count_t, proposals_count_allocator_t> proposal_counts(men.size());
+    buffer_gt<compressed_slot_t, compressed_slot_allocator_t> man_to_woman_slots(men.size());
+    buffer_gt<compressed_slot_t, compressed_slot_allocator_t> woman_to_man_slots(women.size());
+    if (!proposal_counts || !man_to_woman_slots || !woman_to_man_slots)
+        return result.failed("Can't temporary mappings");
 
-	compressed_slot_t missing_slot;
-	std::memset((void *)&missing_slot, 0xFF, sizeof(compressed_slot_t));
-	std::memset((void *)man_to_woman_slots.data(), 0xFF, sizeof(compressed_slot_t) * men.size());
-	std::memset((void *)woman_to_man_slots.data(), 0xFF, sizeof(compressed_slot_t) * women.size());
-	std::memset(proposal_counts.data(), 0, sizeof(proposals_count_t) * men.size());
+    compressed_slot_t missing_slot;
+    std::memset((void*)&missing_slot, 0xFF, sizeof(compressed_slot_t));
+    std::memset((void*)man_to_woman_slots.data(), 0xFF, sizeof(compressed_slot_t) * men.size());
+    std::memset((void*)woman_to_man_slots.data(), 0xFF, sizeof(compressed_slot_t) * women.size());
+    std::memset(proposal_counts.data(), 0, sizeof(proposals_count_t) * men.size());
 
-	// Define locks, to limit concurrent accesses to `man_to_woman_slots` and `woman_to_man_slots`.
-	bitset_t men_locks(men.size()), women_locks(women.size());
-	if (!men_locks || !women_locks)
-		return result.failed("Can't allocate locks");
+    // Define locks, to limit concurrent accesses to `man_to_woman_slots` and `woman_to_man_slots`.
+    bitset_t men_locks(men.size()), women_locks(women.size());
+    if (!men_locks || !women_locks)
+        return result.failed("Can't allocate locks");
 
-	std::atomic<std::size_t> rounds {0};
-	std::atomic<std::size_t> engagements {0};
-	std::atomic<std::size_t> computed_distances {0};
-	std::atomic<std::size_t> visited_members {0};
-	std::atomic<char const *> atomic_error {nullptr};
+    std::atomic<std::size_t> rounds{0};
+    std::atomic<std::size_t> engagements{0};
+    std::atomic<std::size_t> computed_distances{0};
+    std::atomic<std::size_t> visited_members{0};
+    std::atomic<char const*> atomic_error{nullptr};
 
-	// Concurrently process all the men
-	executor.parallel([&](std::size_t thread_idx) {
-		index_search_config_t search_config;
-		search_config.expansion = config.expansion;
-		search_config.exact = config.exact;
-		search_config.thread = thread_idx;
-		compressed_slot_t free_man_slot;
+    // Concurrently process all the men
+    executor.parallel([&](std::size_t thread_idx) {
+        index_search_config_t search_config;
+        search_config.expansion = config.expansion;
+        search_config.exact = config.exact;
+        search_config.thread = thread_idx;
+        compressed_slot_t free_man_slot;
 
-		// While there exist a free man who still has a woman to propose to.
-		while (!atomic_error.load(std::memory_order_relaxed)) {
-			std::size_t passed_rounds = 0;
-			std::size_t total_rounds = 0;
-			{
-				std::unique_lock<std::mutex> pop_lock(free_men_mutex);
-				if (!free_men.try_pop(free_man_slot))
-					// Primary exit path, we have exhausted the list of candidates
-					break;
-				passed_rounds = ++rounds;
-				total_rounds = passed_rounds + free_men.size();
-			}
-			if (thread_idx == 0 && !progress(passed_rounds, total_rounds)) {
-				atomic_error.store("Terminated by user");
-				break;
-			}
-			while (men_locks.atomic_set(free_man_slot))
-				;
+        // While there exist a free man who still has a woman to propose to.
+        while (!atomic_error.load(std::memory_order_relaxed)) {
+            std::size_t passed_rounds = 0;
+            std::size_t total_rounds = 0;
+            {
+                std::unique_lock<std::mutex> pop_lock(free_men_mutex);
+                if (!free_men.try_pop(free_man_slot))
+                    // Primary exit path, we have exhausted the list of candidates
+                    break;
+                passed_rounds = ++rounds;
+                total_rounds = passed_rounds + free_men.size();
+            }
+            if (thread_idx == 0 && !progress(passed_rounds, total_rounds)) {
+                atomic_error.store("Terminated by user");
+                break;
+            }
+            while (men_locks.atomic_set(free_man_slot))
+                ;
 
-			proposals_count_t &free_man_proposals = proposal_counts[free_man_slot];
-			if (free_man_proposals >= config.max_proposals)
-				continue;
+            proposals_count_t& free_man_proposals = proposal_counts[free_man_slot];
+            if (free_man_proposals >= config.max_proposals)
+                continue;
 
-			// Find the closest woman, to whom this man hasn't proposed yet.
-			++free_man_proposals;
-			auto candidates = women.search(men_values[free_man_slot], free_man_proposals, women_metric, search_config);
-			visited_members += candidates.visited_members;
-			computed_distances += candidates.computed_distances;
-			if (!candidates) {
-				atomic_error = candidates.error.release();
-				break;
-			}
+            // Find the closest woman, to whom this man hasn't proposed yet.
+            ++free_man_proposals;
+            auto candidates = women.search(men_values[free_man_slot], free_man_proposals, women_metric, search_config);
+            visited_members += candidates.visited_members;
+            computed_distances += candidates.computed_distances;
+            if (!candidates) {
+                atomic_error = candidates.error.release();
+                break;
+            }
 
-			auto match = candidates.back();
-			auto woman = match.member;
-			while (women_locks.atomic_set(woman.slot))
-				;
+            auto match = candidates.back();
+            auto woman = match.member;
+            while (women_locks.atomic_set(woman.slot))
+                ;
 
-			compressed_slot_t husband_slot = woman_to_man_slots[woman.slot];
-			bool woman_is_free = husband_slot == missing_slot;
-			if (woman_is_free) {
-				// Engagement
-				man_to_woman_slots[free_man_slot] = woman.slot;
-				woman_to_man_slots[woman.slot] = free_man_slot;
-				engagements++;
-			} else {
-				distance_t distance_from_husband = women_metric(women_values[woman.slot], men_values[husband_slot]);
-				distance_t distance_from_candidate = match.distance;
-				if (distance_from_husband > distance_from_candidate) {
-					// Break-up
-					while (men_locks.atomic_set(husband_slot))
-						;
-					man_to_woman_slots[husband_slot] = missing_slot;
-					men_locks.atomic_reset(husband_slot);
+            compressed_slot_t husband_slot = woman_to_man_slots[woman.slot];
+            bool woman_is_free = husband_slot == missing_slot;
+            if (woman_is_free) {
+                // Engagement
+                man_to_woman_slots[free_man_slot] = static_cast<compressed_slot_t>(woman.slot);
+                woman_to_man_slots[woman.slot] = free_man_slot;
+                engagements++;
+            } else {
+                distance_t distance_from_husband =
+                    women_metric(women_values[static_cast<compressed_slot_t>(woman.slot)], men_values[husband_slot]);
+                distance_t distance_from_candidate = match.distance;
+                if (distance_from_husband > distance_from_candidate) {
+                    // Break-up
+                    while (men_locks.atomic_set(husband_slot))
+                        ;
+                    man_to_woman_slots[husband_slot] = missing_slot;
+                    men_locks.atomic_reset(husband_slot);
 
-					// New Engagement
-					man_to_woman_slots[free_man_slot] = woman.slot;
-					woman_to_man_slots[woman.slot] = free_man_slot;
-					engagements++;
+                    // New Engagement
+                    man_to_woman_slots[free_man_slot] = static_cast<compressed_slot_t>(woman.slot);
+                    woman_to_man_slots[woman.slot] = free_man_slot;
+                    engagements++;
 
-					std::unique_lock<std::mutex> push_lock(free_men_mutex);
-					free_men.push(husband_slot);
-				} else {
-					std::unique_lock<std::mutex> push_lock(free_men_mutex);
-					free_men.push(free_man_slot);
-				}
-			}
+                    std::unique_lock<std::mutex> push_lock(free_men_mutex);
+                    free_men.push(husband_slot);
+                } else {
+                    std::unique_lock<std::mutex> push_lock(free_men_mutex);
+                    free_men.push(free_man_slot);
+                }
+            }
 
-			men_locks.atomic_reset(free_man_slot);
-			women_locks.atomic_reset(woman.slot);
-		}
-	});
+            men_locks.atomic_reset(free_man_slot);
+            women_locks.atomic_reset(woman.slot);
+        }
+    });
 
-	if (atomic_error)
-		return result.failed(atomic_error.load());
+    if (atomic_error)
+        return result.failed(atomic_error.load());
 
-	// Export the "slots" into keys:
-	std::size_t intersection_size = 0;
-	for (std::size_t man_slot = 0; man_slot != men.size(); ++man_slot) {
-		compressed_slot_t woman_slot = man_to_woman_slots[man_slot];
-		if (woman_slot != missing_slot) {
-			man_key_t man = men.at(man_slot).key;
-			woman_key_t woman = women.at(woman_slot).key;
-			man_to_woman[man] = woman;
-			woman_to_man[woman] = man;
-			intersection_size++;
-		}
-	}
+    // Export the "slots" into keys:
+    std::size_t intersection_size = 0;
+    for (std::size_t man_slot = 0; man_slot != men.size(); ++man_slot) {
+        compressed_slot_t woman_slot = man_to_woman_slots[man_slot];
+        if (woman_slot != missing_slot) {
+            man_key_t man = men.at(static_cast<compressed_slot_t>(man_slot)).key;
+            woman_key_t woman = women.at(woman_slot).key;
+            man_to_woman[man] = woman;
+            woman_to_man[woman] = man;
+            intersection_size++;
+        }
+    }
 
-	// Export stats
-	result.engagements = engagements;
-	result.intersection_size = intersection_size;
-	result.computed_distances = computed_distances;
-	result.visited_members = visited_members;
-	return result;
+    // Export stats
+    result.engagements = engagements;
+    result.intersection_size = intersection_size;
+    result.computed_distances = computed_distances;
+    result.visited_members = visited_members;
+    return result;
 }
 
 } // namespace usearch

--- a/src/include/usearch/index_dense.hpp
+++ b/src/include/usearch/index_dense.hpp
@@ -628,6 +628,13 @@ class index_dense_gt {
     template <typename predicate_at> search_result_t filtered_search(f32_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from_f32, config_.expansion_search); }
     template <typename predicate_at> search_result_t filtered_search(f64_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from_f64, config_.expansion_search); }
 
+    // filtered_ef_search: like filtered_search but with an explicit expansion factor (mirrors ef_search vs search)
+    template <typename predicate_at> search_result_t filtered_ef_search(b1x8_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_b1x8, ef); }
+    template <typename predicate_at> search_result_t filtered_ef_search(i8_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_i8, ef); }
+    template <typename predicate_at> search_result_t filtered_ef_search(f16_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_f16, ef); }
+    template <typename predicate_at> search_result_t filtered_ef_search(f32_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_f32, ef); }
+    template <typename predicate_at> search_result_t filtered_ef_search(f64_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_f64, ef); }
+
     std::size_t get(vector_key_t key, b1x8_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to_b1x8); }
     std::size_t get(vector_key_t key, i8_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to_i8); }
     std::size_t get(vector_key_t key, f16_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to_f16); }

--- a/src/include/usearch/index_dense.hpp
+++ b/src/include/usearch/index_dense.hpp
@@ -5,12 +5,8 @@
  *  @date       July 26, 2023
  */
 #pragma once
+#include "index.hpp"
 #include <stdlib.h> // `aligned_alloc`
-
-#include <functional> // `std::function`
-#include <numeric>    // `std::iota`
-#include <thread>     // `std::thread`
-#include <vector>     // `std::vector`
 
 #include <usearch/index.hpp>
 #include <usearch/index_plugins.hpp>
@@ -95,10 +91,32 @@ struct index_dense_head_result_t {
     }
 };
 
+/**
+ *  @brief  Configuration settings for the construction of dense
+ *          equidimensional vector indexes.
+ *
+ *  Unlike the underlying `index_gt` class, incorporates the
+ *  `::expansion_add` and `::expansion_search` parameters passed
+ *  separately for the lower-level engine.
+ */
 struct index_dense_config_t : public index_config_t {
     std::size_t expansion_add = default_expansion_add();
     std::size_t expansion_search = default_expansion_search();
+
+    /**
+     *  @brief  Excludes vectors from the serialized file.
+     *          This is handy when you want to store the vectors in a separate file.
+     *
+     *  ! For advanced users only.
+     */
     bool exclude_vectors = false;
+
+    /**
+     *  @brief  Allows you to store multiple vectors per key.
+     *          This is handy when a large document is chunked into many parts.
+     *
+     *  ! May degrade the performance of iterators.
+     */
     bool multi = false;
 
     /**
@@ -107,17 +125,37 @@ struct index_dense_config_t : public index_config_t {
      *          the vectors-to-keys mappings.
      *
      *  ! This configuration parameter doesn't affect the serialized file,
-     *  ! and is not preserved between runs. Makes sense for small vector
-     *  ! representations that fit ina  single cache line.
+     *  ! and is not preserved between runs. Makes sense for smaller vectors
+     *  ! that fit in a couple of cache lines.
+     *
+     *  The trade-off is that some methods won't be available, like `get`, `rename`,
+     *  and `remove`. The basic functionality, like `add` and `search` will work as
+     *  expected even with `enable_key_lookups = false`.
+     *
+     *  If both `!multi && !enable_key_lookups`, the "duplicate entry" checks won't
+     *  be performed and no errors will be raised.
      */
     bool enable_key_lookups = true;
 
-    index_dense_config_t(index_config_t base) noexcept : index_config_t(base) {}
+    inline index_dense_config_t(index_config_t base) noexcept : index_config_t(base) {}
 
-    index_dense_config_t(std::size_t c = default_connectivity(), std::size_t ea = default_expansion_add(),
-                         std::size_t es = default_expansion_search()) noexcept
-        : index_config_t(c), expansion_add(ea ? ea : default_expansion_add()),
-          expansion_search(es ? es : default_expansion_search()) {}
+    inline index_dense_config_t(std::size_t c = 0, std::size_t ea = 0, std::size_t es = 0) noexcept
+        : index_config_t(c), expansion_add(ea), expansion_search(es) {}
+
+    /**
+     *  @brief  Validates the configuration settings, updating them in-place.
+     *  @return Error message, if any.
+     */
+    inline error_t validate() noexcept {
+        error_t error = index_config_t::validate();
+        if (error)
+            return error;
+        if (expansion_add == 0)
+            expansion_add = default_expansion_add();
+        if (expansion_search == 0)
+            expansion_search = default_expansion_search();
+        return {};
+    }
 };
 
 struct index_dense_clustering_config_t {
@@ -170,6 +208,45 @@ struct index_dense_metadata_result_t {
 };
 
 /**
+ *  @brief  Fixes serialized scalar-kind codes for pre-v2.10 versions, until we can upgrade to v3.
+ *          The old enum `scalar_kind_t` is defined without explicit constants from 0.
+ */
+inline scalar_kind_t convert_pre_2_10_scalar_kind(scalar_kind_t scalar_kind) noexcept {
+    switch (static_cast<std::underlying_type<scalar_kind_t>::type>(scalar_kind)) {
+    case 0: return scalar_kind_t::unknown_k;
+    case 1: return scalar_kind_t::b1x8_k;
+    case 2: return scalar_kind_t::u40_k;
+    case 3: return scalar_kind_t::uuid_k;
+    case 4: return scalar_kind_t::f64_k;
+    case 5: return scalar_kind_t::f32_k;
+    case 6: return scalar_kind_t::f16_k;
+    case 7: return scalar_kind_t::e5m2_k;
+    case 8: return scalar_kind_t::u64_k;
+    case 9: return scalar_kind_t::u32_k;
+    case 10: return scalar_kind_t::u8_k;
+    case 11: return scalar_kind_t::i64_k;
+    case 12: return scalar_kind_t::i32_k;
+    case 13: return scalar_kind_t::i16_k;
+    case 14: return scalar_kind_t::i8_k;
+    default: return scalar_kind;
+    }
+}
+
+/**
+ *  @brief  Fixes the metadata for pre-v2.10 versions, until we can upgrade to v3.
+ *          Originates from: https://github.com/unum-cloud/USearch/issues/423
+ */
+inline void fix_pre_2_10_metadata(index_dense_head_t& head) {
+    if (head.version_major == 2 && head.version_minor < 10) {
+        head.kind_scalar = convert_pre_2_10_scalar_kind(head.kind_scalar);
+        head.kind_key = convert_pre_2_10_scalar_kind(head.kind_key);
+        head.kind_compressed_slot = convert_pre_2_10_scalar_kind(head.kind_compressed_slot);
+        head.version_minor = 10;
+        head.version_patch = 0;
+    }
+}
+
+/**
  *  @brief  Extracts metadata from a pre-constructed index on disk,
  *          without loading it or mapping the whole binary file.
  */
@@ -186,8 +263,10 @@ inline index_dense_metadata_result_t index_dense_metadata_from_path(char const* 
 
     // Check if the file immediately starts with the index, instead of vectors
     result.config.exclude_vectors = true;
-    if (std::memcmp(result.head_buffer, default_magic(), std::strlen(default_magic())) == 0)
+    if (std::memcmp(result.head_buffer, default_magic(), std::strlen(default_magic())) == 0) {
+        fix_pre_2_10_metadata(result.head);
         return result;
+    }
 
     if (std::fseek(file.get(), 0L, SEEK_END) != 0)
         return result.failed("Can't infer file size");
@@ -213,8 +292,10 @@ inline index_dense_metadata_result_t index_dense_metadata_from_path(char const* 
 
         result.config.exclude_vectors = false;
         result.config.use_64_bit_dimensions = false;
-        if (std::memcmp(result.head_buffer, default_magic(), std::strlen(default_magic())) == 0)
+        if (std::memcmp(result.head_buffer, default_magic(), std::strlen(default_magic())) == 0) {
+            fix_pre_2_10_metadata(result.head);
             return result;
+        }
     }
 
     // Check if it starts with 64-bit
@@ -228,8 +309,10 @@ inline index_dense_metadata_result_t index_dense_metadata_from_path(char const* 
         // Check if it starts with 64-bit
         result.config.exclude_vectors = false;
         result.config.use_64_bit_dimensions = true;
-        if (std::memcmp(result.head_buffer, default_magic(), std::strlen(default_magic())) == 0)
+        if (std::memcmp(result.head_buffer, default_magic(), std::strlen(default_magic())) == 0) {
+            fix_pre_2_10_metadata(result.head);
             return result;
+        }
     }
 
     return result.failed("Not a dense USearch index!");
@@ -238,7 +321,7 @@ inline index_dense_metadata_result_t index_dense_metadata_from_path(char const* 
 /**
  *  @brief  Extracts metadata from a pre-constructed index serialized into an in-memory buffer.
  */
-inline index_dense_metadata_result_t index_dense_metadata_from_buffer(memory_mapped_file_t file,
+inline index_dense_metadata_result_t index_dense_metadata_from_buffer(memory_mapped_file_t const& file,
                                                                       std::size_t offset = 0) noexcept {
     index_dense_metadata_result_t result;
 
@@ -246,7 +329,7 @@ inline index_dense_metadata_result_t index_dense_metadata_from_buffer(memory_map
     if (offset + sizeof(index_dense_head_buffer_t) >= file.size())
         return result.failed("End of file reached!");
 
-    byte_t* const file_data = file.data() + offset;
+    byte_t const* file_data = file.data() + offset;
     std::size_t const file_size = file.size() - offset;
     std::memcpy(&result.head_buffer, file_data, sizeof(index_dense_head_buffer_t));
 
@@ -323,8 +406,6 @@ class index_dense_gt {
     using tape_allocator_t = memory_mapping_allocator_gt<64>;
 
   private:
-    /// @brief Schema: input buffer, bytes in input buffer, output buffer.
-    using cast_t = std::function<bool(byte_t const*, std::size_t, byte_t*)>;
     /// @brief Punned index.
     using index_t = index_gt<                        //
         distance_t, vector_key_t, compressed_slot_t, //
@@ -359,20 +440,11 @@ class index_dense_gt {
     index_dense_config_t config_;
     index_t* typed_ = nullptr;
 
-    mutable std::vector<byte_t> cast_buffer_;
-    struct casts_t {
-        cast_t from_b1x8;
-        cast_t from_i8;
-        cast_t from_f16;
-        cast_t from_f32;
-        cast_t from_f64;
+    using cast_buffer_t = buffer_gt<byte_t, dynamic_allocator_t>;
 
-        cast_t to_b1x8;
-        cast_t to_i8;
-        cast_t to_f16;
-        cast_t to_f32;
-        cast_t to_f64;
-    } casts_;
+    /// @brief  Temporary memory for every thread to store a casted vector.
+    mutable cast_buffer_t cast_buffer_;
+    casts_punned_t casts_;
 
     /// @brief An instance of a potentially stateful `metric_t` used to initialize copies and forks.
     metric_t metric_;
@@ -381,11 +453,17 @@ class index_dense_gt {
     /// @brief Allocator for the copied vectors, aligned to widest double-precision scalars.
     vectors_tape_allocator_t vectors_tape_allocator_;
 
-    /// @brief For every managed `compressed_slot_t` stores a pointer to the allocated vector copy.
-    mutable std::vector<byte_t*> vectors_lookup_;
+    using vectors_lookup_allocator_t = aligned_allocator_gt<byte_t*, 64>;
+    using vectors_lookup_t = buffer_gt<byte_t*, vectors_lookup_allocator_t>;
 
-    /// @brief Originally forms and array of integers [0, threads], marking all
-    mutable std::vector<std::size_t> available_threads_;
+    /// @brief For every managed `compressed_slot_t` stores a pointer to the allocated vector copy.
+    mutable vectors_lookup_t vectors_lookup_;
+
+    using available_threads_allocator_t = aligned_allocator_gt<std::size_t, 64>;
+    using available_threads_t = ring_gt<std::size_t, available_threads_allocator_t>;
+
+    /// @brief Originally forms and array of integers [0, threads], marking all as available.
+    mutable available_threads_t available_threads_;
 
     /// @brief Mutex, controlling concurrent access to `available_threads_`.
     mutable std::mutex available_threads_mutex_;
@@ -408,8 +486,8 @@ class index_dense_gt {
 
     struct lookup_key_hash_t {
         using is_transparent = void;
-        std::size_t operator()(key_and_slot_t const& k) const noexcept { return std::hash<vector_key_t>{}(k.key); }
-        std::size_t operator()(vector_key_t const& k) const noexcept { return std::hash<vector_key_t>{}(k); }
+        std::size_t operator()(key_and_slot_t const& k) const noexcept { return hash_gt<vector_key_t>{}(k.key); }
+        std::size_t operator()(vector_key_t const& k) const noexcept { return hash_gt<vector_key_t>{}(k); }
     };
 
     struct lookup_key_same_t {
@@ -434,12 +512,56 @@ class index_dense_gt {
     /// @brief A constant for the reserved key value, used to mark deleted entries.
     vector_key_t free_key_ = default_free_value<vector_key_t>();
 
+    /// @brief Locks the thread for the duration of the operation.
+    struct thread_lock_t {
+        index_dense_gt const& parent;
+        std::size_t thread_id = 0;
+        bool engaged = false;
+
+        ~thread_lock_t() usearch_noexcept_m {
+            if (engaged)
+                parent.thread_unlock_(thread_id);
+        }
+
+        thread_lock_t(thread_lock_t const&) = delete;
+        thread_lock_t& operator=(thread_lock_t const&) = delete;
+
+        thread_lock_t(index_dense_gt const& parent, std::size_t thread_id, bool engaged = true) noexcept
+            : parent(parent), thread_id(thread_id), engaged(engaged) {}
+        thread_lock_t(thread_lock_t&& other) noexcept
+            : parent(other.parent), thread_id(other.thread_id), engaged(other.engaged) {
+            other.engaged = false;
+        }
+    };
+
   public:
-    using search_result_t = typename index_t::search_result_t;
     using cluster_result_t = typename index_t::cluster_result_t;
     using add_result_t = typename index_t::add_result_t;
     using stats_t = typename index_t::stats_t;
     using match_t = typename index_t::match_t;
+
+    /**
+     *  @brief  A search result, containing the found keys and distances.
+     *
+     *  As the `index_dense_gt` manages the thread-pool on its own, the search result
+     *  preserves the thread-lock to avoid undefined behaviors, when other threads
+     *  start overwriting the results.
+     */
+    struct search_result_t : public index_t::search_result_t {
+        inline search_result_t(index_dense_gt const& parent) noexcept
+            : index_t::search_result_t(), lock_(parent, 0, false) {}
+        search_result_t failed(error_t message) noexcept {
+            this->error = std::move(message);
+            return std::move(*this);
+        }
+
+      private:
+        friend class index_dense_gt;
+        thread_lock_t lock_;
+
+        inline search_result_t(typename index_t::search_result_t result, thread_lock_t lock) noexcept
+            : index_t::search_result_t(std::move(result)), lock_(std::move(lock)) {}
+    };
 
     index_dense_gt() = default;
     index_dense_gt(index_dense_gt&& other)
@@ -491,51 +613,76 @@ class index_dense_gt {
         typed_ = nullptr;
     }
 
+    struct state_result_t {
+        index_dense_gt index;
+        error_t error;
+
+        explicit operator bool() const noexcept { return !error; }
+        state_result_t failed(error_t message) noexcept {
+            error = std::move(message);
+            return std::move(*this);
+        }
+        operator index_dense_gt&&() && {
+            if (error)
+                usearch_raise_runtime_error(error.what());
+            return std::move(index);
+        }
+    };
+    using copy_result_t = state_result_t;
+
     /**
      *  @brief Constructs an instance of ::index_dense_gt.
      *  @param[in] metric One of the provided or an @b ad-hoc metric, type-punned.
      *  @param[in] config The index configuration (optional).
      *  @param[in] free_key The key used for freed vectors (optional).
-     *  @return An instance of ::index_dense_gt.
+     *  @return An instance of ::index_dense_gt or error, wrapped in a `state_result_t`.
+     *
+     *  ! If the `metric` isn't provided in this method, it has to be set with
+     *  ! the `change_metric` method before the index can be used. Alternatively,
+     *  ! if you are loading an existing index, the metric will be set automatically.
      */
-    static index_dense_gt make(           //
-        metric_t metric,                  //
+    static state_result_t make(           //
+        metric_t metric = {},             //
         index_dense_config_t config = {}, //
         vector_key_t free_key = default_free_value<vector_key_t>()) {
 
-        scalar_kind_t scalar_kind = metric.scalar_kind();
-        std::size_t hardware_threads = std::thread::hardware_concurrency();
-
-        index_dense_gt result;
-        result.config_ = config;
-        result.cast_buffer_.resize(hardware_threads * metric.bytes_per_vector());
-        result.casts_ = make_casts_(scalar_kind);
-        result.metric_ = metric;
-        result.free_key_ = free_key;
-
-        // Fill the thread IDs.
-        result.available_threads_.resize(hardware_threads);
-        std::iota(result.available_threads_.begin(), result.available_threads_.end(), 0ul);
-
-        // Available since C11, but only C++17, so we use the C version.
+        if (metric.missing())
+            return state_result_t{}.failed("Metric won't be initialized!");
+        error_t error = config.validate();
+        if (error)
+            return state_result_t{}.failed(std::move(error));
         index_t* raw = index_allocator_t{}.allocate(1);
+        if (!raw)
+            return state_result_t{}.failed("Failed to allocate memory for the index!");
+
+        state_result_t result;
+        index_dense_gt& index = result.index;
+        index.config_ = config;
+        index.free_key_ = free_key;
+
+        // In some cases the metric is not provided, and will be set later.
+        if (metric) {
+            scalar_kind_t scalar_kind = metric.scalar_kind();
+            index.casts_ = casts_punned_t::make(scalar_kind);
+            index.metric_ = metric;
+        }
+
         new (raw) index_t(config);
-        result.typed_ = raw;
+        index.typed_ = raw;
         return result;
     }
 
-    static index_dense_gt make(char const* path, bool view = false) {
-        index_dense_metadata_result_t meta = index_dense_metadata_from_path(path);
-        if (!meta)
-            return {};
-        metric_punned_t metric(meta.head.dimensions, meta.head.kind_metric, meta.head.kind_scalar);
-        index_dense_gt result = make(metric);
-        if (!result)
-            return result;
-        if (view)
-            result.view(path);
-        else
-            result.load(path);
+    /**
+     *  @brief Constructs an instance of ::index_dense_gt from a serialized binary file.
+     *  @param[in] path The path to the binary file.
+     *  @param[in] view Whether to map the file into memory or load it.
+     *  @return An instance of ::index_dense_gt or error, wrapped in a `state_result_t`.
+     */
+    static state_result_t make(char const* path, bool view = false) {
+        state_result_t result;
+        serialization_result_t serialization_result = view ? result.index.view(path) : result.index.load(path);
+        if (!serialization_result)
+            return result.failed(std::move(serialization_result.error));
         return result;
     }
 
@@ -543,19 +690,27 @@ class index_dense_gt {
     std::size_t connectivity() const { return typed_->connectivity(); }
     std::size_t size() const { return typed_->size() - free_keys_.size(); }
     std::size_t capacity() const { return typed_->capacity(); }
-    std::size_t max_level() const noexcept { return typed_->max_level(); }
+    std::size_t max_level() const { return typed_->max_level(); }
     index_dense_config_t const& config() const { return config_; }
     index_limits_t const& limits() const { return typed_->limits(); }
+    double inverse_log_connectivity() const { return typed_->inverse_log_connectivity(); }
+    std::size_t neighbors_base_bytes() const { return typed_->neighbors_base_bytes(); }
+    std::size_t neighbors_bytes() const { return typed_->neighbors_bytes(); }
     bool multi() const { return config_.multi; }
+    std::size_t currently_available_threads() const {
+        std::unique_lock<std::mutex> available_threads_lock(available_threads_mutex_);
+        return available_threads_.size();
+    }
 
     // The metric and its properties
     metric_t const& metric() const { return metric_; }
     void change_metric(metric_t metric) { metric_ = std::move(metric); }
 
-    scalar_kind_t scalar_kind() const noexcept { return metric_.scalar_kind(); }
-    std::size_t bytes_per_vector() const noexcept { return metric_.bytes_per_vector(); }
-    std::size_t scalar_words() const noexcept { return metric_.scalar_words(); }
-    std::size_t dimensions() const noexcept { return metric_.dimensions(); }
+    scalar_kind_t scalar_kind() const { return metric_.scalar_kind(); }
+    metric_kind_t metric_kind() const { return metric_.metric_kind(); }
+    std::size_t bytes_per_vector() const { return metric_.bytes_per_vector(); }
+    std::size_t scalar_words() const { return metric_.scalar_words(); }
+    std::size_t dimensions() const { return metric_.dimensions(); }
 
     // Fetching and changing search criteria
     std::size_t expansion_add() const { return config_.expansion_add; }
@@ -565,8 +720,6 @@ class index_dense_gt {
 
     member_citerator_t cbegin() const { return typed_->cbegin(); }
     member_citerator_t cend() const { return typed_->cend(); }
-    member_citerator_t begin() const { return typed_->begin(); }
-    member_citerator_t end() const { return typed_->end(); }
     member_iterator_t begin() { return typed_->begin(); }
     member_iterator_t end() { return typed_->end(); }
 
@@ -593,8 +746,36 @@ class index_dense_gt {
             vectors_tape_allocator_.total_allocated();
     }
 
-    static constexpr std::size_t any_thread() { return std::numeric_limits<std::size_t>::max(); }
-    static constexpr distance_t infinite_distance() { return std::numeric_limits<distance_t>::max(); }
+    /**
+     *  @brief  Aggregated memory statistics for the allocator tapes used by the dense index.
+     */
+    struct memory_stats_t {
+        /// Memory stats for the graph structure allocator.
+        std::size_t graph_allocated;
+        std::size_t graph_wasted;
+        std::size_t graph_reserved;
+        /// Memory stats for the vectors data allocator.
+        std::size_t vectors_allocated;
+        std::size_t vectors_wasted;
+        std::size_t vectors_reserved;
+    };
+
+    /**
+     *  @brief  Returns detailed memory statistics with separate breakdowns for the graph
+     *          and vectors allocator tapes.
+     *  @return A `memory_stats_t` struct with per-tape allocated, wasted, and reserved bytes.
+     */
+    memory_stats_t memory_stats() const {
+        auto const& graph_alloc = typed_->tape_allocator();
+        return {
+            graph_alloc.total_allocated(),          graph_alloc.total_wasted(),
+            graph_alloc.total_reserved(),           vectors_tape_allocator_.total_allocated(),
+            vectors_tape_allocator_.total_wasted(), vectors_tape_allocator_.total_reserved(),
+        };
+    }
+
+    static constexpr std::size_t any_thread() { return (std::numeric_limits<std::size_t>::max)(); }
+    static constexpr distance_t infinite_distance() { return (std::numeric_limits<distance_t>::max)(); }
 
     struct aggregated_distances_t {
         std::size_t count = 0;
@@ -604,54 +785,91 @@ class index_dense_gt {
     };
 
     // clang-format off
-    add_result_t add(vector_key_t key, b1x8_t const* vector, std::size_t thread = any_thread(), bool force_vector_copy = true) { return add_(key, vector, thread, force_vector_copy, casts_.from_b1x8); }
-    add_result_t add(vector_key_t key, i8_t const* vector, std::size_t thread = any_thread(), bool force_vector_copy = true) { return add_(key, vector, thread, force_vector_copy, casts_.from_i8); }
-    add_result_t add(vector_key_t key, f16_t const* vector, std::size_t thread = any_thread(), bool force_vector_copy = true) { return add_(key, vector, thread, force_vector_copy, casts_.from_f16); }
-    add_result_t add(vector_key_t key, f32_t const* vector, std::size_t thread = any_thread(), bool force_vector_copy = true) { return add_(key, vector, thread, force_vector_copy, casts_.from_f32); }
-    add_result_t add(vector_key_t key, f64_t const* vector, std::size_t thread = any_thread(), bool force_vector_copy = true) { return add_(key, vector, thread, force_vector_copy, casts_.from_f64); }
+    add_result_t add(vector_key_t key, f64_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.f64); }
+    add_result_t add(vector_key_t key, f32_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.f32); }
+    add_result_t add(vector_key_t key, bf16_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.bf16); }
+    add_result_t add(vector_key_t key, f16_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.f16); }
+    add_result_t add(vector_key_t key, e5m2_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.e5m2); }
+    add_result_t add(vector_key_t key, e4m3_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.e4m3); }
+    add_result_t add(vector_key_t key, e3m2_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.e3m2); }
+    add_result_t add(vector_key_t key, e2m3_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.e2m3); }
+    add_result_t add(vector_key_t key, i8_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.i8); }
+    add_result_t add(vector_key_t key, u8_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.u8); }
+    add_result_t add(vector_key_t key, b1x8_t const* vector, std::size_t thread = any_thread(), bool copy_vector = true) { return add_(key, vector, thread, copy_vector, casts_.from.b1x8); }
 
-    search_result_t search(b1x8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_b1x8, config_.expansion_search); }
-    search_result_t search(i8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_i8, config_.expansion_search); }
-    search_result_t search(f16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_f16, config_.expansion_search); }
-    search_result_t search(f32_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_f32, config_.expansion_search); }
-    search_result_t search(f64_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_f64, config_.expansion_search); }
+    search_result_t search(f64_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f64); }
+    search_result_t search(f32_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f32); }
+    search_result_t search(bf16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.bf16); }
+    search_result_t search(f16_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.f16); }
+    search_result_t search(e5m2_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e5m2); }
+    search_result_t search(e4m3_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e4m3); }
+    search_result_t search(e3m2_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e3m2); }
+    search_result_t search(e2m3_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.e2m3); }
+    search_result_t search(i8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.i8); }
+    search_result_t search(u8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.u8); }
+    search_result_t search(b1x8_t const* vector, std::size_t wanted, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from.b1x8); }
 
-    search_result_t ef_search(b1x8_t const* vector, std::size_t wanted, std::size_t ef_search, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_b1x8, ef_search); }
-    search_result_t ef_search(i8_t const* vector, std::size_t wanted, std::size_t ef_search, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_i8, ef_search); }
-    search_result_t ef_search(f16_t const* vector, std::size_t wanted, std::size_t ef_search, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_f16, ef_search); }
-    search_result_t ef_search(f32_t const* vector, std::size_t wanted, std::size_t ef_search, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_f32, ef_search); }
-    search_result_t ef_search(f64_t const* vector, std::size_t wanted, std::size_t ef_search, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, dummy_predicate_t {}, thread, exact, casts_.from_f64, ef_search); }
+    template <typename predicate_at> search_result_t filtered_search(f64_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f64); }
+    template <typename predicate_at> search_result_t filtered_search(f32_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f32); }
+    template <typename predicate_at> search_result_t filtered_search(bf16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.bf16); }
+    template <typename predicate_at> search_result_t filtered_search(f16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f16); }
+    template <typename predicate_at> search_result_t filtered_search(e5m2_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e5m2); }
+    template <typename predicate_at> search_result_t filtered_search(e4m3_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e4m3); }
+    template <typename predicate_at> search_result_t filtered_search(e3m2_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e3m2); }
+    template <typename predicate_at> search_result_t filtered_search(e2m3_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.e2m3); }
+    template <typename predicate_at> search_result_t filtered_search(i8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.i8); }
+    template <typename predicate_at> search_result_t filtered_search(u8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.u8); }
+    template <typename predicate_at> search_result_t filtered_search(b1x8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.b1x8); }
 
-    template <typename predicate_at> search_result_t filtered_search(b1x8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from_b1x8, config_.expansion_search); }
-    template <typename predicate_at> search_result_t filtered_search(i8_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from_i8, config_.expansion_search); }
-    template <typename predicate_at> search_result_t filtered_search(f16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from_f16, config_.expansion_search); }
-    template <typename predicate_at> search_result_t filtered_search(f32_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from_f32, config_.expansion_search); }
-    template <typename predicate_at> search_result_t filtered_search(f64_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from_f64, config_.expansion_search); }
+    // ef_search: like search() but with an explicit expansion factor per call (duckdb-vss addition)
+    search_result_t ef_search(f64_t const*  v, std::size_t w, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, dummy_predicate_t {}, t, exact, casts_.from.f64,  ef); }
+    search_result_t ef_search(f32_t const*  v, std::size_t w, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, dummy_predicate_t {}, t, exact, casts_.from.f32,  ef); }
+    search_result_t ef_search(f16_t const*  v, std::size_t w, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, dummy_predicate_t {}, t, exact, casts_.from.f16,  ef); }
+    search_result_t ef_search(i8_t const*   v, std::size_t w, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, dummy_predicate_t {}, t, exact, casts_.from.i8,   ef); }
+    search_result_t ef_search(b1x8_t const* v, std::size_t w, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, dummy_predicate_t {}, t, exact, casts_.from.b1x8, ef); }
 
-    // filtered_ef_search: like filtered_search but with an explicit expansion factor (mirrors ef_search vs search)
-    template <typename predicate_at> search_result_t filtered_ef_search(b1x8_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_b1x8, ef); }
-    template <typename predicate_at> search_result_t filtered_ef_search(i8_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_i8, ef); }
-    template <typename predicate_at> search_result_t filtered_ef_search(f16_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_f16, ef); }
-    template <typename predicate_at> search_result_t filtered_ef_search(f32_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_f32, ef); }
-    template <typename predicate_at> search_result_t filtered_ef_search(f64_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from_f64, ef); }
+    // filtered_ef_search: like filtered_search() but with an explicit expansion factor per call (duckdb-vss addition)
+    template <typename predicate_at> search_result_t filtered_ef_search(f64_t const*  v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from.f64,  ef); }
+    template <typename predicate_at> search_result_t filtered_ef_search(f32_t const*  v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from.f32,  ef); }
+    template <typename predicate_at> search_result_t filtered_ef_search(f16_t const*  v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from.f16,  ef); }
+    template <typename predicate_at> search_result_t filtered_ef_search(i8_t const*   v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from.i8,   ef); }
+    template <typename predicate_at> search_result_t filtered_ef_search(b1x8_t const* v, std::size_t w, predicate_at&& p, std::size_t ef, std::size_t t = any_thread(), bool exact = false) const { return search_(v, w, std::forward<predicate_at>(p), t, exact, casts_.from.b1x8, ef); }
 
-    std::size_t get(vector_key_t key, b1x8_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to_b1x8); }
-    std::size_t get(vector_key_t key, i8_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to_i8); }
-    std::size_t get(vector_key_t key, f16_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to_f16); }
-    std::size_t get(vector_key_t key, f32_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to_f32); }
-    std::size_t get(vector_key_t key, f64_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to_f64); }
+    std::size_t get(vector_key_t key, f64_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.f64); }
+    std::size_t get(vector_key_t key, f32_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.f32); }
+    std::size_t get(vector_key_t key, bf16_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.bf16); }
+    std::size_t get(vector_key_t key, f16_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.f16); }
+    std::size_t get(vector_key_t key, e5m2_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.e5m2); }
+    std::size_t get(vector_key_t key, e4m3_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.e4m3); }
+    std::size_t get(vector_key_t key, e3m2_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.e3m2); }
+    std::size_t get(vector_key_t key, e2m3_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.e2m3); }
+    std::size_t get(vector_key_t key, i8_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.i8); }
+    std::size_t get(vector_key_t key, u8_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.u8); }
+    std::size_t get(vector_key_t key, b1x8_t* vector, std::size_t vectors_count = 1) const { return get_(key, vector, vectors_count, casts_.to.b1x8); }
 
-    cluster_result_t cluster(b1x8_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from_b1x8); }
-    cluster_result_t cluster(i8_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from_i8); }
-    cluster_result_t cluster(f16_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from_f16); }
-    cluster_result_t cluster(f32_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from_f32); }
-    cluster_result_t cluster(f64_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from_f64); }
+    cluster_result_t cluster(f64_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.f64); }
+    cluster_result_t cluster(f32_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.f32); }
+    cluster_result_t cluster(bf16_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.bf16); }
+    cluster_result_t cluster(f16_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.f16); }
+    cluster_result_t cluster(e5m2_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.e5m2); }
+    cluster_result_t cluster(e4m3_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.e4m3); }
+    cluster_result_t cluster(e3m2_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.e3m2); }
+    cluster_result_t cluster(e2m3_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.e2m3); }
+    cluster_result_t cluster(i8_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.i8); }
+    cluster_result_t cluster(u8_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.u8); }
+    cluster_result_t cluster(b1x8_t const* vector, std::size_t level, std::size_t thread = any_thread()) const { return cluster_(vector, level, thread, casts_.from.b1x8); }
 
-    aggregated_distances_t distance_between(vector_key_t key, b1x8_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to_b1x8); }
-    aggregated_distances_t distance_between(vector_key_t key, i8_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to_i8); }
-    aggregated_distances_t distance_between(vector_key_t key, f16_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to_f16); }
-    aggregated_distances_t distance_between(vector_key_t key, f32_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to_f32); }
-    aggregated_distances_t distance_between(vector_key_t key, f64_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to_f64); }
+    aggregated_distances_t distance_between(vector_key_t key, f64_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.f64); }
+    aggregated_distances_t distance_between(vector_key_t key, f32_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.f32); }
+    aggregated_distances_t distance_between(vector_key_t key, bf16_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.bf16); }
+    aggregated_distances_t distance_between(vector_key_t key, f16_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.f16); }
+    aggregated_distances_t distance_between(vector_key_t key, e5m2_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.e5m2); }
+    aggregated_distances_t distance_between(vector_key_t key, e4m3_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.e4m3); }
+    aggregated_distances_t distance_between(vector_key_t key, e3m2_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.e3m2); }
+    aggregated_distances_t distance_between(vector_key_t key, e2m3_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.e2m3); }
+    aggregated_distances_t distance_between(vector_key_t key, i8_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.i8); }
+    aggregated_distances_t distance_between(vector_key_t key, u8_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.u8); }
+    aggregated_distances_t distance_between(vector_key_t key, b1x8_t const* vector, std::size_t thread = any_thread()) const { return distance_between_(key, vector, thread, casts_.to.b1x8); }
     // clang-format on
 
     /**
@@ -660,6 +878,7 @@ class index_dense_gt {
      *          exporting the mean, maximum, and minimum values.
      */
     aggregated_distances_t distance_between(vector_key_t a, vector_key_t b, std::size_t = any_thread()) const {
+        usearch_assert_m(config().enable_key_lookups, "Key lookups are disabled!");
         shared_lock_t lock(slot_lookup_mutex_);
         aggregated_distances_t result;
         if (!multi()) {
@@ -688,8 +907,8 @@ class index_dense_gt {
         if (a_missing || b_missing)
             return result;
 
-        result.min = std::numeric_limits<distance_t>::max();
-        result.max = std::numeric_limits<distance_t>::min();
+        result.min = (std::numeric_limits<distance_t>::max)();
+        result.max = (std::numeric_limits<distance_t>::min)();
         result.mean = 0;
         result.count = 0;
 
@@ -733,10 +952,8 @@ class index_dense_gt {
         cluster_config.thread = lock.thread_id;
         cluster_config.expansion = config_.expansion_search;
         metric_proxy_t metric{*this};
-        auto &free_key_ = this->free_key_;
-        auto allow = [&free_key_](member_cref_t const& member) noexcept {
-            return member.key != free_key_;
-        };
+        vector_key_t free_key_copy = free_key_;
+        auto allow = [free_key_copy](member_cref_t const& member) noexcept { return member.key != free_key_copy; };
 
         // Find the closest cluster for any vector under that key.
         while (key_range.first != key_range.second) {
@@ -756,19 +973,52 @@ class index_dense_gt {
     /**
      *  @brief Reserves memory for the index and the keyed lookup.
      *  @return `true` if the memory reservation was successful, `false` otherwise.
+     *
+     *  ! No update or search operations should be running during this operation.
      */
-    bool reserve(index_limits_t limits) {
-        {
-            unique_lock_t lock(slot_lookup_mutex_);
-            slot_lookup_.reserve(limits.members);
-            vectors_lookup_.resize(limits.members);
+    bool try_reserve(index_limits_t limits) {
 
-            // During reserve, no insertions may be happening, so we can safely overwrite the whole collection.
-            std::unique_lock<std::mutex> available_threads_lock(available_threads_mutex_);
-            available_threads_.resize(limits.threads());
-            std::iota(available_threads_.begin(), available_threads_.end(), 0ul);
+        // The slot lookup system will generally prefer power-of-two sizes.
+        if (config_.enable_key_lookups) {
+            unique_lock_t lock(slot_lookup_mutex_);
+            if (!slot_lookup_.try_reserve(limits.members))
+                return false;
+            limits.members = slot_lookup_.capacity();
         }
+
+        // Once the `slot_lookup_` grows, let's use its capacity as the new
+        // target for the `vectors_lookup_` to synchronize allocations and
+        // expensive index re-organizations.
+        if (limits.members != vectors_lookup_.size()) {
+            vectors_lookup_t new_vectors_lookup(limits.members);
+            if (!new_vectors_lookup)
+                return false;
+            if (vectors_lookup_.size() > 0)
+                std::memcpy(new_vectors_lookup.data(), vectors_lookup_.data(),
+                            vectors_lookup_.size() * sizeof(byte_t*));
+            vectors_lookup_ = std::move(new_vectors_lookup);
+        }
+
+        // During reserve, no insertions may be happening, so we can safely overwrite the whole collection.
+        std::unique_lock<std::mutex> available_threads_lock(available_threads_mutex_);
+        available_threads_.clear();
+        if (!available_threads_.reserve(limits.threads()))
+            return false;
+        for (std::size_t i = 0; i < limits.threads(); i++)
+            available_threads_.push(i);
+
+        // Allocate a buffer for the casted vectors.
+        cast_buffer_t cast_buffer(limits.threads() * metric_.bytes_per_vector());
+        if (!cast_buffer)
+            return false;
+        cast_buffer_ = std::move(cast_buffer);
+
         return typed_->reserve(limits);
+    }
+
+    void reserve(index_limits_t limits) {
+        if (!try_reserve(limits))
+            usearch_raise_runtime_error("failed to reserve memory");
     }
 
     /**
@@ -783,7 +1033,7 @@ class index_dense_gt {
         std::unique_lock<std::mutex> free_lock(free_keys_mutex_);
         typed_->clear();
         slot_lookup_.clear();
-        vectors_lookup_.clear();
+        vectors_lookup_.reset();
         free_keys_.clear();
         vectors_tape_allocator_.reset();
     }
@@ -796,19 +1046,18 @@ class index_dense_gt {
      *  If the index is memory-mapped - releases the mapping and the descriptor.
      */
     void reset() {
-        unique_lock_t lookup_lock(slot_lookup_mutex_);
 
+        unique_lock_t lookup_lock(slot_lookup_mutex_);
         std::unique_lock<std::mutex> free_lock(free_keys_mutex_);
         std::unique_lock<std::mutex> available_threads_lock(available_threads_mutex_);
-        typed_->reset();
+
+        if (typed_)
+            typed_->reset();
         slot_lookup_.clear();
-        vectors_lookup_.clear();
+        vectors_lookup_.reset();
         free_keys_.clear();
         vectors_tape_allocator_.reset();
-
-        // Reset the thread IDs.
-        available_threads_.resize(std::thread::hardware_concurrency());
-        std::iota(available_threads_.begin(), available_threads_.end(), 0ul);
+        available_threads_.reset();
     }
 
     /**
@@ -887,7 +1136,7 @@ class index_dense_gt {
     /**
      *  @brief  Estimate the binary length (in bytes) of the serialized index.
      */
-    std::size_t serialized_length(serialization_config_t config = {}) const noexcept {
+    std::size_t serialized_length(serialization_config_t config = {}) const {
         std::size_t dimensions_length = 0;
         std::size_t matrix_length = 0;
         if (!config.exclude_vectors) {
@@ -899,8 +1148,9 @@ class index_dense_gt {
 
     /**
      *  @brief Parses the index from file to RAM.
-     *  @param[in] path The path to the file.
+     *  @param[in] input The input stream to read from.
      *  @param[in] config Configuration parameters for imports.
+     *  @param[in] progress Callback to report the execution progress.
      *  @return Outcome descriptor explicitly convertible to boolean.
      */
     template <typename input_callback_at, typename progress_at = dummy_progress_t>
@@ -909,6 +1159,7 @@ class index_dense_gt {
                                             progress_at&& progress = {}) {
 
         // Discard all previous memory allocations of `vectors_tape_allocator_`
+        index_limits_t old_limits = typed_ ? typed_->limits() : index_limits_t{};
         reset();
 
         // Infer the new index size
@@ -933,7 +1184,9 @@ class index_dense_gt {
                 matrix_cols = dimensions[1];
             }
             // Load the vectors one after another
-            vectors_lookup_.resize(matrix_rows);
+            vectors_lookup_ = vectors_lookup_t(matrix_rows);
+            if (!vectors_lookup_)
+                return result.failed("Failed to allocate memory to address vectors");
             for (std::uint64_t slot = 0; slot != matrix_rows; ++slot) {
                 byte_t* vector = vectors_tape_allocator_.allocate(matrix_cols);
                 if (!input(vector, matrix_cols))
@@ -952,6 +1205,9 @@ class index_dense_gt {
             if (std::memcmp(buffer, default_magic(), std::strlen(default_magic())) != 0)
                 return result.failed("Magic header mismatch - the file isn't an index");
 
+            // fix pre-2.10 headers
+            fix_pre_2_10_metadata(head);
+
             // Validate the software version
             if (head.version_major != USEARCH_VERSION_MAJOR)
                 return result.failed("File format may be different, please rebuild");
@@ -964,16 +1220,40 @@ class index_dense_gt {
 
             config_.multi = head.multi;
             metric_ = metric_t::builtin(head.dimensions, head.kind_metric, head.kind_scalar);
-            cast_buffer_.resize(available_threads_.size() * metric_.bytes_per_vector());
-            casts_ = make_casts_(head.kind_scalar);
+            // available_threads_.size() will be updated to old_limits.threads() later in this
+            // method, so use that as the number of threads to prepare for.
+            cast_buffer_ = cast_buffer_t(old_limits.threads() * metric_.bytes_per_vector());
+            if (!cast_buffer_)
+                return result.failed("Failed to allocate memory for the casts");
+            casts_ = casts_punned_t::make(head.kind_scalar);
         }
 
         // Pull the actual proximity graph
+        if (!typed_) {
+            index_t* raw = index_allocator_t{}.allocate(1);
+            if (!raw)
+                return result.failed("Failed to allocate memory for the index");
+            new (raw) index_t(config_);
+            typed_ = raw;
+        }
         result = typed_->load_from_stream(std::forward<input_callback_at>(input), std::forward<progress_at>(progress));
         if (!result)
             return result;
         if (typed_->size() != static_cast<std::size_t>(matrix_rows))
             return result.failed("Index size and the number of vectors doesn't match");
+        old_limits.members = static_cast<std::size_t>(matrix_rows);
+        if (!typed_->try_reserve(old_limits))
+            return result.failed("Failed to reserve memory for the index");
+
+        // After the index is loaded, we may have to resize the `available_threads_` to
+        // match the limits of the underlying engine.
+        available_threads_t available_threads;
+        std::size_t max_threads = old_limits.threads();
+        if (!available_threads.reserve(max_threads))
+            return result.failed("Failed to allocate memory for the available threads!");
+        for (std::size_t i = 0; i < max_threads; i++)
+            available_threads.push(i);
+        available_threads_ = std::move(available_threads);
 
         reindex_keys_();
         return result;
@@ -981,8 +1261,10 @@ class index_dense_gt {
 
     /**
      *  @brief Parses the index from file, without loading it into RAM.
-     *  @param[in] path The path to the file.
+     *  @param[in] file The input file to read from.
+     *  @param[in] offset The offset in the file to start reading from.
      *  @param[in] config Configuration parameters for imports.
+     *  @param[in] progress Callback to report the execution progress.
      *  @return Outcome descriptor explicitly convertible to boolean.
      */
     template <typename progress_at = dummy_progress_t>
@@ -991,6 +1273,7 @@ class index_dense_gt {
                                 progress_at&& progress = {}) {
 
         // Discard all previous memory allocations of `vectors_tape_allocator_`
+        index_limits_t old_limits = typed_ ? typed_->limits() : index_limits_t{};
         reset();
 
         serialization_result_t result = file.open_if_not();
@@ -1038,6 +1321,9 @@ class index_dense_gt {
             if (std::memcmp(buffer, default_magic(), std::strlen(default_magic())) != 0)
                 return result.failed("Magic header mismatch - the file isn't an index");
 
+            // fix pre-2.10 headers
+            fix_pre_2_10_metadata(head);
+
             // Validate the software version
             if (head.version_major != USEARCH_VERSION_MAJOR)
                 return result.failed("File format may be different, please rebuild");
@@ -1050,23 +1336,49 @@ class index_dense_gt {
 
             config_.multi = head.multi;
             metric_ = metric_t::builtin(head.dimensions, head.kind_metric, head.kind_scalar);
-            cast_buffer_.resize(available_threads_.size() * metric_.bytes_per_vector());
-            casts_ = make_casts_(head.kind_scalar);
+            // available_threads_.size() will be updated to old_limits.threads() later in this
+            // method, so use that as the number of threads to prepare for.
+            cast_buffer_ = cast_buffer_t(old_limits.threads() * metric_.bytes_per_vector());
+            if (!cast_buffer_)
+                return result.failed("Failed to allocate memory for the casts");
+            casts_ = casts_punned_t::make(head.kind_scalar);
             offset += sizeof(buffer);
         }
 
         // Pull the actual proximity graph
+        if (!typed_) {
+            index_t* raw = index_allocator_t{}.allocate(1);
+            if (!raw)
+                return result.failed("Failed to allocate memory for the index");
+            new (raw) index_t(config_);
+            typed_ = raw;
+        }
         result = typed_->view(std::move(file), offset, std::forward<progress_at>(progress));
         if (!result)
             return result;
         if (typed_->size() != static_cast<std::size_t>(matrix_rows))
             return result.failed("Index size and the number of vectors doesn't match");
+        old_limits.members = static_cast<std::size_t>(matrix_rows);
+        if (!typed_->try_reserve(old_limits))
+            return result.failed("Failed to reserve memory for the index");
 
         // Address the vectors
-        vectors_lookup_.resize(matrix_rows);
+        vectors_lookup_ = vectors_lookup_t(matrix_rows);
+        if (!vectors_lookup_)
+            return result.failed("Failed to allocate memory to address vectors");
         if (!config.exclude_vectors)
             for (std::uint64_t slot = 0; slot != matrix_rows; ++slot)
                 vectors_lookup_[slot] = (byte_t*)vectors_buffer.data() + matrix_cols * slot;
+
+        // After the index is loaded, we may have to resize the `available_threads_` to
+        // match the limits of the underlying engine.
+        available_threads_t available_threads;
+        std::size_t max_threads = old_limits.threads();
+        if (!available_threads.reserve(max_threads))
+            return result.failed("Failed to allocate memory for the available threads!");
+        for (std::size_t i = 0; i < max_threads; i++)
+            available_threads.push(i);
+        available_threads_ = std::move(available_threads);
 
         reindex_keys_();
         return result;
@@ -1074,8 +1386,9 @@ class index_dense_gt {
 
     /**
      *  @brief Saves the index to a file.
-     *  @param[in] path The path to the file.
+     *  @param[in] file The output file to write to.
      *  @param[in] config Configuration parameters for exports.
+     *  @param[in] progress Callback to report the execution progress.
      *  @return Outcome descriptor explicitly convertible to boolean.
      */
     template <typename progress_at = dummy_progress_t>
@@ -1129,8 +1442,9 @@ class index_dense_gt {
 
     /**
      *  @brief Parses the index from file to RAM.
-     *  @param[in] path The path to the file.
+     *  @param[in] file The input file to read from.
      *  @param[in] config Configuration parameters for imports.
+     *  @param[in] progress Progress callback.
      *  @return Outcome descriptor explicitly convertible to boolean.
      */
     template <typename progress_at = dummy_progress_t>
@@ -1200,6 +1514,7 @@ class index_dense_gt {
      *  @return `true` if the key is present in the index, `false` otherwise.
      */
     bool contains(vector_key_t key) const {
+        usearch_assert_m(config().enable_key_lookups, "Key lookups are disabled");
         shared_lock_t lock(slot_lookup_mutex_);
         return slot_lookup_.contains(key_and_slot_t::any_slot(key));
     }
@@ -1209,6 +1524,7 @@ class index_dense_gt {
      *  @return Zero if nothing is found, a positive integer otherwise.
      */
     std::size_t count(vector_key_t key) const {
+        usearch_assert_m(config().enable_key_lookups, "Key lookups are disabled");
         shared_lock_t lock(slot_lookup_mutex_);
         return slot_lookup_.count(key_and_slot_t::any_slot(key));
     }
@@ -1233,7 +1549,10 @@ class index_dense_gt {
      *          If an error occurred during the removal operation, `result.error` will contain an error message.
      */
     labeling_result_t remove(vector_key_t key) {
+        usearch_assert_m(config().enable_key_lookups, "Key lookups are disabled");
         labeling_result_t result;
+        if (typed_->is_immutable())
+            return result.failed("Can't remove from an immutable index");
 
         unique_lock_t lookup_lock(slot_lookup_mutex_);
         auto matching_slots = slot_lookup_.equal_range(key_and_slot_t::any_slot(key));
@@ -1243,7 +1562,8 @@ class index_dense_gt {
         // Grow the removed entries ring, if needed
         std::size_t matching_count = std::distance(matching_slots.first, matching_slots.second);
         std::unique_lock<std::mutex> free_lock(free_keys_mutex_);
-        if (!free_keys_.reserve(free_keys_.size() + matching_count))
+        std::size_t free_count_old = free_keys_.size();
+        if (!free_keys_.reserve(free_count_old + matching_count))
             return result.failed("Can't allocate memory for a free-list");
 
         // A removed entry would be:
@@ -1257,6 +1577,7 @@ class index_dense_gt {
         }
         slot_lookup_.erase(key);
         result.completed = matching_count;
+        usearch_assert_m(free_keys_.size() == free_count_old + matching_count, "Free keys count mismatch");
 
         return result;
     }
@@ -1271,6 +1592,7 @@ class index_dense_gt {
      */
     template <typename keys_iterator_at>
     labeling_result_t remove(keys_iterator_at keys_begin, keys_iterator_at keys_end) {
+        usearch_assert_m(config().enable_key_lookups, "Key lookups are disabled");
 
         labeling_result_t result;
         unique_lock_t lookup_lock(slot_lookup_mutex_);
@@ -1357,17 +1679,6 @@ class index_dense_gt {
         });
     }
 
-    struct copy_result_t {
-        index_dense_gt index;
-        error_t error;
-
-        explicit operator bool() const noexcept { return !error; }
-        copy_result_t failed(error_t message) noexcept {
-            error = std::move(message);
-            return std::move(*this);
-        }
-    };
-
     /**
      *  @brief Copies the ::index_dense_gt @b with all the data in it.
      *  @param config The copy configuration (optional).
@@ -1390,19 +1701,22 @@ class index_dense_gt {
             copy.free_keys_.push(free_keys_[i]);
 
         // Allocate buffers and move the vectors themselves
-        if (!config.force_vector_copy && copy.config_.exclude_vectors)
-            copy.vectors_lookup_ = vectors_lookup_;
-        else {
-            copy.vectors_lookup_.resize(vectors_lookup_.size());
-            for (std::size_t slot = 0; slot != vectors_lookup_.size(); ++slot)
+        copy.vectors_lookup_ = vectors_lookup_t(vectors_lookup_.size());
+        if (!copy.vectors_lookup_)
+            return result.failed("Out of memory!");
+        if (!config.force_vector_copy && copy.config_.exclude_vectors) {
+            std::memcpy(copy.vectors_lookup_.data(), vectors_lookup_.data(), vectors_lookup_.size() * sizeof(byte_t*));
+        } else {
+            std::size_t slots_count = typed_result.index.size();
+            for (std::size_t slot = 0; slot != slots_count; ++slot)
                 copy.vectors_lookup_[slot] = copy.vectors_tape_allocator_.allocate(copy.metric_.bytes_per_vector());
-            if (std::count(copy.vectors_lookup_.begin(), copy.vectors_lookup_.end(), nullptr))
+            if (std::count(copy.vectors_lookup_.begin(), copy.vectors_lookup_.begin() + slots_count, nullptr))
                 return result.failed("Out of memory!");
-            for (std::size_t slot = 0; slot != vectors_lookup_.size(); ++slot)
+            for (std::size_t slot = 0; slot != slots_count; ++slot)
                 std::memcpy(copy.vectors_lookup_[slot], vectors_lookup_[slot], metric_.bytes_per_vector());
         }
 
-        copy.slot_lookup_ = slot_lookup_;
+        copy.slot_lookup_ = slot_lookup_; // TODO: Handle out of memory
         *copy.typed_ = std::move(typed_result.index);
         return result;
     }
@@ -1412,22 +1726,34 @@ class index_dense_gt {
      *  @return A similarly configured ::index_dense_gt instance.
      */
     copy_result_t fork() const {
+
+        cast_buffer_t cast_buffer(cast_buffer_.size());
+        if (!cast_buffer)
+            return state_result_t{}.failed("Failed to allocate memory for the casts!");
+        available_threads_t available_threads;
+        std::size_t max_threads = limits().threads();
+        if (!available_threads.reserve(max_threads))
+            return state_result_t{}.failed("Failed to allocate memory for the available threads!");
+        for (std::size_t i = 0; i < max_threads; i++)
+            available_threads.push(i);
+        index_t* raw = index_allocator_t{}.allocate(1);
+        if (!raw)
+            return state_result_t{}.failed("Failed to allocate memory for the index!");
+
         copy_result_t result;
         index_dense_gt& other = result.index;
-
+        index_limits_t other_limits = limits();
+        other_limits.members = 0;
         other.config_ = config_;
-        other.cast_buffer_ = cast_buffer_;
+        other.cast_buffer_ = std::move(cast_buffer);
         other.casts_ = casts_;
 
         other.metric_ = metric_;
-        other.available_threads_ = available_threads_;
+        other.available_threads_ = std::move(available_threads);
         other.free_key_ = free_key_;
 
-        index_t* raw = index_allocator_t{}.allocate(1);
-        if (!raw)
-            return result.failed("Can't allocate the index");
-
         new (raw) index_t(config());
+        raw->try_reserve(other_limits);
         other.typed_ = raw;
         return result;
     }
@@ -1455,12 +1781,12 @@ class index_dense_gt {
     compaction_result_t isolate(executor_at&& executor = executor_at{}, progress_at&& progress = progress_at{}) {
         compaction_result_t result;
         std::atomic<std::size_t> pruned_edges;
-        auto disallow = [&](member_cref_t const& member) noexcept {
+        auto allow = [&](member_cref_t const& member) noexcept {
             bool freed = member.key == free_key_;
             pruned_edges += freed;
-            return freed;
+            return !freed;
         };
-        typed_->isolate(disallow, std::forward<executor_at>(executor), std::forward<progress_at>(progress));
+        typed_->isolate(allow, std::forward<executor_at>(executor), std::forward<progress_at>(progress));
         result.pruned_edges = pruned_edges;
         return result;
     }
@@ -1486,7 +1812,10 @@ class index_dense_gt {
     compaction_result_t compact(executor_at&& executor = executor_at{}, progress_at&& progress = progress_at{}) {
         compaction_result_t result;
 
-        std::vector<byte_t*> new_vectors_lookup(vectors_lookup_.size());
+        vectors_lookup_t new_vectors_lookup(vectors_lookup_.size());
+        if (!new_vectors_lookup)
+            return result.failed("Out of memory!");
+
         vectors_tape_allocator_t new_vectors_allocator;
 
         auto track_slot_change = [&](vector_key_t, compressed_slot_t old_slot, compressed_slot_t new_slot) {
@@ -1666,7 +1995,7 @@ class index_dense_gt {
 
             cluster_t& merge_source = clusters[unique_clusters - 1];
             std::size_t merge_target_idx = 0;
-            distance_t merge_distance = std::numeric_limits<distance_t>::max();
+            distance_t merge_distance = (std::numeric_limits<distance_t>::max)();
 
             for (std::size_t candidate_idx = 0; candidate_idx + 1 < unique_clusters; ++candidate_idx) {
                 distance_t distance = metric_(merge_source.vector, clusters[candidate_idx].vector);
@@ -1717,51 +2046,41 @@ class index_dense_gt {
 
         result.computed_distances = computed_distances;
         result.visited_members = visited_members;
+        result.clusters = unique_clusters;
 
         (void)progress;
         return result;
     }
 
   private:
-    struct thread_lock_t {
-        index_dense_gt const& parent;
-        std::size_t thread_id;
-        bool engaged;
-
-        ~thread_lock_t() {
-            if (engaged)
-                parent.thread_unlock_(thread_id);
-        }
-    };
-
-    thread_lock_t thread_lock_(std::size_t thread_id) const {
+    thread_lock_t thread_lock_(std::size_t thread_id) const usearch_noexcept_m {
         if (thread_id != any_thread())
             return {*this, thread_id, false};
 
         available_threads_mutex_.lock();
-        thread_id = available_threads_.back();
-        available_threads_.pop_back();
+        usearch_assert_m(available_threads_.size(), "No available threads to lock");
+        available_threads_.try_pop(thread_id);
         available_threads_mutex_.unlock();
         return {*this, thread_id, true};
     }
 
-    void thread_unlock_(std::size_t thread_id) const {
+    void thread_unlock_(std::size_t thread_id) const usearch_noexcept_m {
         available_threads_mutex_.lock();
-        available_threads_.push_back(thread_id);
+        usearch_assert_m(available_threads_.size() < available_threads_.capacity(), "Too many threads unlocked");
+        available_threads_.push(thread_id);
         available_threads_mutex_.unlock();
     }
 
     template <typename scalar_at>
     add_result_t add_(                             //
         vector_key_t key, scalar_at const* vector, //
-        std::size_t thread, bool force_vector_copy, cast_t const& cast) {
+        std::size_t thread, bool copy_vector, cast_punned_t const& cast) {
 
-        if (!multi() && contains(key))
+        if (!multi() && config().enable_key_lookups && contains(key))
             return add_result_t{}.failed("Duplicate keys not allowed in high-level wrappers");
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
-        bool copy_vector = !config_.exclude_vectors || force_vector_copy;
         byte_t const* vector_data = reinterpret_cast<byte_t const*>(vector);
         {
             byte_t* casted_data = cast_buffer_.data() + metric_.bytes_per_vector() * lock.thread_id;
@@ -1779,12 +2098,21 @@ class index_dense_gt {
 
         // Perform the insertion or the update
         bool reuse_node = free_slot != default_free_value<compressed_slot_t>();
+
+        byte_t* allocated_vector = nullptr;
+        if (copy_vector && !reuse_node) {
+            allocated_vector = vectors_tape_allocator_.allocate(metric_.bytes_per_vector());
+            if (!allocated_vector)
+                return add_result_t{}.failed("Out of memory!");
+        }
         auto on_success = [&](member_ref_t member) {
-            unique_lock_t slot_lock(slot_lookup_mutex_);
-            slot_lookup_.try_emplace(key_and_slot_t{key, static_cast<compressed_slot_t>(member.slot)});
+            if (config_.enable_key_lookups) {
+                unique_lock_t slot_lock(slot_lookup_mutex_);
+                slot_lookup_.try_emplace(key_and_slot_t{key, static_cast<compressed_slot_t>(member.slot)});
+            }
             if (copy_vector) {
                 if (!reuse_node)
-                    vectors_lookup_[member.slot] = vectors_tape_allocator_.allocate(metric_.bytes_per_vector());
+                    vectors_lookup_[member.slot] = allocated_vector;
                 std::memcpy(vectors_lookup_[member.slot], vector_data, metric_.bytes_per_vector());
             } else
                 vectors_lookup_[member.slot] = (byte_t*)vector_data;
@@ -1802,7 +2130,8 @@ class index_dense_gt {
 
     template <typename scalar_at, typename predicate_at>
     search_result_t search_(scalar_at const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread,
-                            bool exact, cast_t const& cast, std::size_t expansion_search) const {
+                            bool exact, cast_punned_t const& cast,
+                            std::size_t expansion_override = 0) const {
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
@@ -1816,27 +2145,29 @@ class index_dense_gt {
 
         index_search_config_t search_config;
         search_config.thread = lock.thread_id;
-        search_config.expansion = expansion_search;
+        search_config.expansion = expansion_override ? expansion_override : config_.expansion_search;
         search_config.exact = exact;
 
-        auto &free_key_ = this->free_key_;
+        vector_key_t free_key_copy = free_key_;
         if (std::is_same<typename std::decay<predicate_at>::type, dummy_predicate_t>::value) {
-            auto allow = [&free_key_](member_cref_t const& member) noexcept {
-                return member.key != free_key_;
+            auto allow = [free_key_copy](member_cref_t const& member) noexcept {
+                return (vector_key_t)member.key != free_key_copy;
             };
-            return typed_->search(vector_data, wanted, metric_proxy_t{*this}, search_config, allow);
+            auto typed_result = typed_->search(vector_data, wanted, metric_proxy_t{*this}, search_config, allow);
+            return search_result_t{std::move(typed_result), std::move(lock)};
         } else {
-            auto allow = [&free_key_, &predicate](member_cref_t const& member) noexcept {
-                return member.key != free_key_ && predicate(member.key);
+            auto allow = [free_key_copy, &predicate](member_cref_t const& member) noexcept {
+                return (vector_key_t)member.key != free_key_copy && predicate(member.key);
             };
-            return typed_->search(vector_data, wanted, metric_proxy_t{*this}, search_config, allow);
+            auto typed_result = typed_->search(vector_data, wanted, metric_proxy_t{*this}, search_config, allow);
+            return search_result_t{std::move(typed_result), std::move(lock)};
         }
     }
 
     template <typename scalar_at>
     cluster_result_t cluster_(                      //
         scalar_at const* vector, std::size_t level, //
-        std::size_t thread, cast_t const& cast) const {
+        std::size_t thread, cast_punned_t const& cast) const {
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
@@ -1852,17 +2183,15 @@ class index_dense_gt {
         cluster_config.thread = lock.thread_id;
         cluster_config.expansion = config_.expansion_search;
 
-        auto &free_key_ = this->free_key_;
-        auto allow = [&free_key_](member_cref_t const& member) noexcept {
-            return member.key != free_key_;
-        };
+        vector_key_t free_key_copy = free_key_;
+        auto allow = [free_key_copy](member_cref_t const& member) noexcept { return member.key != free_key_copy; };
         return typed_->cluster(vector_data, level, metric_proxy_t{*this}, cluster_config, allow);
     }
 
     template <typename scalar_at>
     aggregated_distances_t distance_between_(      //
         vector_key_t key, scalar_at const* vector, //
-        std::size_t thread, cast_t const& cast) const {
+        std::size_t thread, cast_punned_t const& cast) const {
 
         // Cast the vector, if needed for compatibility with `metric_`
         thread_lock_t lock = thread_lock_(thread);
@@ -1875,14 +2204,15 @@ class index_dense_gt {
         }
 
         // Check if such `key` is even present.
+        usearch_assert_m(config().enable_key_lookups, "Key lookups are disabled!");
         shared_lock_t slots_lock(slot_lookup_mutex_);
         auto key_range = slot_lookup_.equal_range(key_and_slot_t::any_slot(key));
         aggregated_distances_t result;
         if (key_range.first == key_range.second)
             return result;
 
-        result.min = std::numeric_limits<distance_t>::max();
-        result.max = std::numeric_limits<distance_t>::min();
+        result.min = (std::numeric_limits<distance_t>::max)();
+        result.max = (std::numeric_limits<distance_t>::min)();
         result.mean = 0;
         result.count = 0;
 
@@ -1911,7 +2241,8 @@ class index_dense_gt {
         std::size_t count_total = typed_->size();
         std::size_t count_removed = 0;
         for (std::size_t i = 0; i != count_total; ++i) {
-            member_cref_t member = typed_->at(i);
+            auto member_slot = static_cast<compressed_slot_t>(i);
+            member_cref_t member = typed_->at(member_slot);
             count_removed += member.key == free_key_;
         }
 
@@ -1927,16 +2258,18 @@ class index_dense_gt {
         free_keys_.clear();
         free_keys_.reserve(count_removed);
         for (std::size_t i = 0; i != typed_->size(); ++i) {
-            member_cref_t member = typed_->at(i);
+            auto member_slot = static_cast<compressed_slot_t>(i);
+            member_cref_t member = typed_->at(member_slot);
             if (member.key == free_key_)
-                free_keys_.push(static_cast<compressed_slot_t>(i));
+                free_keys_.push(member_slot);
             else if (config_.enable_key_lookups)
-                slot_lookup_.try_emplace(key_and_slot_t{vector_key_t(member.key), static_cast<compressed_slot_t>(i)});
+                slot_lookup_.try_emplace(key_and_slot_t{vector_key_t(member.key), member_slot});
         }
     }
 
     template <typename scalar_at>
-    std::size_t get_(vector_key_t key, scalar_at* reconstructed, std::size_t vectors_limit, cast_t const& cast) const {
+    std::size_t get_(vector_key_t key, scalar_at* reconstructed, std::size_t vectors_limit,
+                     cast_punned_t const& cast) const {
 
         if (!multi()) {
             compressed_slot_t slot;
@@ -1969,35 +2302,6 @@ class index_dense_gt {
                     std::memcpy(reconstructed_vector, punned_vector, metric_.bytes_per_vector());
             }
             return count_exported;
-        }
-    }
-
-    template <typename to_scalar_at> static casts_t make_casts_() {
-        casts_t result;
-
-        result.from_b1x8 = cast_gt<b1x8_t, to_scalar_at>{};
-        result.from_i8 = cast_gt<i8_t, to_scalar_at>{};
-        result.from_f16 = cast_gt<f16_t, to_scalar_at>{};
-        result.from_f32 = cast_gt<f32_t, to_scalar_at>{};
-        result.from_f64 = cast_gt<f64_t, to_scalar_at>{};
-
-        result.to_b1x8 = cast_gt<to_scalar_at, b1x8_t>{};
-        result.to_i8 = cast_gt<to_scalar_at, i8_t>{};
-        result.to_f16 = cast_gt<to_scalar_at, f16_t>{};
-        result.to_f32 = cast_gt<to_scalar_at, f32_t>{};
-        result.to_f64 = cast_gt<to_scalar_at, f64_t>{};
-
-        return result;
-    }
-
-    static casts_t make_casts_(scalar_kind_t scalar_kind) {
-        switch (scalar_kind) {
-        case scalar_kind_t::f64_k: return make_casts_<f64_t>();
-        case scalar_kind_t::f32_k: return make_casts_<f32_t>();
-        case scalar_kind_t::f16_k: return make_casts_<f16_t>();
-        case scalar_kind_t::i8_k: return make_casts_<i8_t>();
-        case scalar_kind_t::b1x8_k: return make_casts_<b1x8_t>();
-        default: return {};
         }
     }
 };
@@ -2035,7 +2339,7 @@ static join_result_t join(                                    //
     man_to_woman_at&& man_to_woman = man_to_woman_at{}, //
     woman_to_man_at&& woman_to_man = woman_to_man_at{}, //
     executor_at&& executor = executor_at{},             //
-    progress_at&& progress = progress_at{}) noexcept {
+    progress_at&& progress = progress_at{}) {
 
     return men.join(                                 //
         women, config,                               //

--- a/src/include/usearch/index_plugins.hpp
+++ b/src/include/usearch/index_plugins.hpp
@@ -3,15 +3,16 @@
 #include <float.h>  // `_Float16`
 #include <stdlib.h> // `aligned_alloc`
 
+#include <atomic>  // `std::atomic`
+#include <chrono>  // `std::chrono`
 #include <cstring> // `std::strncmp`
-#include <numeric> // `std::iota`
 #include <thread>  // `std::thread`
-#include <vector>  // `std::vector`
-
-#include <atomic> // `std::atomic`
-#include <thread> // `std::thread`
 
 #include <usearch/index.hpp> // `expected_gt` and macros
+
+#if defined(USEARCH_DEFINED_LINUX)
+#include <sys/auxv.h> // `getauxval()`
+#endif
 
 #if !defined(USEARCH_USE_OPENMP)
 #define USEARCH_USE_OPENMP 0
@@ -21,42 +22,44 @@
 #include <omp.h> // `omp_get_num_threads()`
 #endif
 
-#if defined(USEARCH_DEFINED_LINUX)
-#include <sys/auxv.h> // `getauxval()`
+#if !defined(USEARCH_USE_NUMKONG)
+#define USEARCH_USE_NUMKONG 0
 #endif
 
-#if !defined(USEARCH_USE_FP16LIB)
-#if defined(__AVX512F__)
-#define USEARCH_USE_FP16LIB 0
-#elif defined(USEARCH_DEFINED_ARM)
-#include <arm_fp16.h> // `__fp16`
-#define USEARCH_USE_FP16LIB 0
-#else
-#define USEARCH_USE_FP16LIB 1
-#endif
-#endif
-
-#if USEARCH_USE_FP16LIB
-#include <fp16/fp16.h>
-#endif
-
-#if !defined(USEARCH_USE_SIMSIMD)
-#define USEARCH_USE_SIMSIMD 0
-#endif
-
-#if USEARCH_USE_SIMSIMD
+#if USEARCH_USE_NUMKONG
 // Propagate the `f16` settings
-#if !defined(SIMSIMD_NATIVE_F16)
-#define SIMSIMD_NATIVE_F16 !USEARCH_USE_FP16LIB
+#if defined(USEARCH_CAN_COMPILE_FP16) || defined(USEARCH_CAN_COMPILE_FLOAT16)
+#if USEARCH_CAN_COMPILE_FP16 || USEARCH_CAN_COMPILE_FLOAT16
+#define NK_NATIVE_F16 1
+#else
+#define NK_NATIVE_F16 0
 #endif
-#define SIMSIMD_DYNAMIC_DISPATCH 0
+#endif
+// Propagate the `bf16` settings
+#if defined(USEARCH_CAN_COMPILE_BF16) || defined(USEARCH_CAN_COMPILE_BFLOAT16)
+#if USEARCH_CAN_COMPILE_BF16 || USEARCH_CAN_COMPILE_BFLOAT16
+#define NK_NATIVE_BF16 1
+#else
+#define NK_NATIVE_BF16 0
+#endif
+#endif
 // No problem, if some of the functions are unused or undefined
 #pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Wall"
+#pragma GCC diagnostic ignored "-Wunused"
 #pragma GCC diagnostic ignored "-Wunused-function"
+#pragma GCC diagnostic ignored "-Wunused-parameter"
+#pragma GCC diagnostic ignored "-Wunused-variable"
+#pragma GCC diagnostic ignored "-Wunused-but-set-variable"
+#if defined(_MSC_VER)
 #pragma warning(push)
-#pragma warning(disable : 4101)
-#include <simsimd/simsimd.h>
+#pragma warning(disable : 4101) // "Unused variables"
+#pragma warning(disable : 4068) // "Unknown pragmas", when MSVC tries to read GCC pragmas
+#endif                          // _MSC_VER
+#include <numkong/numkong.h>
+#ifdef _MSC_VER
 #pragma warning(pop)
+#endif // _MSC_VER
 #pragma GCC diagnostic pop
 #endif
 
@@ -70,22 +73,19 @@ struct uuid_t {
     std::uint8_t octets[16];
 };
 
+class bf16_bits_t;
 class f16_bits_t;
-class i8_converted_t;
+class e5m2_bits_t;
+class e4m3_bits_t;
+class e3m2_bits_t;
+class e2m3_bits_t;
 
-#if !USEARCH_USE_FP16LIB
-#if USEARCH_USE_SIMSIMD
-using f16_native_t = simsimd_f16_t;
-#elif defined(USEARCH_DEFINED_ARM)
-using f16_native_t = __fp16;
-#else
-using f16_native_t = _Float16;
-#endif
-using f16_t = f16_native_t;
-#else
-using f16_native_t = void;
+using bf16_t = bf16_bits_t;
 using f16_t = f16_bits_t;
-#endif
+using e5m2_t = e5m2_bits_t;
+using e4m3_t = e4m3_bits_t;
+using e3m2_t = e3m2_bits_t;
+using e2m3_t = e2m3_bits_t;
 
 using f64_t = double;
 using f32_t = float;
@@ -100,6 +100,17 @@ using i32_t = std::int32_t;
 using i16_t = std::int16_t;
 using i8_t = std::int8_t;
 
+/**
+ *  @brief  Reinterpret-cast between float and uint32 without UB on most compilers.
+ */
+union fu32_t {
+    float f;
+    std::uint32_t u;
+};
+
+/**
+ *  @brief  Enumerates the most commonly used distance metrics, mostly for dense vector representations.
+ */
 enum class metric_kind_t : std::uint8_t {
     unknown_k = 0,
     // Classics:
@@ -112,24 +123,35 @@ enum class metric_kind_t : std::uint8_t {
     haversine_k = 'h',
     divergence_k = 'd',
 
-    // Sets:
-    jaccard_k = 'j',
+    // Dense Sets:
     hamming_k = 'b',
     tanimoto_k = 't',
     sorensen_k = 's',
+
+    // Sparse Sets:
+    jaccard_k = 'j',
 };
 
+/**
+ *  @brief  Enumerates the most commonly used scalar types, mostly for dense vector representations.
+ *          Doesn't include logical types, like complex numbers or quaternions.
+ */
 enum class scalar_kind_t : std::uint8_t {
     unknown_k = 0,
     // Custom:
     b1x8_k = 1,
     u40_k = 2,
     uuid_k = 3,
+    bf16_k = 4,
+    // Mini-floats:
+    e5m2_k = 5, ///< FP8 IEEE 754: 1 sign + 5 exponent + 2 mantissa, range +/-57344
+    e4m3_k = 6, ///< FP8 OCP: 1 sign + 4 exponent + 3 mantissa, range +/-448
+    e3m2_k = 8, ///< FP6: 1 sign + 3 exponent + 2 mantissa, range +/-28
+    e2m3_k = 7, ///< FP6: 1 sign + 2 exponent + 3 mantissa, range +/-7.5
     // Common:
     f64_k = 10,
     f32_k = 11,
     f16_k = 12,
-    f8_k = 13,
     // Common Integral:
     u64_k = 14,
     u32_k = 15,
@@ -141,12 +163,9 @@ enum class scalar_kind_t : std::uint8_t {
     i8_k = 23,
 };
 
-enum class prefetching_kind_t {
-    none_k,
-    cpu_k,
-    io_uring_k,
-};
-
+/**
+ *  @brief  Maps a scalar type to its corresponding scalar_kind_t enumeration value.
+ */
 template <typename scalar_at> scalar_kind_t scalar_kind() noexcept {
     if (std::is_same<scalar_at, b1x8_t>())
         return scalar_kind_t::b1x8_k;
@@ -160,6 +179,16 @@ template <typename scalar_at> scalar_kind_t scalar_kind() noexcept {
         return scalar_kind_t::f32_k;
     if (std::is_same<scalar_at, f16_t>())
         return scalar_kind_t::f16_k;
+    if (std::is_same<scalar_at, bf16_t>())
+        return scalar_kind_t::bf16_k;
+    if (std::is_same<scalar_at, e5m2_t>())
+        return scalar_kind_t::e5m2_k;
+    if (std::is_same<scalar_at, e4m3_t>())
+        return scalar_kind_t::e4m3_k;
+    if (std::is_same<scalar_at, e3m2_t>())
+        return scalar_kind_t::e3m2_k;
+    if (std::is_same<scalar_at, e2m3_t>())
+        return scalar_kind_t::e2m3_k;
     if (std::is_same<scalar_at, i8_t>())
         return scalar_kind_t::i8_k;
     if (std::is_same<scalar_at, u64_t>())
@@ -181,55 +210,128 @@ template <typename scalar_at> scalar_kind_t scalar_kind() noexcept {
     return scalar_kind_t::unknown_k;
 }
 
+/**
+ *  @brief  Converts an angle from degrees to radians.
+ */
 template <typename at> at angle_to_radians(at angle) noexcept { return angle * at(3.14159265358979323846) / at(180); }
 
+/**
+ *  @brief  Readability helper to compute the square of a given value.
+ */
 template <typename at> at square(at value) noexcept { return value * value; }
 
+/**
+ *  @brief  Clamps a value between a lower and upper bound using a custom comparator. Similar to `std::clamp`.
+ *          https://en.cppreference.com/w/cpp/algorithm/clamp
+ */
 template <typename at, typename compare_at> inline at clamp(at v, at lo, at hi, compare_at comp) noexcept {
     return comp(v, lo) ? lo : comp(hi, v) ? hi : v;
 }
+
+/**
+ *  @brief  Clamps a value between a lower and upper bound. Similar to `std::clamp`.
+ *          https://en.cppreference.com/w/cpp/algorithm/clamp
+ */
 template <typename at> inline at clamp(at v, at lo, at hi) noexcept {
     return usearch::clamp(v, lo, hi, std::less<at>{});
 }
 
-inline bool str_equals(char const* begin, std::size_t len, char const* other_begin) noexcept {
-    std::size_t other_len = std::strlen(other_begin);
-    return len == other_len && std::strncmp(begin, other_begin, len) == 0;
+/**
+ *  @brief  Compares two strings for equality, given a length for the first string.
+ */
+inline bool str_equals(char const* first_begin, std::size_t first_len, char const* second_begin) noexcept {
+    std::size_t second_len = std::strlen(second_begin);
+    return first_len == second_len && std::strncmp(first_begin, second_begin, first_len) == 0;
 }
 
+/**
+ *  @brief  Returns the number of bits required to represent a scalar type.
+ */
 inline std::size_t bits_per_scalar(scalar_kind_t scalar_kind) noexcept {
     switch (scalar_kind) {
-    case scalar_kind_t::f64_k: return 64;
-    case scalar_kind_t::f32_k: return 32;
-    case scalar_kind_t::f16_k: return 16;
-    case scalar_kind_t::i8_k: return 8;
+    case scalar_kind_t::uuid_k: return 128;
+    case scalar_kind_t::u40_k: return 40;
+    case scalar_kind_t::bf16_k: return 16;
     case scalar_kind_t::b1x8_k: return 1;
+    case scalar_kind_t::u64_k: return 64;
+    case scalar_kind_t::i64_k: return 64;
+    case scalar_kind_t::f64_k: return 64;
+    case scalar_kind_t::u32_k: return 32;
+    case scalar_kind_t::i32_k: return 32;
+    case scalar_kind_t::f32_k: return 32;
+    case scalar_kind_t::u16_k: return 16;
+    case scalar_kind_t::i16_k: return 16;
+    case scalar_kind_t::f16_k: return 16;
+    case scalar_kind_t::u8_k: return 8;
+    case scalar_kind_t::i8_k: return 8;
+    case scalar_kind_t::e5m2_k: return 8;
+    case scalar_kind_t::e4m3_k: return 8;
+    case scalar_kind_t::e2m3_k: return 8;
+    case scalar_kind_t::e3m2_k: return 8;
     default: return 0;
     }
 }
 
+/**
+ *  @brief  Returns the number of bits in a scalar word for a given scalar type.
+ *          Equivalent to `bits_per_scalar` for types that are not bit-packed.
+ */
 inline std::size_t bits_per_scalar_word(scalar_kind_t scalar_kind) noexcept {
     switch (scalar_kind) {
-    case scalar_kind_t::f64_k: return 64;
-    case scalar_kind_t::f32_k: return 32;
-    case scalar_kind_t::f16_k: return 16;
-    case scalar_kind_t::i8_k: return 8;
+    case scalar_kind_t::uuid_k: return 128;
+    case scalar_kind_t::u40_k: return 40;
+    case scalar_kind_t::bf16_k: return 16;
     case scalar_kind_t::b1x8_k: return 8;
+    case scalar_kind_t::u64_k: return 64;
+    case scalar_kind_t::i64_k: return 64;
+    case scalar_kind_t::f64_k: return 64;
+    case scalar_kind_t::u32_k: return 32;
+    case scalar_kind_t::i32_k: return 32;
+    case scalar_kind_t::f32_k: return 32;
+    case scalar_kind_t::u16_k: return 16;
+    case scalar_kind_t::i16_k: return 16;
+    case scalar_kind_t::f16_k: return 16;
+    case scalar_kind_t::u8_k: return 8;
+    case scalar_kind_t::i8_k: return 8;
+    case scalar_kind_t::e5m2_k: return 8;
+    case scalar_kind_t::e4m3_k: return 8;
+    case scalar_kind_t::e2m3_k: return 8;
+    case scalar_kind_t::e3m2_k: return 8;
     default: return 0;
     }
 }
 
+/**
+ *  @brief  Returns the string name of a given scalar type.
+ */
 inline char const* scalar_kind_name(scalar_kind_t scalar_kind) noexcept {
     switch (scalar_kind) {
-    case scalar_kind_t::f32_k: return "f32";
-    case scalar_kind_t::f16_k: return "f16";
-    case scalar_kind_t::f64_k: return "f64";
-    case scalar_kind_t::i8_k: return "i8";
+    case scalar_kind_t::uuid_k: return "uuid";
+    case scalar_kind_t::u40_k: return "u40";
+    case scalar_kind_t::bf16_k: return "bf16";
     case scalar_kind_t::b1x8_k: return "b1x8";
+    case scalar_kind_t::u64_k: return "u64";
+    case scalar_kind_t::i64_k: return "i64";
+    case scalar_kind_t::f64_k: return "f64";
+    case scalar_kind_t::u32_k: return "u32";
+    case scalar_kind_t::i32_k: return "i32";
+    case scalar_kind_t::f32_k: return "f32";
+    case scalar_kind_t::u16_k: return "u16";
+    case scalar_kind_t::i16_k: return "i16";
+    case scalar_kind_t::f16_k: return "f16";
+    case scalar_kind_t::u8_k: return "u8";
+    case scalar_kind_t::i8_k: return "i8";
+    case scalar_kind_t::e5m2_k: return "e5m2";
+    case scalar_kind_t::e4m3_k: return "e4m3";
+    case scalar_kind_t::e2m3_k: return "e2m3";
+    case scalar_kind_t::e3m2_k: return "e3m2";
     default: return "";
     }
 }
 
+/**
+ *  @brief  Returns the string name of a given distance metric.
+ */
 inline char const* metric_kind_name(metric_kind_t metric) noexcept {
     switch (metric) {
     case metric_kind_t::unknown_k: return "unknown";
@@ -243,28 +345,52 @@ inline char const* metric_kind_name(metric_kind_t metric) noexcept {
     case metric_kind_t::hamming_k: return "hamming";
     case metric_kind_t::tanimoto_k: return "tanimoto";
     case metric_kind_t::sorensen_k: return "sorensen";
+    default: return "";
     }
-    return "";
 }
+
+/**
+ *  @brief  Parses a string to identify the corresponding `scalar_kind_t` enumeration value.
+ */
 inline expected_gt<scalar_kind_t> scalar_kind_from_name(char const* name, std::size_t len) {
     expected_gt<scalar_kind_t> parsed;
-    if (str_equals(name, len, "f32"))
-        parsed.result = scalar_kind_t::f32_k;
-    else if (str_equals(name, len, "f64"))
+    if (str_equals(name, len, "f64"))
         parsed.result = scalar_kind_t::f64_k;
+    else if (str_equals(name, len, "f32"))
+        parsed.result = scalar_kind_t::f32_k;
+    else if (str_equals(name, len, "bf16"))
+        parsed.result = scalar_kind_t::bf16_k;
     else if (str_equals(name, len, "f16"))
         parsed.result = scalar_kind_t::f16_k;
+    else if (str_equals(name, len, "e5m2"))
+        parsed.result = scalar_kind_t::e5m2_k;
+    else if (str_equals(name, len, "e4m3"))
+        parsed.result = scalar_kind_t::e4m3_k;
+    else if (str_equals(name, len, "e3m2"))
+        parsed.result = scalar_kind_t::e3m2_k;
+    else if (str_equals(name, len, "e2m3"))
+        parsed.result = scalar_kind_t::e2m3_k;
     else if (str_equals(name, len, "i8"))
         parsed.result = scalar_kind_t::i8_k;
+    else if (str_equals(name, len, "u8"))
+        parsed.result = scalar_kind_t::u8_k;
+    else if (str_equals(name, len, "b1"))
+        parsed.result = scalar_kind_t::b1x8_k;
     else
-        parsed.failed("Unknown type, choose: f32, f16, f64, i8");
+        parsed.failed("Unknown type, choose: f64, f32, bf16, f16, e5m2, e4m3, e3m2, e2m3, i8, u8, b1");
     return parsed;
 }
 
+/**
+ *  @brief  Parses a string to identify the corresponding `scalar_kind_t` enumeration value.
+ */
 inline expected_gt<scalar_kind_t> scalar_kind_from_name(char const* name) {
     return scalar_kind_from_name(name, std::strlen(name));
 }
 
+/**
+ *  @brief  Parses a string to identify the corresponding `metric_kind_t` enumeration value.
+ */
 inline expected_gt<metric_kind_t> metric_from_name(char const* name, std::size_t len) {
     expected_gt<metric_kind_t> parsed;
     if (str_equals(name, len, "l2sq") || str_equals(name, len, "euclidean_sq")) {
@@ -291,28 +417,147 @@ inline expected_gt<metric_kind_t> metric_from_name(char const* name, std::size_t
     return parsed;
 }
 
+/**
+ *  @brief  Parses a string to identify the corresponding `metric_kind_t` enumeration value.
+ */
 inline expected_gt<metric_kind_t> metric_from_name(char const* name) {
     return metric_from_name(name, std::strlen(name));
 }
 
+/**
+ *  @brief Convenience function to upcast a half-precision floating point number to a single-precision one.
+ */
 inline float f16_to_f32(std::uint16_t u16) noexcept {
-#if !USEARCH_USE_FP16LIB
-    f16_native_t f16;
-    std::memcpy(&f16, &u16, sizeof(std::uint16_t));
-    return float(f16);
+#if USEARCH_USE_NUMKONG
+    nk_f32_t result;
+    nk_f16_to_f32_serial((nk_f16_t const*)&u16, &result);
+    return result;
 #else
-    return fp16_ieee_to_fp32_value(u16);
+    std::uint32_t sign = (u16 >> 15) & 1;
+    std::uint32_t exponent = (u16 >> 10) & 0x1F;
+    std::uint32_t mantissa = u16 & 0x03FF;
+    fu32_t conv;
+    if (exponent == 0) {
+        if (mantissa == 0) {
+            conv.u = sign << 31;
+        } else {
+            // Denormal: use FPU normalization trick
+            fu32_t temp;
+            temp.f = (float)mantissa;
+            conv.u = (sign << 31) | (temp.u - 0x0C000000u);
+        }
+    } else if (exponent == 31) {
+        conv.u = (sign << 31) | 0x7F800000u | (mantissa << 13);
+    } else {
+        conv.u = (sign << 31) | ((exponent + 112u) << 23) | (mantissa << 13);
+    }
+    return conv.f;
 #endif
 }
 
+/**
+ *  @brief Convenience function to downcast a single-precision floating point number to a half-precision one.
+ */
 inline std::uint16_t f32_to_f16(float f32) noexcept {
-#if !USEARCH_USE_FP16LIB
-    f16_native_t f16 = f16_native_t(f32);
+#if USEARCH_USE_NUMKONG
+    nk_f16_t result;
+    nk_f32_to_f16_serial((nk_f32_t const*)&f32, &result);
     std::uint16_t u16;
-    std::memcpy(&u16, &f16, sizeof(std::uint16_t));
+    std::memcpy(&u16, &result, sizeof(u16));
     return u16;
 #else
-    return fp16_ieee_from_fp32_value(f32);
+    fu32_t conv;
+    conv.f = f32;
+    std::uint32_t sign = (conv.u >> 31) & 1;
+    std::uint32_t exponent = (conv.u >> 23) & 0xFF;
+    std::uint32_t mantissa = conv.u & 0x007FFFFFu;
+    std::uint16_t result;
+    if (exponent == 0) {
+        result = (std::uint16_t)(sign << 15);
+    } else if (exponent == 255) {
+        std::uint16_t payload = (std::uint16_t)(mantissa >> 13);
+        if (mantissa != 0 && payload == 0)
+            payload = 1;
+        result = (std::uint16_t)((sign << 15) | 0x7C00 | payload);
+    } else if (exponent <= 102) {
+        if (exponent == 102 && mantissa > 0)
+            result = (std::uint16_t)((sign << 15) | 0x0001);
+        else
+            result = (std::uint16_t)(sign << 15);
+    } else if (exponent < 113) {
+        // Denormal range with RNE rounding
+        unsigned shift = 113 - exponent;
+        unsigned shift_amount = shift + 13;
+        std::uint64_t full_mant = 0x00800000ULL | mantissa;
+        std::uint32_t mant = (std::uint32_t)(full_mant >> shift_amount);
+        std::uint32_t round_bit = (std::uint32_t)((full_mant >> (shift_amount - 1)) & 1);
+        std::uint64_t sticky_bits = full_mant & ((1ULL << (shift_amount - 1)) - 1);
+        if (round_bit && (sticky_bits || (mant & 1)))
+            mant++;
+        result = (std::uint16_t)((sign << 15) | mant);
+    } else if (exponent < 143) {
+        // Normal range with RNE rounding
+        std::uint32_t f16_exp = exponent - 112;
+        std::uint32_t f16_mant = mantissa >> 13;
+        std::uint32_t round_bit = (mantissa >> 12) & 1;
+        std::uint32_t sticky_bits = mantissa & 0xFFF;
+        if (round_bit && (sticky_bits || (f16_mant & 1))) {
+            f16_mant++;
+            if (f16_mant > 0x3FF) {
+                f16_mant = 0;
+                f16_exp++;
+            }
+        }
+        if (f16_exp > 30)
+            result = (std::uint16_t)((sign << 15) | 0x7C00);
+        else
+            result = (std::uint16_t)((sign << 15) | (f16_exp << 10) | f16_mant);
+    } else {
+        result = (std::uint16_t)((sign << 15) | 0x7C00);
+    }
+    return result;
+#endif
+}
+
+/**
+ *  @brief Convenience function to upcast a brain-floating point number to a single-precision one.
+ *  https://github.com/ashvardanian/NumKong/blob/7e58e9fee9e096238cf29f7c30774fa3dcd0fe85/include/numkong/cast/serial.h#L226-L244
+ */
+inline float bf16_to_f32(std::uint16_t u16) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_f32_t result;
+    nk_bf16_to_f32_serial((nk_bf16_t const*)&u16, &result);
+    return result;
+#else
+    union float_or_unsigned_int_t {
+        float f;
+        unsigned int i;
+    } conv;
+    conv.i = u16 << 16; // Zero extends the mantissa
+    return conv.f;
+#endif
+}
+
+/**
+ *  @brief Convenience function to downcast a single-precision floating point number to a brain-floating point one.
+ *  https://github.com/ashvardanian/NumKong/blob/7e58e9fee9e096238cf29f7c30774fa3dcd0fe85/include/numkong/cast/serial.h#L244-L262
+ */
+inline std::uint16_t f32_to_bf16(float f32) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_bf16_t result;
+    nk_f32_to_bf16_serial((nk_f32_t const*)&f32, &result);
+    std::uint16_t u16;
+    std::memcpy(&u16, &result, sizeof(u16));
+    return u16;
+#else
+    union float_or_unsigned_int_t {
+        float f;
+        unsigned int i;
+    } conv;
+    conv.f = f32;
+    conv.i >>= 16;
+    conv.i &= 0xFFFF;
+    return (unsigned short)conv.i;
 #endif
 }
 
@@ -334,23 +579,25 @@ class f16_bits_t {
     inline operator float() const noexcept { return f16_to_f32(uint16_); }
     inline explicit operator bool() const noexcept { return f16_to_f32(uint16_) > 0.5f; }
 
-    inline f16_bits_t(i8_converted_t) noexcept;
-    inline f16_bits_t(bool v) noexcept : uint16_(f32_to_f16(v)) {}
+    inline f16_bits_t(int v) noexcept : uint16_(f32_to_f16(static_cast<float>(v))) {}
+    inline f16_bits_t(bool v) noexcept : uint16_(f32_to_f16(static_cast<float>(v))) {}
     inline f16_bits_t(float v) noexcept : uint16_(f32_to_f16(v)) {}
     inline f16_bits_t(double v) noexcept : uint16_(f32_to_f16(static_cast<float>(v))) {}
+
+    inline bool operator<(f16_bits_t const& other) const noexcept { return float(*this) < float(other); }
 
     inline f16_bits_t operator+(f16_bits_t other) const noexcept { return {float(*this) + float(other)}; }
     inline f16_bits_t operator-(f16_bits_t other) const noexcept { return {float(*this) - float(other)}; }
     inline f16_bits_t operator*(f16_bits_t other) const noexcept { return {float(*this) * float(other)}; }
     inline f16_bits_t operator/(f16_bits_t other) const noexcept { return {float(*this) / float(other)}; }
-    inline f16_bits_t operator+(float other) const noexcept { return {float(*this) + other}; }
-    inline f16_bits_t operator-(float other) const noexcept { return {float(*this) - other}; }
-    inline f16_bits_t operator*(float other) const noexcept { return {float(*this) * other}; }
-    inline f16_bits_t operator/(float other) const noexcept { return {float(*this) / other}; }
-    inline f16_bits_t operator+(double other) const noexcept { return {float(*this) + other}; }
-    inline f16_bits_t operator-(double other) const noexcept { return {float(*this) - other}; }
-    inline f16_bits_t operator*(double other) const noexcept { return {float(*this) * other}; }
-    inline f16_bits_t operator/(double other) const noexcept { return {float(*this) / other}; }
+    inline float operator+(float other) const noexcept { return float(*this) + other; }
+    inline float operator-(float other) const noexcept { return float(*this) - other; }
+    inline float operator*(float other) const noexcept { return float(*this) * other; }
+    inline float operator/(float other) const noexcept { return float(*this) / other; }
+    inline double operator+(double other) const noexcept { return float(*this) + other; }
+    inline double operator-(double other) const noexcept { return float(*this) - other; }
+    inline double operator*(double other) const noexcept { return float(*this) * other; }
+    inline double operator/(double other) const noexcept { return float(*this) / other; }
 
     inline f16_bits_t& operator+=(float v) noexcept {
         uint16_ = f32_to_f16(v + f16_to_f32(uint16_));
@@ -373,6 +620,730 @@ class f16_bits_t {
     }
 };
 
+#if USEARCH_USE_OPENMP
+#pragma omp declare reduction(+ : unum::usearch::f16_bits_t : omp_out = omp_out + omp_in)                              \
+    initializer(omp_priv = unum::usearch::f16_bits_t())
+#endif
+
+/**
+ *  @brief  Numeric type for brain-floating point half-precision floating point.
+ *          If hardware support isn't available, falls back to a hardware
+ *          agnostic in-software implementation.
+ */
+class bf16_bits_t {
+    std::uint16_t uint16_{};
+
+  public:
+    inline bf16_bits_t() noexcept : uint16_(0) {}
+    inline bf16_bits_t(bf16_bits_t&&) = default;
+    inline bf16_bits_t& operator=(bf16_bits_t&&) = default;
+    inline bf16_bits_t(bf16_bits_t const&) = default;
+    inline bf16_bits_t& operator=(bf16_bits_t const&) = default;
+
+    inline operator float() const noexcept { return bf16_to_f32(uint16_); }
+    inline explicit operator bool() const noexcept { return bf16_to_f32(uint16_) > 0.5f; }
+
+    inline bf16_bits_t(int v) noexcept : uint16_(f32_to_bf16(static_cast<float>(v))) {}
+    inline bf16_bits_t(bool v) noexcept : uint16_(f32_to_bf16(static_cast<float>(v))) {}
+    inline bf16_bits_t(float v) noexcept : uint16_(f32_to_bf16(v)) {}
+    inline bf16_bits_t(double v) noexcept : uint16_(f32_to_bf16(static_cast<float>(v))) {}
+
+    inline bool operator<(bf16_bits_t const& other) const noexcept { return float(*this) < float(other); }
+
+    inline bf16_bits_t operator+(bf16_bits_t other) const noexcept { return {float(*this) + float(other)}; }
+    inline bf16_bits_t operator-(bf16_bits_t other) const noexcept { return {float(*this) - float(other)}; }
+    inline bf16_bits_t operator*(bf16_bits_t other) const noexcept { return {float(*this) * float(other)}; }
+    inline bf16_bits_t operator/(bf16_bits_t other) const noexcept { return {float(*this) / float(other)}; }
+    inline float operator+(float other) const noexcept { return float(*this) + other; }
+    inline float operator-(float other) const noexcept { return float(*this) - other; }
+    inline float operator*(float other) const noexcept { return float(*this) * other; }
+    inline float operator/(float other) const noexcept { return float(*this) / other; }
+    inline double operator+(double other) const noexcept { return float(*this) + other; }
+    inline double operator-(double other) const noexcept { return float(*this) - other; }
+    inline double operator*(double other) const noexcept { return float(*this) * other; }
+    inline double operator/(double other) const noexcept { return float(*this) / other; }
+
+    inline bf16_bits_t& operator+=(float v) noexcept {
+        uint16_ = f32_to_bf16(v + bf16_to_f32(uint16_));
+        return *this;
+    }
+
+    inline bf16_bits_t& operator-=(float v) noexcept {
+        uint16_ = f32_to_bf16(v - bf16_to_f32(uint16_));
+        return *this;
+    }
+
+    inline bf16_bits_t& operator*=(float v) noexcept {
+        uint16_ = f32_to_bf16(v * bf16_to_f32(uint16_));
+        return *this;
+    }
+
+    inline bf16_bits_t& operator/=(float v) noexcept {
+        uint16_ = f32_to_bf16(v / bf16_to_f32(uint16_));
+        return *this;
+    }
+
+    inline bf16_bits_t& operator=(float v) noexcept {
+        uint16_ = f32_to_bf16(v);
+        return *this;
+    }
+};
+
+#if USEARCH_USE_OPENMP
+#pragma omp declare reduction(+ : unum::usearch::bf16_bits_t : omp_out = omp_out + omp_in)                             \
+    initializer(omp_priv = unum::usearch::bf16_bits_t())
+#endif
+
+/**
+ *  @brief Convenience function to upcast an FP8 E5M2 value to single-precision.
+ *         E5M2: 1 sign + 5 exponent (bias=15) + 2 mantissa, range +/-57344, supports inf/NaN.
+ */
+inline float e5m2_to_f32(std::uint8_t u8) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_f32_t result;
+    nk_e5m2_to_f32_serial((nk_e5m2_t const*)&u8, &result);
+    return result;
+#else
+    // 128-entry LUT for the 7-bit magnitude, sign handled separately.
+    static std::uint32_t const lut[128] = {
+        0x00000000, 0x37800000, 0x38000000, 0x38400000, // exp=0  sub
+        0x38800000, 0x38A00000, 0x38C00000, 0x38E00000, // exp=1
+        0x39000000, 0x39200000, 0x39400000, 0x39600000, // exp=2
+        0x39800000, 0x39A00000, 0x39C00000, 0x39E00000, // exp=3
+        0x3A000000, 0x3A200000, 0x3A400000, 0x3A600000, // exp=4
+        0x3A800000, 0x3AA00000, 0x3AC00000, 0x3AE00000, // exp=5
+        0x3B000000, 0x3B200000, 0x3B400000, 0x3B600000, // exp=6
+        0x3B800000, 0x3BA00000, 0x3BC00000, 0x3BE00000, // exp=7
+        0x3C000000, 0x3C200000, 0x3C400000, 0x3C600000, // exp=8
+        0x3C800000, 0x3CA00000, 0x3CC00000, 0x3CE00000, // exp=9
+        0x3D000000, 0x3D200000, 0x3D400000, 0x3D600000, // exp=10
+        0x3D800000, 0x3DA00000, 0x3DC00000, 0x3DE00000, // exp=11
+        0x3E000000, 0x3E200000, 0x3E400000, 0x3E600000, // exp=12
+        0x3E800000, 0x3EA00000, 0x3EC00000, 0x3EE00000, // exp=13
+        0x3F000000, 0x3F200000, 0x3F400000, 0x3F600000, // exp=14
+        0x3F800000, 0x3FA00000, 0x3FC00000, 0x3FE00000, // exp=15
+        0x40000000, 0x40200000, 0x40400000, 0x40600000, // exp=16
+        0x40800000, 0x40A00000, 0x40C00000, 0x40E00000, // exp=17
+        0x41000000, 0x41200000, 0x41400000, 0x41600000, // exp=18
+        0x41800000, 0x41A00000, 0x41C00000, 0x41E00000, // exp=19
+        0x42000000, 0x42200000, 0x42400000, 0x42600000, // exp=20
+        0x42800000, 0x42A00000, 0x42C00000, 0x42E00000, // exp=21
+        0x43000000, 0x43200000, 0x43400000, 0x43600000, // exp=22
+        0x43800000, 0x43A00000, 0x43C00000, 0x43E00000, // exp=23
+        0x44000000, 0x44200000, 0x44400000, 0x44600000, // exp=24
+        0x44800000, 0x44A00000, 0x44C00000, 0x44E00000, // exp=25
+        0x45000000, 0x45200000, 0x45400000, 0x45600000, // exp=26
+        0x45800000, 0x45A00000, 0x45C00000, 0x45E00000, // exp=27
+        0x46000000, 0x46200000, 0x46400000, 0x46600000, // exp=28
+        0x46800000, 0x46A00000, 0x46C00000, 0x46E00000, // exp=29
+        0x47000000, 0x47200000, 0x47400000, 0x47600000, // exp=30
+        0x7F800000, 0x7FC00000, 0x7FC00000, 0x7FC00000, // inf, nan
+    };
+    std::uint32_t sign = (std::uint32_t)(u8 & 0x80) << 24;
+    fu32_t conv;
+    conv.u = sign | lut[u8 & 0x7F];
+    return conv.f;
+#endif
+}
+
+/**
+ *  @brief Convenience function to downcast a single-precision value to FP8 E5M2.
+ *         Uses RNE rounding. Overflow → inf, NaN → NaN, subnormals handled.
+ */
+inline std::uint8_t f32_to_e5m2(float f32) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_e5m2_t result;
+    nk_f32_to_e5m2_serial((nk_f32_t const*)&f32, &result);
+    return result;
+#else
+    fu32_t conv;
+    conv.f = f32;
+    std::uint32_t sign_bit = conv.u >> 31;
+    std::uint32_t abs_bits = conv.u & 0x7FFFFFFFu;
+    std::uint8_t sign = (std::uint8_t)(sign_bit << 7);
+
+    // NaN or inf
+    if (abs_bits >= 0x7F800000u) {
+        std::uint8_t mant = (abs_bits > 0x7F800000u) ? 0x01u : 0x00u;
+        return (std::uint8_t)(sign | 0x7Cu | mant);
+    }
+    if (abs_bits == 0)
+        return sign;
+
+    float abs_x = sign_bit ? -f32 : f32;
+
+    // Subnormal range: |x| < 2^-14
+    if (abs_x < (1.0f / 16384.0f)) {
+        float scaled = abs_x * 65536.0f;
+        int mant = (int)scaled;
+        float frac = scaled - (float)mant;
+        if (frac > 0.5f || (frac == 0.5f && (mant & 1)))
+            ++mant;
+        if (mant > 3)
+            return (std::uint8_t)(sign | 0x04u);
+        return (std::uint8_t)(sign | (std::uint8_t)mant);
+    }
+
+    int exp = (int)((abs_bits >> 23) & 0xFFu) - 127;
+    std::uint32_t mantissa = abs_bits & 0x7FFFFFu;
+    std::uint32_t significand = (1u << 23) | mantissa;
+    int shift = 23 - 2;
+    std::uint32_t remainder_mask = (1u << shift) - 1;
+    std::uint32_t remainder = significand & remainder_mask;
+    std::uint32_t halfway = 1u << (shift - 1);
+    std::uint32_t significand_rounded = significand >> shift;
+    if (remainder > halfway || (remainder == halfway && (significand_rounded & 1)))
+        ++significand_rounded;
+    if (significand_rounded == (1u << 3)) {
+        significand_rounded >>= 1;
+        ++exp;
+    }
+    if (exp > 15)
+        return (std::uint8_t)(sign | 0x7Cu); // overflow → inf
+    if (exp < -14) {
+        float scaled = abs_x * 65536.0f;
+        int mant = (int)scaled;
+        float frac = scaled - (float)mant;
+        if (frac > 0.5f || (frac == 0.5f && (mant & 1)))
+            ++mant;
+        if (mant > 3)
+            return (std::uint8_t)(sign | 0x04u);
+        return (std::uint8_t)(sign | (std::uint8_t)mant);
+    }
+
+    std::uint8_t exp_field = (std::uint8_t)(exp + 15);
+    std::uint8_t mant_field = (std::uint8_t)(significand_rounded & 0x03u);
+    return (std::uint8_t)(sign | (exp_field << 2) | mant_field);
+#endif
+}
+
+/**
+ *  @brief Convenience function to upcast an FP8 E4M3 value to single-precision.
+ *         E4M3: 1 sign + 4 exponent (bias=7) + 3 mantissa, range +/-448, no inf.
+ */
+inline float e4m3_to_f32(std::uint8_t u8) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_f32_t result;
+    nk_e4m3_to_f32_serial((nk_e4m3_t const*)&u8, &result);
+    return result;
+#else
+    static std::uint32_t const lut[128] = {
+        0x00000000, 0x3B000000, 0x3B800000, 0x3BC00000, 0x3C000000, 0x3C200000, 0x3C400000, 0x3C600000, // exp=0 sub
+        0x3C800000, 0x3C900000, 0x3CA00000, 0x3CB00000, 0x3CC00000, 0x3CD00000, 0x3CE00000, 0x3CF00000, // exp=1
+        0x3D000000, 0x3D100000, 0x3D200000, 0x3D300000, 0x3D400000, 0x3D500000, 0x3D600000, 0x3D700000, // exp=2
+        0x3D800000, 0x3D900000, 0x3DA00000, 0x3DB00000, 0x3DC00000, 0x3DD00000, 0x3DE00000, 0x3DF00000, // exp=3
+        0x3E000000, 0x3E100000, 0x3E200000, 0x3E300000, 0x3E400000, 0x3E500000, 0x3E600000, 0x3E700000, // exp=4
+        0x3E800000, 0x3E900000, 0x3EA00000, 0x3EB00000, 0x3EC00000, 0x3ED00000, 0x3EE00000, 0x3EF00000, // exp=5
+        0x3F000000, 0x3F100000, 0x3F200000, 0x3F300000, 0x3F400000, 0x3F500000, 0x3F600000, 0x3F700000, // exp=6
+        0x3F800000, 0x3F900000, 0x3FA00000, 0x3FB00000, 0x3FC00000, 0x3FD00000, 0x3FE00000, 0x3FF00000, // exp=7
+        0x40000000, 0x40100000, 0x40200000, 0x40300000, 0x40400000, 0x40500000, 0x40600000, 0x40700000, // exp=8
+        0x40800000, 0x40900000, 0x40A00000, 0x40B00000, 0x40C00000, 0x40D00000, 0x40E00000, 0x40F00000, // exp=9
+        0x41000000, 0x41100000, 0x41200000, 0x41300000, 0x41400000, 0x41500000, 0x41600000, 0x41700000, // exp=10
+        0x41800000, 0x41900000, 0x41A00000, 0x41B00000, 0x41C00000, 0x41D00000, 0x41E00000, 0x41F00000, // exp=11
+        0x42000000, 0x42100000, 0x42200000, 0x42300000, 0x42400000, 0x42500000, 0x42600000, 0x42700000, // exp=12
+        0x42800000, 0x42900000, 0x42A00000, 0x42B00000, 0x42C00000, 0x42D00000, 0x42E00000, 0x42F00000, // exp=13
+        0x43000000, 0x43100000, 0x43200000, 0x43300000, 0x43400000, 0x43500000, 0x43600000, 0x43700000, // exp=14
+        0x43800000, 0x43900000, 0x43A00000, 0x43B00000, 0x43C00000, 0x43D00000, 0x43E00000, 0x7FC00000, // exp=15
+    };
+    std::uint32_t sign = (std::uint32_t)(u8 & 0x80) << 24;
+    fu32_t conv;
+    conv.u = sign | lut[u8 & 0x7F];
+    return conv.f;
+#endif
+}
+
+/**
+ *  @brief Convenience function to downcast a single-precision value to FP8 E4M3.
+ *         Uses RNE rounding. Overflow saturates to +/-448 (no inf in E4M3FN).
+ */
+inline std::uint8_t f32_to_e4m3(float f32) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_e4m3_t result;
+    nk_f32_to_e4m3_serial((nk_f32_t const*)&f32, &result);
+    return result;
+#else
+    fu32_t conv;
+    conv.f = f32;
+    std::uint32_t sign_bit = conv.u >> 31;
+    std::uint32_t abs_bits = conv.u & 0x7FFFFFFFu;
+    std::uint8_t sign = (std::uint8_t)(sign_bit << 7);
+
+    // NaN → E4M3FN NaN
+    if (abs_bits > 0x7F800000u)
+        return (std::uint8_t)(sign | 0x7Fu);
+    // Inf → saturate to max (448)
+    if (abs_bits == 0x7F800000u)
+        return (std::uint8_t)(sign | 0x7Eu);
+    if (abs_bits == 0)
+        return sign;
+
+    float abs_x = sign_bit ? -f32 : f32;
+
+    // Subnormal range: |x| < 2^-6
+    if (abs_x < (1.0f / 64.0f)) {
+        float scaled = abs_x * 512.0f;
+        int mant = (int)scaled;
+        float frac = scaled - (float)mant;
+        if (frac > 0.5f || (frac == 0.5f && (mant & 1)))
+            ++mant;
+        if (mant > 7)
+            return (std::uint8_t)(sign | 0x08u);
+        return (std::uint8_t)(sign | (std::uint8_t)mant);
+    }
+
+    int exp = (int)((abs_bits >> 23) & 0xFFu) - 127;
+    std::uint32_t mantissa = abs_bits & 0x7FFFFFu;
+    std::uint32_t significand = (1u << 23) | mantissa;
+    int shift = 23 - 3;
+    std::uint32_t remainder_mask = (1u << shift) - 1;
+    std::uint32_t remainder = significand & remainder_mask;
+    std::uint32_t halfway = 1u << (shift - 1);
+    std::uint32_t significand_rounded = significand >> shift;
+    if (remainder > halfway || (remainder == halfway && (significand_rounded & 1)))
+        ++significand_rounded;
+    if (significand_rounded == (1u << 4)) {
+        significand_rounded >>= 1;
+        ++exp;
+    }
+    // Overflow → saturate to max (0x7E = 448)
+    if (exp > 8)
+        return (std::uint8_t)(sign | 0x7Eu);
+    if (exp < -6) {
+        float scaled = abs_x * 512.0f;
+        int mant = (int)scaled;
+        float frac = scaled - (float)mant;
+        if (frac > 0.5f || (frac == 0.5f && (mant & 1)))
+            ++mant;
+        if (mant > 7)
+            return (std::uint8_t)(sign | 0x08u);
+        return (std::uint8_t)(sign | (std::uint8_t)mant);
+    }
+
+    std::uint8_t exp_field = (std::uint8_t)(exp + 7);
+    std::uint8_t mant_field = (std::uint8_t)(significand_rounded & 0x07u);
+    // Clamp to avoid NaN encoding (0x7F)
+    if (exp_field == 15 && mant_field > 6)
+        mant_field = 6;
+    return (std::uint8_t)(sign | (exp_field << 3) | mant_field);
+#endif
+}
+
+/**
+ *  @brief  Numeric type for FP8 E5M2 (IEEE 754-like) floating point.
+ *          1 sign + 5 exponent + 2 mantissa bits, range +/-57344.
+ */
+class e5m2_bits_t {
+    std::uint8_t uint8_{};
+
+  public:
+    inline e5m2_bits_t() noexcept : uint8_(0) {}
+    inline e5m2_bits_t(e5m2_bits_t&&) = default;
+    inline e5m2_bits_t& operator=(e5m2_bits_t&&) = default;
+    inline e5m2_bits_t(e5m2_bits_t const&) = default;
+    inline e5m2_bits_t& operator=(e5m2_bits_t const&) = default;
+
+    inline operator float() const noexcept { return e5m2_to_f32(uint8_); }
+    inline explicit operator bool() const noexcept { return e5m2_to_f32(uint8_) > 0.5f; }
+
+    inline e5m2_bits_t(int v) noexcept : uint8_(f32_to_e5m2(static_cast<float>(v))) {}
+    inline e5m2_bits_t(bool v) noexcept : uint8_(f32_to_e5m2(static_cast<float>(v))) {}
+    inline e5m2_bits_t(float v) noexcept : uint8_(f32_to_e5m2(v)) {}
+    inline e5m2_bits_t(double v) noexcept : uint8_(f32_to_e5m2(static_cast<float>(v))) {}
+
+    inline bool operator<(e5m2_bits_t const& other) const noexcept { return float(*this) < float(other); }
+
+    inline e5m2_bits_t operator+(e5m2_bits_t other) const noexcept { return {float(*this) + float(other)}; }
+    inline e5m2_bits_t operator-(e5m2_bits_t other) const noexcept { return {float(*this) - float(other)}; }
+    inline e5m2_bits_t operator*(e5m2_bits_t other) const noexcept { return {float(*this) * float(other)}; }
+    inline e5m2_bits_t operator/(e5m2_bits_t other) const noexcept { return {float(*this) / float(other)}; }
+    inline float operator+(float other) const noexcept { return float(*this) + other; }
+    inline float operator-(float other) const noexcept { return float(*this) - other; }
+    inline float operator*(float other) const noexcept { return float(*this) * other; }
+    inline float operator/(float other) const noexcept { return float(*this) / other; }
+    inline double operator+(double other) const noexcept { return float(*this) + other; }
+    inline double operator-(double other) const noexcept { return float(*this) - other; }
+    inline double operator*(double other) const noexcept { return float(*this) * other; }
+    inline double operator/(double other) const noexcept { return float(*this) / other; }
+
+    inline e5m2_bits_t& operator+=(float v) noexcept {
+        uint8_ = f32_to_e5m2(v + e5m2_to_f32(uint8_));
+        return *this;
+    }
+    inline e5m2_bits_t& operator-=(float v) noexcept {
+        uint8_ = f32_to_e5m2(v - e5m2_to_f32(uint8_));
+        return *this;
+    }
+    inline e5m2_bits_t& operator*=(float v) noexcept {
+        uint8_ = f32_to_e5m2(v * e5m2_to_f32(uint8_));
+        return *this;
+    }
+    inline e5m2_bits_t& operator/=(float v) noexcept {
+        uint8_ = f32_to_e5m2(v / e5m2_to_f32(uint8_));
+        return *this;
+    }
+    inline e5m2_bits_t& operator=(float v) noexcept {
+        uint8_ = f32_to_e5m2(v);
+        return *this;
+    }
+};
+
+/**
+ *  @brief  Numeric type for FP8 E4M3 (OCP) floating point.
+ *          1 sign + 4 exponent + 3 mantissa bits, range +/-448.
+ */
+class e4m3_bits_t {
+    std::uint8_t uint8_{};
+
+  public:
+    inline e4m3_bits_t() noexcept : uint8_(0) {}
+    inline e4m3_bits_t(e4m3_bits_t&&) = default;
+    inline e4m3_bits_t& operator=(e4m3_bits_t&&) = default;
+    inline e4m3_bits_t(e4m3_bits_t const&) = default;
+    inline e4m3_bits_t& operator=(e4m3_bits_t const&) = default;
+
+    inline operator float() const noexcept { return e4m3_to_f32(uint8_); }
+    inline explicit operator bool() const noexcept { return e4m3_to_f32(uint8_) > 0.5f; }
+
+    inline e4m3_bits_t(int v) noexcept : uint8_(f32_to_e4m3(static_cast<float>(v))) {}
+    inline e4m3_bits_t(bool v) noexcept : uint8_(f32_to_e4m3(static_cast<float>(v))) {}
+    inline e4m3_bits_t(float v) noexcept : uint8_(f32_to_e4m3(v)) {}
+    inline e4m3_bits_t(double v) noexcept : uint8_(f32_to_e4m3(static_cast<float>(v))) {}
+
+    inline bool operator<(e4m3_bits_t const& other) const noexcept { return float(*this) < float(other); }
+
+    inline e4m3_bits_t operator+(e4m3_bits_t other) const noexcept { return {float(*this) + float(other)}; }
+    inline e4m3_bits_t operator-(e4m3_bits_t other) const noexcept { return {float(*this) - float(other)}; }
+    inline e4m3_bits_t operator*(e4m3_bits_t other) const noexcept { return {float(*this) * float(other)}; }
+    inline e4m3_bits_t operator/(e4m3_bits_t other) const noexcept { return {float(*this) / float(other)}; }
+    inline float operator+(float other) const noexcept { return float(*this) + other; }
+    inline float operator-(float other) const noexcept { return float(*this) - other; }
+    inline float operator*(float other) const noexcept { return float(*this) * other; }
+    inline float operator/(float other) const noexcept { return float(*this) / other; }
+    inline double operator+(double other) const noexcept { return float(*this) + other; }
+    inline double operator-(double other) const noexcept { return float(*this) - other; }
+    inline double operator*(double other) const noexcept { return float(*this) * other; }
+    inline double operator/(double other) const noexcept { return float(*this) / other; }
+
+    inline e4m3_bits_t& operator+=(float v) noexcept {
+        uint8_ = f32_to_e4m3(v + e4m3_to_f32(uint8_));
+        return *this;
+    }
+    inline e4m3_bits_t& operator-=(float v) noexcept {
+        uint8_ = f32_to_e4m3(v - e4m3_to_f32(uint8_));
+        return *this;
+    }
+    inline e4m3_bits_t& operator*=(float v) noexcept {
+        uint8_ = f32_to_e4m3(v * e4m3_to_f32(uint8_));
+        return *this;
+    }
+    inline e4m3_bits_t& operator/=(float v) noexcept {
+        uint8_ = f32_to_e4m3(v / e4m3_to_f32(uint8_));
+        return *this;
+    }
+    inline e4m3_bits_t& operator=(float v) noexcept {
+        uint8_ = f32_to_e4m3(v);
+        return *this;
+    }
+};
+
+/**
+ *  @brief Convenience function to upcast an FP6 E2M3 value to single-precision.
+ *         E2M3: 1 sign + 2 exponent (bias=1) + 3 mantissa, stored as 0b00SEEMMM, range +/-7.5.
+ */
+inline float e2m3_to_f32(std::uint8_t u8) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_f32_t result;
+    nk_e2m3_to_f32_serial((nk_e2m3_t const*)&u8, &result);
+    return result;
+#else
+    static std::uint32_t const lut[64] = {
+        0x00000000, 0x3E000000, 0x3E800000, 0x3EC00000, 0x3F000000, 0x3F200000, 0x3F400000, 0x3F600000, // positive
+        0x3F800000, 0x3F900000, 0x3FA00000, 0x3FB00000, 0x3FC00000, 0x3FD00000, 0x3FE00000, 0x3FF00000, // positive
+        0x40000000, 0x40100000, 0x40200000, 0x40300000, 0x40400000, 0x40500000, 0x40600000, 0x40700000, // positive
+        0x40800000, 0x40900000, 0x40A00000, 0x40B00000, 0x40C00000, 0x40D00000, 0x40E00000, 0x40F00000, // positive
+        0x80000000, 0xBE000000, 0xBE800000, 0xBEC00000, 0xBF000000, 0xBF200000, 0xBF400000, 0xBF600000, // negative
+        0xBF800000, 0xBF900000, 0xBFA00000, 0xBFB00000, 0xBFC00000, 0xBFD00000, 0xBFE00000, 0xBFF00000, // negative
+        0xC0000000, 0xC0100000, 0xC0200000, 0xC0300000, 0xC0400000, 0xC0500000, 0xC0600000, 0xC0700000, // negative
+        0xC0800000, 0xC0900000, 0xC0A00000, 0xC0B00000, 0xC0C00000, 0xC0D00000, 0xC0E00000, 0xC0F00000, // negative
+    };
+    fu32_t conv;
+    conv.u = lut[u8 & 0x3F];
+    return conv.f;
+#endif
+}
+
+/**
+ *  @brief Convenience function to downcast a single-precision value to FP6 E2M3.
+ */
+inline std::uint8_t f32_to_e2m3(float f32) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_e2m3_t result;
+    nk_f32_to_e2m3_serial((nk_f32_t const*)&f32, &result);
+    return result;
+#else
+    fu32_t conv;
+    conv.f = f32;
+    std::uint32_t sign_bit = conv.u >> 31;
+    std::uint32_t abs_bits = conv.u & 0x7FFFFFFFu;
+    std::uint8_t sign = (std::uint8_t)(sign_bit << 5);
+    if (abs_bits == 0)
+        return sign;
+    float abs_x = sign_bit ? -f32 : f32;
+    // E2M3: bias=1, 2 exp bits, 3 mant bits, max normal = 7.5, min subnormal = 0.125
+    if (abs_x >= 7.5f)
+        return (std::uint8_t)(sign | 0x1Fu); // saturate to max
+    if (abs_x < 0.0625f)
+        return sign; // underflow to zero
+    // Subnormal range: abs_x < 1.0 (min normal = 2^(1-1) = 1.0)
+    if (abs_x < 1.0f) {
+        // Subnormals: value = mant * 2^(-3) = mant/8, so mant = round(abs_x * 8)
+        std::uint32_t mant = (std::uint32_t)(abs_x * 8.0f + 0.5f);
+        if (mant > 7)
+            mant = 7;
+        if (mant == 0)
+            return sign;
+        return (std::uint8_t)(sign | mant);
+    }
+    // Normal range: value = (1 + mant/8) * 2^(exp-1)
+    // Find exponent: exp-1 = floor(log2(abs_x)), so exp = floor(log2(abs_x)) + 1
+    int exp_val;
+    float frac = std::frexp(abs_x, &exp_val); // abs_x = frac * 2^exp_val, frac in [0.5, 1)
+    // frexp returns frac in [0.5, 1), but we want significand in [1, 2)
+    // so significand = frac * 2, and true_exp = exp_val - 1
+    float significand = frac * 2.0f; // [1.0, 2.0)
+    int biased_exp = exp_val;        // exp_val - 1 + bias(1) = exp_val
+    if (biased_exp < 1) {
+        // Fell into subnormal, handled above
+        std::uint32_t mant = (std::uint32_t)(abs_x * 8.0f + 0.5f);
+        if (mant > 7)
+            mant = 7;
+        return (std::uint8_t)(sign | mant);
+    }
+    if (biased_exp > 3)
+        biased_exp = 3; // clamp to max exp
+    // Round mantissa: 3 mant bits, significand in [1, 2)
+    std::uint32_t mant = (std::uint32_t)((significand - 1.0f) * 8.0f + 0.5f);
+    if (mant > 7) {
+        mant = 0;
+        biased_exp++;
+    }
+    if (biased_exp > 3)
+        return (std::uint8_t)(sign | 0x1Fu); // overflow
+    return (std::uint8_t)(sign | (biased_exp << 3) | mant);
+#endif
+}
+
+/**
+ *  @brief Convenience function to upcast an FP6 E3M2 value to single-precision.
+ *         E3M2: 1 sign + 3 exponent (bias=3) + 2 mantissa, stored as 0b00SEEEMM, range +/-28.
+ */
+inline float e3m2_to_f32(std::uint8_t u8) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_f32_t result;
+    nk_e3m2_to_f32_serial((nk_e3m2_t const*)&u8, &result);
+    return result;
+#else
+    static std::uint32_t const lut[64] = {
+        0x00000000, 0x3D800000, 0x3E000000, 0x3E400000, 0x3E800000, 0x3EA00000, 0x3EC00000, 0x3EE00000, // positive
+        0x3F000000, 0x3F200000, 0x3F400000, 0x3F600000, 0x3F800000, 0x3FA00000, 0x3FC00000, 0x3FE00000, // positive
+        0x40000000, 0x40200000, 0x40400000, 0x40600000, 0x40800000, 0x40A00000, 0x40C00000, 0x40E00000, // positive
+        0x41000000, 0x41200000, 0x41400000, 0x41600000, 0x41800000, 0x41A00000, 0x41C00000, 0x41E00000, // positive
+        0x80000000, 0xBD800000, 0xBE000000, 0xBE400000, 0xBE800000, 0xBEA00000, 0xBEC00000, 0xBEE00000, // negative
+        0xBF000000, 0xBF200000, 0xBF400000, 0xBF600000, 0xBF800000, 0xBFA00000, 0xBFC00000, 0xBFE00000, // negative
+        0xC0000000, 0xC0200000, 0xC0400000, 0xC0600000, 0xC0800000, 0xC0A00000, 0xC0C00000, 0xC0E00000, // negative
+        0xC1000000, 0xC1200000, 0xC1400000, 0xC1600000, 0xC1800000, 0xC1A00000, 0xC1C00000, 0xC1E00000, // negative
+    };
+    fu32_t conv;
+    conv.u = lut[u8 & 0x3F];
+    return conv.f;
+#endif
+}
+
+/**
+ *  @brief Convenience function to downcast a single-precision value to FP6 E3M2.
+ */
+inline std::uint8_t f32_to_e3m2(float f32) noexcept {
+#if USEARCH_USE_NUMKONG
+    nk_e3m2_t result;
+    nk_f32_to_e3m2_serial((nk_f32_t const*)&f32, &result);
+    return result;
+#else
+    fu32_t conv;
+    conv.f = f32;
+    std::uint32_t sign_bit = conv.u >> 31;
+    std::uint32_t abs_bits = conv.u & 0x7FFFFFFFu;
+    std::uint8_t sign = (std::uint8_t)(sign_bit << 5);
+    if (abs_bits == 0)
+        return sign;
+    float abs_x = sign_bit ? -f32 : f32;
+    // E3M2: bias=3, 3 exp bits, 2 mant bits, max normal = 28.0, min subnormal = 0.0625
+    if (abs_x >= 28.0f)
+        return (std::uint8_t)(sign | 0x1Fu); // saturate to max
+    if (abs_x < 0.03125f)
+        return sign; // underflow to zero
+    // Subnormal range: abs_x < 0.25 (min normal = 2^(1-3) = 0.25)
+    if (abs_x < 0.25f) {
+        // Subnormals: value = mant * 2^(-4) = mant/16, so mant = round(abs_x * 16)
+        std::uint32_t mant = (std::uint32_t)(abs_x * 16.0f + 0.5f);
+        if (mant > 3)
+            mant = 3;
+        if (mant == 0)
+            return sign;
+        return (std::uint8_t)(sign | mant);
+    }
+    // Normal range: value = (1 + mant/4) * 2^(exp-3)
+    int exp_val;
+    float frac = std::frexp(abs_x, &exp_val);
+    float significand = frac * 2.0f;
+    int biased_exp = exp_val - 1 + 3; // true_exp = exp_val - 1, biased = true_exp + 3
+    if (biased_exp < 1) {
+        std::uint32_t mant = (std::uint32_t)(abs_x * 16.0f + 0.5f);
+        if (mant > 3)
+            mant = 3;
+        return (std::uint8_t)(sign | mant);
+    }
+    if (biased_exp > 7)
+        biased_exp = 7;
+    std::uint32_t mant = (std::uint32_t)((significand - 1.0f) * 4.0f + 0.5f);
+    if (mant > 3) {
+        mant = 0;
+        biased_exp++;
+    }
+    if (biased_exp > 7)
+        return (std::uint8_t)(sign | 0x1Fu);
+    return (std::uint8_t)(sign | (biased_exp << 2) | mant);
+#endif
+}
+
+/**
+ *  @brief  Numeric type for FP6 E2M3 floating point.
+ *          1 sign + 2 exponent + 3 mantissa bits, stored as 0b00SEEMMM, range +/-7.5.
+ */
+class e2m3_bits_t {
+    std::uint8_t uint8_{};
+
+  public:
+    inline e2m3_bits_t() noexcept : uint8_(0) {}
+    inline e2m3_bits_t(e2m3_bits_t&&) = default;
+    inline e2m3_bits_t& operator=(e2m3_bits_t&&) = default;
+    inline e2m3_bits_t(e2m3_bits_t const&) = default;
+    inline e2m3_bits_t& operator=(e2m3_bits_t const&) = default;
+
+    inline operator float() const noexcept { return e2m3_to_f32(uint8_); }
+    inline explicit operator bool() const noexcept { return e2m3_to_f32(uint8_) > 0.5f; }
+
+    inline e2m3_bits_t(int v) noexcept : uint8_(f32_to_e2m3(static_cast<float>(v))) {}
+    inline e2m3_bits_t(bool v) noexcept : uint8_(f32_to_e2m3(static_cast<float>(v))) {}
+    inline e2m3_bits_t(float v) noexcept : uint8_(f32_to_e2m3(v)) {}
+    inline e2m3_bits_t(double v) noexcept : uint8_(f32_to_e2m3(static_cast<float>(v))) {}
+
+    inline bool operator<(e2m3_bits_t const& other) const noexcept { return float(*this) < float(other); }
+
+    inline e2m3_bits_t operator+(e2m3_bits_t other) const noexcept { return {float(*this) + float(other)}; }
+    inline e2m3_bits_t operator-(e2m3_bits_t other) const noexcept { return {float(*this) - float(other)}; }
+    inline e2m3_bits_t operator*(e2m3_bits_t other) const noexcept { return {float(*this) * float(other)}; }
+    inline e2m3_bits_t operator/(e2m3_bits_t other) const noexcept { return {float(*this) / float(other)}; }
+    inline float operator+(float other) const noexcept { return float(*this) + other; }
+    inline float operator-(float other) const noexcept { return float(*this) - other; }
+    inline float operator*(float other) const noexcept { return float(*this) * other; }
+    inline float operator/(float other) const noexcept { return float(*this) / other; }
+    inline double operator+(double other) const noexcept { return float(*this) + other; }
+    inline double operator-(double other) const noexcept { return float(*this) - other; }
+    inline double operator*(double other) const noexcept { return float(*this) * other; }
+    inline double operator/(double other) const noexcept { return float(*this) / other; }
+
+    inline e2m3_bits_t& operator+=(float v) noexcept {
+        uint8_ = f32_to_e2m3(v + e2m3_to_f32(uint8_));
+        return *this;
+    }
+    inline e2m3_bits_t& operator-=(float v) noexcept {
+        uint8_ = f32_to_e2m3(v - e2m3_to_f32(uint8_));
+        return *this;
+    }
+    inline e2m3_bits_t& operator*=(float v) noexcept {
+        uint8_ = f32_to_e2m3(v * e2m3_to_f32(uint8_));
+        return *this;
+    }
+    inline e2m3_bits_t& operator/=(float v) noexcept {
+        uint8_ = f32_to_e2m3(v / e2m3_to_f32(uint8_));
+        return *this;
+    }
+    inline e2m3_bits_t& operator=(float v) noexcept {
+        uint8_ = f32_to_e2m3(v);
+        return *this;
+    }
+};
+
+/**
+ *  @brief  Numeric type for FP6 E3M2 floating point.
+ *          1 sign + 3 exponent + 2 mantissa bits, stored as 0b00SEEEMM, range +/-28.
+ */
+class e3m2_bits_t {
+    std::uint8_t uint8_{};
+
+  public:
+    inline e3m2_bits_t() noexcept : uint8_(0) {}
+    inline e3m2_bits_t(e3m2_bits_t&&) = default;
+    inline e3m2_bits_t& operator=(e3m2_bits_t&&) = default;
+    inline e3m2_bits_t(e3m2_bits_t const&) = default;
+    inline e3m2_bits_t& operator=(e3m2_bits_t const&) = default;
+
+    inline operator float() const noexcept { return e3m2_to_f32(uint8_); }
+    inline explicit operator bool() const noexcept { return e3m2_to_f32(uint8_) > 0.5f; }
+
+    inline e3m2_bits_t(int v) noexcept : uint8_(f32_to_e3m2(static_cast<float>(v))) {}
+    inline e3m2_bits_t(bool v) noexcept : uint8_(f32_to_e3m2(static_cast<float>(v))) {}
+    inline e3m2_bits_t(float v) noexcept : uint8_(f32_to_e3m2(v)) {}
+    inline e3m2_bits_t(double v) noexcept : uint8_(f32_to_e3m2(static_cast<float>(v))) {}
+
+    inline bool operator<(e3m2_bits_t const& other) const noexcept { return float(*this) < float(other); }
+
+    inline e3m2_bits_t operator+(e3m2_bits_t other) const noexcept { return {float(*this) + float(other)}; }
+    inline e3m2_bits_t operator-(e3m2_bits_t other) const noexcept { return {float(*this) - float(other)}; }
+    inline e3m2_bits_t operator*(e3m2_bits_t other) const noexcept { return {float(*this) * float(other)}; }
+    inline e3m2_bits_t operator/(e3m2_bits_t other) const noexcept { return {float(*this) / float(other)}; }
+    inline float operator+(float other) const noexcept { return float(*this) + other; }
+    inline float operator-(float other) const noexcept { return float(*this) - other; }
+    inline float operator*(float other) const noexcept { return float(*this) * other; }
+    inline float operator/(float other) const noexcept { return float(*this) / other; }
+    inline double operator+(double other) const noexcept { return float(*this) + other; }
+    inline double operator-(double other) const noexcept { return float(*this) - other; }
+    inline double operator*(double other) const noexcept { return float(*this) * other; }
+    inline double operator/(double other) const noexcept { return float(*this) / other; }
+
+    inline e3m2_bits_t& operator+=(float v) noexcept {
+        uint8_ = f32_to_e3m2(v + e3m2_to_f32(uint8_));
+        return *this;
+    }
+    inline e3m2_bits_t& operator-=(float v) noexcept {
+        uint8_ = f32_to_e3m2(v - e3m2_to_f32(uint8_));
+        return *this;
+    }
+    inline e3m2_bits_t& operator*=(float v) noexcept {
+        uint8_ = f32_to_e3m2(v * e3m2_to_f32(uint8_));
+        return *this;
+    }
+    inline e3m2_bits_t& operator/=(float v) noexcept {
+        uint8_ = f32_to_e3m2(v / e3m2_to_f32(uint8_));
+        return *this;
+    }
+    inline e3m2_bits_t& operator=(float v) noexcept {
+        uint8_ = f32_to_e3m2(v);
+        return *this;
+    }
+};
+
+#if USEARCH_USE_OPENMP
+#pragma omp declare reduction(+ : unum::usearch::e5m2_bits_t : omp_out = omp_out + omp_in)                             \
+    initializer(omp_priv = unum::usearch::e5m2_bits_t())
+#pragma omp declare reduction(+ : unum::usearch::e4m3_bits_t : omp_out = omp_out + omp_in)                             \
+    initializer(omp_priv = unum::usearch::e4m3_bits_t())
+#pragma omp declare reduction(+ : unum::usearch::e2m3_bits_t : omp_out = omp_out + omp_in)                             \
+    initializer(omp_priv = unum::usearch::e2m3_bits_t())
+#pragma omp declare reduction(+ : unum::usearch::e3m2_bits_t : omp_out = omp_out + omp_in)                             \
+    initializer(omp_priv = unum::usearch::e3m2_bits_t())
+#endif
+
 /**
  *  @brief  An STL-based executor or a "thread-pool" for parallel execution.
  *          Isn't efficient for small batches, as it recreates the threads on every call.
@@ -382,14 +1353,16 @@ class executor_stl_t {
 
     struct jthread_t {
         std::thread native_;
+        bool initialized_ = false;
 
         jthread_t() = default;
         jthread_t(jthread_t&&) = default;
         jthread_t(jthread_t const&) = delete;
-        template <typename callable_at> jthread_t(callable_at&& func) : native_([=]() { func(); }) {}
+        template <typename callable_at>
+        jthread_t(callable_at&& func) : native_([=]() { func(); }), initialized_(true) {}
 
         ~jthread_t() {
-            if (native_.joinable())
+            if (initialized_ && native_.joinable())
                 native_.join();
         }
     };
@@ -414,13 +1387,16 @@ class executor_stl_t {
      */
     template <typename thread_aware_function_at>
     void fixed(std::size_t tasks, thread_aware_function_at&& thread_aware_function) noexcept(false) {
-        std::vector<jthread_t> threads_pool;
+        buffer_gt<jthread_t> threads_pool(threads_count_ - 1); // Allocate space for threads minus the main thread
         std::size_t tasks_per_thread = tasks;
         std::size_t threads_count = (std::min)(threads_count_, tasks);
         if (threads_count > 1) {
             tasks_per_thread = (tasks / threads_count) + ((tasks % threads_count) != 0);
             for (std::size_t thread_idx = 1; thread_idx < threads_count; ++thread_idx) {
-                threads_pool.emplace_back([=]() {
+                new (&threads_pool[thread_idx - 1]) jthread_t([=]() {
+#if USEARCH_USE_NUMKONG
+                    nk_configure_thread_(nk_capabilities());
+#endif
                     for (std::size_t task_idx = thread_idx * tasks_per_thread;
                          task_idx < (std::min)(tasks, thread_idx * tasks_per_thread + tasks_per_thread); ++task_idx)
                         thread_aware_function(thread_idx, task_idx);
@@ -439,14 +1415,17 @@ class executor_stl_t {
      */
     template <typename thread_aware_function_at>
     void dynamic(std::size_t tasks, thread_aware_function_at&& thread_aware_function) noexcept(false) {
-        std::vector<jthread_t> threads_pool;
+        buffer_gt<jthread_t> threads_pool(threads_count_ - 1);
         std::size_t tasks_per_thread = tasks;
         std::size_t threads_count = (std::min)(threads_count_, tasks);
         std::atomic_bool stop{false};
         if (threads_count > 1) {
             tasks_per_thread = (tasks / threads_count) + ((tasks % threads_count) != 0);
             for (std::size_t thread_idx = 1; thread_idx < threads_count; ++thread_idx) {
-                threads_pool.emplace_back([=, &stop]() {
+                new (&threads_pool[thread_idx - 1]) jthread_t([=, &stop]() {
+#if USEARCH_USE_NUMKONG
+                    nk_configure_thread_(nk_capabilities());
+#endif
                     for (std::size_t task_idx = thread_idx * tasks_per_thread;
                          task_idx < (std::min)(tasks, thread_idx * tasks_per_thread + tasks_per_thread) &&
                          !stop.load(std::memory_order_relaxed);
@@ -471,9 +1450,14 @@ class executor_stl_t {
     void parallel(thread_aware_function_at&& thread_aware_function) noexcept(false) {
         if (threads_count_ == 1)
             return thread_aware_function(0);
-        std::vector<jthread_t> threads_pool;
+        buffer_gt<jthread_t> threads_pool(threads_count_ - 1);
         for (std::size_t thread_idx = 1; thread_idx < threads_count_; ++thread_idx)
-            threads_pool.emplace_back([=]() { thread_aware_function(thread_idx); });
+            new (&threads_pool[thread_idx - 1]) jthread_t([=]() {
+#if USEARCH_USE_NUMKONG
+                nk_configure_thread_(nk_capabilities());
+#endif
+                thread_aware_function(thread_idx);
+            });
         thread_aware_function(0);
     }
 };
@@ -482,7 +1466,7 @@ class executor_stl_t {
 
 /**
  *  @brief  An OpenMP-based executor or a "thread-pool" for parallel execution.
- *          Is the preferred implementation, when available, and maximum performance is needed.
+ *          Is the preferred implementation, when available, and target environment has OpenMP.
  */
 class executor_openmp_t {
   public:
@@ -491,6 +1475,14 @@ class executor_openmp_t {
      */
     executor_openmp_t(std::size_t threads_count = 0) noexcept {
         omp_set_num_threads(static_cast<int>(threads_count ? threads_count : std::thread::hardware_concurrency()));
+#if USEARCH_USE_NUMKONG
+        nk_capability_t caps = nk_capabilities();
+        nk_configure_thread(caps);
+#pragma omp parallel
+        {
+            nk_configure_thread(caps);
+        }
+#endif
     }
 
     /**
@@ -548,7 +1540,9 @@ class executor_openmp_t {
     template <typename thread_aware_function_at>
     void parallel(thread_aware_function_at&& thread_aware_function) noexcept(false) {
 #pragma omp parallel
-        { thread_aware_function(omp_get_thread_num()); }
+        {
+            thread_aware_function(omp_get_thread_num());
+        }
     }
 };
 
@@ -561,7 +1555,8 @@ using executor_default_t = executor_stl_t;
 #endif
 
 /**
- *  @brief Uses OS-specific APIs for aligned memory allocations.
+ *  @brief  Uses OS-specific APIs for aligned memory allocations.
+ *          Available since C11, but only C++17, so we wrap the C version.
  */
 template <typename element_at = char, std::size_t alignment_ak = 64> //
 class aligned_allocator_gt {
@@ -578,12 +1573,18 @@ class aligned_allocator_gt {
 
     pointer allocate(size_type length) const {
         std::size_t length_bytes = alignment_ak * divide_round_up<alignment_ak>(length * sizeof(value_type));
+        // Avoid overflow
+        if (length > length_bytes)
+            return nullptr;
         std::size_t alignment = alignment_ak;
-        // void* result = nullptr;
-        // int status = posix_memalign(&result, alignment, length_bytes);
-        // return status == 0 ? (pointer)result : nullptr;
 #if defined(USEARCH_DEFINED_WINDOWS)
         return (pointer)_aligned_malloc(length_bytes, alignment);
+#elif defined(USEARCH_DEFINED_APPLE) || defined(USEARCH_DEFINED_ANDROID)
+        // Apple Clang keeps complaining that `aligned_alloc` is only available
+        // with macOS 10.15 and newer or Android API >= 28, so let's use `posix_memalign` there.
+        void* result = nullptr;
+        int status = posix_memalign(&result, alignment, length_bytes);
+        return status == 0 ? (pointer)result : nullptr;
 #else
         return (pointer)aligned_alloc(alignment, length_bytes);
 #endif
@@ -600,6 +1601,10 @@ class aligned_allocator_gt {
 
 using aligned_allocator_t = aligned_allocator_gt<>;
 
+/**
+ *  @brief  A simple RAM-page allocator that uses the OS-specific APIs for memory allocation.
+ *          Shouldn't be used frequently, as system calls are slow.
+ */
 class page_allocator_t {
   public:
     static constexpr std::size_t page_size() { return 4096; }
@@ -614,7 +1619,8 @@ class page_allocator_t {
 #if defined(USEARCH_DEFINED_WINDOWS)
         return (byte_t*)(::VirtualAlloc(NULL, count_bytes, MEM_COMMIT | MEM_RESERVE, PAGE_READWRITE));
 #else
-        return (byte_t*)mmap(NULL, count_bytes, PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, 0, 0);
+        auto* result = mmap(NULL, count_bytes, PROT_WRITE | PROT_READ, MAP_PRIVATE | MAP_ANONYMOUS, -1, 0);
+        return (result == MAP_FAILED) ? nullptr : (byte_t*)result;
 #endif
     }
 
@@ -649,6 +1655,7 @@ template <std::size_t alignment_ak = 1> class memory_mapping_allocator_gt {
     std::size_t last_usage_ = head_size();
     std::size_t last_capacity_ = min_capacity();
     std::size_t wasted_space_ = 0;
+    std::size_t total_allocated_ = 0;
 
   public:
     using value_type = byte_t;
@@ -659,13 +1666,15 @@ template <std::size_t alignment_ak = 1> class memory_mapping_allocator_gt {
     memory_mapping_allocator_gt() = default;
     memory_mapping_allocator_gt(memory_mapping_allocator_gt&& other) noexcept
         : last_arena_(exchange(other.last_arena_, nullptr)), last_usage_(exchange(other.last_usage_, 0)),
-          last_capacity_(exchange(other.last_capacity_, 0)), wasted_space_(exchange(other.wasted_space_, 0)) {}
+          last_capacity_(exchange(other.last_capacity_, 0)), wasted_space_(exchange(other.wasted_space_, 0)),
+          total_allocated_(exchange(other.total_allocated_, 0)) {}
 
     memory_mapping_allocator_gt& operator=(memory_mapping_allocator_gt&& other) noexcept {
         std::swap(last_arena_, other.last_arena_);
         std::swap(last_usage_, other.last_usage_);
         std::swap(last_capacity_, other.last_capacity_);
         std::swap(wasted_space_, other.wasted_space_);
+        std::swap(total_allocated_, other.total_allocated_);
         return *this;
     }
 
@@ -690,6 +1699,7 @@ template <std::size_t alignment_ak = 1> class memory_mapping_allocator_gt {
         last_usage_ = head_size();
         last_capacity_ = min_capacity();
         wasted_space_ = 0;
+        total_allocated_ = 0;
     }
 
     /**
@@ -728,6 +1738,7 @@ template <std::size_t alignment_ak = 1> class memory_mapping_allocator_gt {
             last_arena_ = new_arena;
             last_capacity_ = new_cap;
             last_usage_ = head_size();
+            total_allocated_ += new_cap;
         }
 
         wasted_space_ += extended_bytes - count_bytes;
@@ -738,17 +1749,7 @@ template <std::size_t alignment_ak = 1> class memory_mapping_allocator_gt {
      *  @brief Returns the amount of memory used by the allocator across all arenas.
      *  @return The amount of space in bytes.
      */
-    std::size_t total_allocated() const noexcept {
-        if (!last_arena_)
-            return 0;
-        std::size_t total_used = 0;
-        std::size_t last_capacity = last_capacity_;
-        do {
-            total_used += last_capacity;
-            last_capacity /= capacity_multiplier();
-        } while (last_capacity >= min_capacity());
-        return total_used;
-    }
+    std::size_t total_allocated() const noexcept { return total_allocated_; }
 
     /**
      *  @brief Returns the amount of wasted space due to alignment.
@@ -863,7 +1864,7 @@ template <typename mutex_at = unfair_shared_mutex_t> class shared_lock_gt {
  *          avoiding unnecessary conversions.
  */
 template <typename from_scalar_at, typename to_scalar_at> struct cast_gt {
-    inline bool operator()(byte_t const* input, std::size_t dim, byte_t* output) const {
+    static bool try_(byte_t const* input, std::size_t dim, byte_t* output) noexcept {
         from_scalar_at const* typed_input = reinterpret_cast<from_scalar_at const*>(input);
         to_scalar_at* typed_output = reinterpret_cast<to_scalar_at*>(output);
         auto converter = [](from_scalar_at from) { return to_scalar_at(from); };
@@ -873,29 +1874,38 @@ template <typename from_scalar_at, typename to_scalar_at> struct cast_gt {
 };
 
 template <> struct cast_gt<f32_t, f32_t> {
-    bool operator()(byte_t const*, std::size_t, byte_t*) const { return false; }
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
 };
 
 template <> struct cast_gt<f64_t, f64_t> {
-    bool operator()(byte_t const*, std::size_t, byte_t*) const { return false; }
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
 };
 
 template <> struct cast_gt<f16_bits_t, f16_bits_t> {
-    bool operator()(byte_t const*, std::size_t, byte_t*) const { return false; }
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
+};
+
+template <> struct cast_gt<bf16_bits_t, bf16_bits_t> {
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
 };
 
 template <> struct cast_gt<i8_t, i8_t> {
-    bool operator()(byte_t const*, std::size_t, byte_t*) const { return false; }
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
+};
+
+template <> struct cast_gt<u8_t, u8_t> {
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
 };
 
 template <> struct cast_gt<b1x8_t, b1x8_t> {
-    bool operator()(byte_t const*, std::size_t, byte_t*) const { return false; }
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
 };
 
-template <typename from_scalar_at> struct cast_gt<from_scalar_at, b1x8_t> {
-    inline bool operator()(byte_t const* input, std::size_t dim, byte_t* output) const {
+template <typename from_scalar_at> struct cast_to_b1x8_gt {
+    inline static bool try_(byte_t const* input, std::size_t dim, byte_t* output) noexcept {
         from_scalar_at const* typed_input = reinterpret_cast<from_scalar_at const*>(input);
         unsigned char* typed_output = reinterpret_cast<unsigned char*>(output);
+        std::memset(typed_output, 0, dim / CHAR_BIT);
         for (std::size_t i = 0; i != dim; ++i)
             // Converting from scalar types to boolean isn't trivial and depends on the type.
             // The most common case is to consider all positive values as `true` and all others as `false`.
@@ -912,8 +1922,8 @@ template <typename from_scalar_at> struct cast_gt<from_scalar_at, b1x8_t> {
     }
 };
 
-template <typename to_scalar_at> struct cast_gt<b1x8_t, to_scalar_at> {
-    inline bool operator()(byte_t const* input, std::size_t dim, byte_t* output) const {
+template <typename to_scalar_at> struct cast_from_b1x8_gt {
+    static bool try_(byte_t const* input, std::size_t dim, byte_t* output) noexcept {
         unsigned char const* typed_input = reinterpret_cast<unsigned char const*>(input);
         to_scalar_at* typed_output = reinterpret_cast<to_scalar_at*>(output);
         for (std::size_t i = 0; i != dim; ++i)
@@ -924,55 +1934,287 @@ template <typename to_scalar_at> struct cast_gt<b1x8_t, to_scalar_at> {
     }
 };
 
-/**
- *  @brief  Numeric type for uniformly-distributed floating point
- *          values within [-1,1] range, quantized to integers [-100,100].
- */
-class i8_converted_t {
-    std::int8_t int8_{};
-
-  public:
-    constexpr static f32_t divisor_k = 100.f;
-    constexpr static std::int8_t min_k = -100;
-    constexpr static std::int8_t max_k = 100;
-
-    inline i8_converted_t() noexcept : int8_(0) {}
-    inline i8_converted_t(bool v) noexcept : int8_(v ? max_k : 0) {}
-
-    inline i8_converted_t(i8_converted_t&&) = default;
-    inline i8_converted_t& operator=(i8_converted_t&&) = default;
-    inline i8_converted_t(i8_converted_t const&) = default;
-    inline i8_converted_t& operator=(i8_converted_t const&) = default;
-
-    inline operator f16_t() const noexcept { return static_cast<f16_t>(f32_t(int8_) / divisor_k); }
-    inline operator f32_t() const noexcept { return f32_t(int8_) / divisor_k; }
-    inline operator f64_t() const noexcept { return f64_t(int8_) / divisor_k; }
-    inline explicit operator bool() const noexcept { return int8_ > (max_k / 2); }
-    inline explicit operator std::int8_t() const noexcept { return int8_; }
-    inline explicit operator std::int16_t() const noexcept { return int8_; }
-    inline explicit operator std::int32_t() const noexcept { return int8_; }
-    inline explicit operator std::int64_t() const noexcept { return int8_; }
-
-    inline i8_converted_t(f16_t v)
-        : int8_(usearch::clamp<std::int8_t>(static_cast<std::int8_t>(v * divisor_k), min_k, max_k)) {}
-    inline i8_converted_t(f32_t v)
-        : int8_(usearch::clamp<std::int8_t>(static_cast<std::int8_t>(v * divisor_k), min_k, max_k)) {}
-    inline i8_converted_t(f64_t v)
-        : int8_(usearch::clamp<std::int8_t>(static_cast<std::int8_t>(v * divisor_k), min_k, max_k)) {}
+template <typename from_scalar_at> struct cast_to_i8_gt {
+    inline static bool try_(byte_t const* input, std::size_t dim, byte_t* output) noexcept {
+        from_scalar_at const* typed_input = reinterpret_cast<from_scalar_at const*>(input);
+        std::int8_t* typed_output = reinterpret_cast<std::int8_t*>(output);
+        // Unlike other casting mechanisms, switching to small range integers is a two step procedure.
+        // First we want to estimate the magnitude of the vector to scale into [-1.0, 1.0] interval,
+        // instead of clamping. And then we scale the values into the [-127, 127] range.
+        // ! This makes an assumption, that the distance metric is dot-product-like, which may not
+        // ! be true in many cases, so it's recommended to avoid automatic casting from floats to
+        // ! integers.
+        double magnitude = 0.0;
+        for (std::size_t i = 0; i != dim; ++i)
+            magnitude += (double)typed_input[i] * (double)typed_input[i];
+        magnitude = std::sqrt(magnitude);
+        for (std::size_t i = 0; i != dim; ++i)
+            typed_output[i] =
+                static_cast<std::int8_t>(usearch::clamp<double>(typed_input[i] * 127.0 / magnitude, -127.0, 127.0));
+        return true;
+    }
 };
 
-f16_bits_t::f16_bits_t(i8_converted_t v) noexcept : uint16_(f32_to_f16(v)) {}
+template <typename to_scalar_at> struct cast_from_i8_gt {
+    static bool try_(byte_t const* input, std::size_t dim, byte_t* output) noexcept {
+        std::int8_t const* typed_input = reinterpret_cast<std::int8_t const*>(input);
+        to_scalar_at* typed_output = reinterpret_cast<to_scalar_at*>(output);
+        for (std::size_t i = 0; i != dim; ++i)
+            typed_output[i] = static_cast<to_scalar_at>(typed_input[i]) / 127.f;
+        return true;
+    }
+};
 
-template <> struct cast_gt<i8_t, f16_t> : public cast_gt<i8_converted_t, f16_t> {};
-template <> struct cast_gt<i8_t, f32_t> : public cast_gt<i8_converted_t, f32_t> {};
-template <> struct cast_gt<i8_t, f64_t> : public cast_gt<i8_converted_t, f64_t> {};
+template <typename from_scalar_at> struct cast_to_u8_gt {
+    inline static bool try_(byte_t const* input, std::size_t dim, byte_t* output) noexcept {
+        from_scalar_at const* typed_input = reinterpret_cast<from_scalar_at const*>(input);
+        std::uint8_t* typed_output = reinterpret_cast<std::uint8_t*>(output);
+        double magnitude = 0.0;
+        for (std::size_t i = 0; i != dim; ++i)
+            magnitude += (double)typed_input[i] * (double)typed_input[i];
+        magnitude = std::sqrt(magnitude);
+        for (std::size_t i = 0; i != dim; ++i)
+            typed_output[i] =
+                static_cast<std::uint8_t>(usearch::clamp<double>(typed_input[i] * 255.0 / magnitude, 0.0, 255.0));
+        return true;
+    }
+};
 
-template <> struct cast_gt<f16_t, i8_t> : public cast_gt<f16_t, i8_converted_t> {};
-template <> struct cast_gt<f32_t, i8_t> : public cast_gt<f32_t, i8_converted_t> {};
-template <> struct cast_gt<f64_t, i8_t> : public cast_gt<f64_t, i8_converted_t> {};
+template <typename to_scalar_at> struct cast_from_u8_gt {
+    static bool try_(byte_t const* input, std::size_t dim, byte_t* output) noexcept {
+        std::uint8_t const* typed_input = reinterpret_cast<std::uint8_t const*>(input);
+        to_scalar_at* typed_output = reinterpret_cast<to_scalar_at*>(output);
+        for (std::size_t i = 0; i != dim; ++i)
+            typed_output[i] = static_cast<to_scalar_at>(typed_input[i]) / 255.f;
+        return true;
+    }
+};
+
+template <> struct cast_gt<i8_t, f16_bits_t> : public cast_from_i8_gt<f16_t> {};
+template <> struct cast_gt<i8_t, bf16_bits_t> : public cast_from_i8_gt<bf16_t> {};
+template <> struct cast_gt<i8_t, f32_t> : public cast_from_i8_gt<f32_t> {};
+template <> struct cast_gt<i8_t, f64_t> : public cast_from_i8_gt<f64_t> {};
+
+template <> struct cast_gt<f16_bits_t, i8_t> : public cast_to_i8_gt<f16_t> {};
+template <> struct cast_gt<bf16_bits_t, i8_t> : public cast_to_i8_gt<bf16_t> {};
+template <> struct cast_gt<f32_t, i8_t> : public cast_to_i8_gt<f32_t> {};
+template <> struct cast_gt<f64_t, i8_t> : public cast_to_i8_gt<f64_t> {};
+
+template <> struct cast_gt<b1x8_t, f16_bits_t> : public cast_from_b1x8_gt<f16_t> {};
+template <> struct cast_gt<b1x8_t, bf16_bits_t> : public cast_from_b1x8_gt<bf16_t> {};
+template <> struct cast_gt<b1x8_t, f32_t> : public cast_from_b1x8_gt<f32_t> {};
+template <> struct cast_gt<b1x8_t, f64_t> : public cast_from_b1x8_gt<f64_t> {};
+
+template <> struct cast_gt<f16_bits_t, b1x8_t> : public cast_to_b1x8_gt<f16_t> {};
+template <> struct cast_gt<bf16_bits_t, b1x8_t> : public cast_to_b1x8_gt<bf16_t> {};
+template <> struct cast_gt<f32_t, b1x8_t> : public cast_to_b1x8_gt<f32_t> {};
+template <> struct cast_gt<f64_t, b1x8_t> : public cast_to_b1x8_gt<f64_t> {};
+
+template <> struct cast_gt<b1x8_t, i8_t> : public cast_from_b1x8_gt<i8_t> {};
+template <> struct cast_gt<i8_t, b1x8_t> : public cast_to_b1x8_gt<i8_t> {};
+
+template <typename from_at, typename to_at> struct cast_through_f32_gt {
+    static bool try_(byte_t const* input, std::size_t dim, byte_t* output) noexcept {
+        from_at const* in = reinterpret_cast<from_at const*>(input);
+        to_at* out = reinterpret_cast<to_at*>(output);
+        for (std::size_t i = 0; i != dim; ++i)
+            out[i] = to_at(float(in[i]));
+        return true;
+    }
+};
+
+template <> struct cast_gt<e5m2_bits_t, e5m2_bits_t> {
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
+};
+template <> struct cast_gt<e5m2_bits_t, f32_t> : public cast_through_f32_gt<e5m2_t, f32_t> {};
+template <> struct cast_gt<f32_t, e5m2_bits_t> : public cast_through_f32_gt<f32_t, e5m2_t> {};
+template <> struct cast_gt<e5m2_bits_t, f64_t> : public cast_through_f32_gt<e5m2_t, f64_t> {};
+template <> struct cast_gt<f64_t, e5m2_bits_t> : public cast_through_f32_gt<f64_t, e5m2_t> {};
+template <> struct cast_gt<e5m2_bits_t, f16_bits_t> : public cast_through_f32_gt<e5m2_t, f16_t> {};
+template <> struct cast_gt<f16_bits_t, e5m2_bits_t> : public cast_through_f32_gt<f16_t, e5m2_t> {};
+template <> struct cast_gt<e5m2_bits_t, bf16_bits_t> : public cast_through_f32_gt<e5m2_t, bf16_t> {};
+template <> struct cast_gt<bf16_bits_t, e5m2_bits_t> : public cast_through_f32_gt<bf16_t, e5m2_t> {};
+template <> struct cast_gt<e5m2_bits_t, i8_t> : public cast_to_i8_gt<e5m2_t> {};
+template <> struct cast_gt<i8_t, e5m2_bits_t> : public cast_from_i8_gt<e5m2_t> {};
+template <> struct cast_gt<e5m2_bits_t, b1x8_t> : public cast_to_b1x8_gt<e5m2_t> {};
+template <> struct cast_gt<b1x8_t, e5m2_bits_t> : public cast_from_b1x8_gt<e5m2_t> {};
+
+template <> struct cast_gt<e4m3_bits_t, e4m3_bits_t> {
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
+};
+template <> struct cast_gt<e4m3_bits_t, f32_t> : public cast_through_f32_gt<e4m3_t, f32_t> {};
+template <> struct cast_gt<f32_t, e4m3_bits_t> : public cast_through_f32_gt<f32_t, e4m3_t> {};
+template <> struct cast_gt<e4m3_bits_t, f64_t> : public cast_through_f32_gt<e4m3_t, f64_t> {};
+template <> struct cast_gt<f64_t, e4m3_bits_t> : public cast_through_f32_gt<f64_t, e4m3_t> {};
+template <> struct cast_gt<e4m3_bits_t, f16_bits_t> : public cast_through_f32_gt<e4m3_t, f16_t> {};
+template <> struct cast_gt<f16_bits_t, e4m3_bits_t> : public cast_through_f32_gt<f16_t, e4m3_t> {};
+template <> struct cast_gt<e4m3_bits_t, bf16_bits_t> : public cast_through_f32_gt<e4m3_t, bf16_t> {};
+template <> struct cast_gt<bf16_bits_t, e4m3_bits_t> : public cast_through_f32_gt<bf16_t, e4m3_t> {};
+template <> struct cast_gt<e4m3_bits_t, i8_t> : public cast_to_i8_gt<e4m3_t> {};
+template <> struct cast_gt<i8_t, e4m3_bits_t> : public cast_from_i8_gt<e4m3_t> {};
+template <> struct cast_gt<e4m3_bits_t, b1x8_t> : public cast_to_b1x8_gt<e4m3_t> {};
+template <> struct cast_gt<b1x8_t, e4m3_bits_t> : public cast_from_b1x8_gt<e4m3_t> {};
+
+template <> struct cast_gt<e2m3_bits_t, e2m3_bits_t> {
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
+};
+template <> struct cast_gt<e2m3_bits_t, f32_t> : public cast_through_f32_gt<e2m3_t, f32_t> {};
+template <> struct cast_gt<f32_t, e2m3_bits_t> : public cast_through_f32_gt<f32_t, e2m3_t> {};
+template <> struct cast_gt<e2m3_bits_t, f64_t> : public cast_through_f32_gt<e2m3_t, f64_t> {};
+template <> struct cast_gt<f64_t, e2m3_bits_t> : public cast_through_f32_gt<f64_t, e2m3_t> {};
+template <> struct cast_gt<e2m3_bits_t, f16_bits_t> : public cast_through_f32_gt<e2m3_t, f16_t> {};
+template <> struct cast_gt<f16_bits_t, e2m3_bits_t> : public cast_through_f32_gt<f16_t, e2m3_t> {};
+template <> struct cast_gt<e2m3_bits_t, bf16_bits_t> : public cast_through_f32_gt<e2m3_t, bf16_t> {};
+template <> struct cast_gt<bf16_bits_t, e2m3_bits_t> : public cast_through_f32_gt<bf16_t, e2m3_t> {};
+template <> struct cast_gt<e2m3_bits_t, i8_t> : public cast_to_i8_gt<e2m3_t> {};
+template <> struct cast_gt<i8_t, e2m3_bits_t> : public cast_from_i8_gt<e2m3_t> {};
+template <> struct cast_gt<e2m3_bits_t, b1x8_t> : public cast_to_b1x8_gt<e2m3_t> {};
+template <> struct cast_gt<b1x8_t, e2m3_bits_t> : public cast_from_b1x8_gt<e2m3_t> {};
+
+template <> struct cast_gt<e3m2_bits_t, e3m2_bits_t> {
+    static bool try_(byte_t const*, std::size_t, byte_t*) noexcept { return false; }
+};
+template <> struct cast_gt<e3m2_bits_t, f32_t> : public cast_through_f32_gt<e3m2_t, f32_t> {};
+template <> struct cast_gt<f32_t, e3m2_bits_t> : public cast_through_f32_gt<f32_t, e3m2_t> {};
+template <> struct cast_gt<e3m2_bits_t, f64_t> : public cast_through_f32_gt<e3m2_t, f64_t> {};
+template <> struct cast_gt<f64_t, e3m2_bits_t> : public cast_through_f32_gt<f64_t, e3m2_t> {};
+template <> struct cast_gt<e3m2_bits_t, f16_bits_t> : public cast_through_f32_gt<e3m2_t, f16_t> {};
+template <> struct cast_gt<f16_bits_t, e3m2_bits_t> : public cast_through_f32_gt<f16_t, e3m2_t> {};
+template <> struct cast_gt<e3m2_bits_t, bf16_bits_t> : public cast_through_f32_gt<e3m2_t, bf16_t> {};
+template <> struct cast_gt<bf16_bits_t, e3m2_bits_t> : public cast_through_f32_gt<bf16_t, e3m2_t> {};
+template <> struct cast_gt<e3m2_bits_t, i8_t> : public cast_to_i8_gt<e3m2_t> {};
+template <> struct cast_gt<i8_t, e3m2_bits_t> : public cast_from_i8_gt<e3m2_t> {};
+template <> struct cast_gt<e3m2_bits_t, b1x8_t> : public cast_to_b1x8_gt<e3m2_t> {};
+template <> struct cast_gt<b1x8_t, e3m2_bits_t> : public cast_from_b1x8_gt<e3m2_t> {};
+
+template <> struct cast_gt<u8_t, f16_bits_t> : public cast_from_u8_gt<f16_t> {};
+template <> struct cast_gt<u8_t, bf16_bits_t> : public cast_from_u8_gt<bf16_t> {};
+template <> struct cast_gt<u8_t, f32_t> : public cast_from_u8_gt<f32_t> {};
+template <> struct cast_gt<u8_t, f64_t> : public cast_from_u8_gt<f64_t> {};
+template <> struct cast_gt<f16_bits_t, u8_t> : public cast_to_u8_gt<f16_t> {};
+template <> struct cast_gt<bf16_bits_t, u8_t> : public cast_to_u8_gt<bf16_t> {};
+template <> struct cast_gt<f32_t, u8_t> : public cast_to_u8_gt<f32_t> {};
+template <> struct cast_gt<f64_t, u8_t> : public cast_to_u8_gt<f64_t> {};
+template <> struct cast_gt<b1x8_t, u8_t> : public cast_from_b1x8_gt<u8_t> {};
+template <> struct cast_gt<u8_t, b1x8_t> : public cast_to_b1x8_gt<u8_t> {};
+template <> struct cast_gt<e5m2_bits_t, u8_t> : public cast_to_u8_gt<e5m2_t> {};
+template <> struct cast_gt<u8_t, e5m2_bits_t> : public cast_from_u8_gt<e5m2_t> {};
+template <> struct cast_gt<e4m3_bits_t, u8_t> : public cast_to_u8_gt<e4m3_t> {};
+template <> struct cast_gt<u8_t, e4m3_bits_t> : public cast_from_u8_gt<e4m3_t> {};
+template <> struct cast_gt<e2m3_bits_t, u8_t> : public cast_to_u8_gt<e2m3_t> {};
+template <> struct cast_gt<u8_t, e2m3_bits_t> : public cast_from_u8_gt<e2m3_t> {};
+template <> struct cast_gt<e3m2_bits_t, u8_t> : public cast_to_u8_gt<e3m2_t> {};
+template <> struct cast_gt<u8_t, e3m2_bits_t> : public cast_from_u8_gt<e3m2_t> {};
+template <> struct cast_gt<i8_t, u8_t> : public cast_to_u8_gt<i8_t> {};
+template <> struct cast_gt<u8_t, i8_t> : public cast_from_u8_gt<i8_t> {};
+
+/**
+ *  @brief  Type-punned array casting function.
+ *          Arguments: input buffer, bytes in input buffer, output buffer.
+ *          Returns `true` if the casting was performed successfully, `false` otherwise.
+ */
+using cast_punned_t = bool (*)(byte_t const*, std::size_t, byte_t*);
+
+/**
+ *  @brief  A collection of casting functions for typical vector types.
+ *          Covers to/from conversions for boolean, integer, half-precision,
+ *          single-precision, and double-precision scalars.
+ */
+struct casts_punned_t {
+    struct group_t {
+        cast_punned_t f64{};
+        cast_punned_t f32{};
+        cast_punned_t bf16{};
+        cast_punned_t f16{};
+        cast_punned_t e5m2{};
+        cast_punned_t e4m3{};
+        cast_punned_t e3m2{};
+        cast_punned_t e2m3{};
+        cast_punned_t i8{};
+        cast_punned_t u8{};
+        cast_punned_t b1x8{};
+
+        cast_punned_t operator[](scalar_kind_t scalar_kind) const noexcept {
+            switch (scalar_kind) {
+            case scalar_kind_t::f64_k: return f64;
+            case scalar_kind_t::f32_k: return f32;
+            case scalar_kind_t::bf16_k: return bf16;
+            case scalar_kind_t::f16_k: return f16;
+            case scalar_kind_t::e5m2_k: return e5m2;
+            case scalar_kind_t::e4m3_k: return e4m3;
+            case scalar_kind_t::e3m2_k: return e3m2;
+            case scalar_kind_t::e2m3_k: return e2m3;
+            case scalar_kind_t::i8_k: return i8;
+            case scalar_kind_t::u8_k: return u8;
+            case scalar_kind_t::b1x8_k: return b1x8;
+            default: return nullptr;
+            }
+        }
+
+    } from, to;
+
+    template <typename scalar_at> static casts_punned_t make() noexcept {
+        casts_punned_t result;
+
+        result.from.f64 = &cast_gt<f64_t, scalar_at>::try_;
+        result.from.f32 = &cast_gt<f32_t, scalar_at>::try_;
+        result.from.bf16 = &cast_gt<bf16_t, scalar_at>::try_;
+        result.from.f16 = &cast_gt<f16_t, scalar_at>::try_;
+        result.from.e5m2 = &cast_gt<e5m2_t, scalar_at>::try_;
+        result.from.e4m3 = &cast_gt<e4m3_t, scalar_at>::try_;
+        result.from.e3m2 = &cast_gt<e3m2_t, scalar_at>::try_;
+        result.from.e2m3 = &cast_gt<e2m3_t, scalar_at>::try_;
+        result.from.i8 = &cast_gt<i8_t, scalar_at>::try_;
+        result.from.u8 = &cast_gt<u8_t, scalar_at>::try_;
+        result.from.b1x8 = &cast_gt<b1x8_t, scalar_at>::try_;
+
+        result.to.f64 = &cast_gt<scalar_at, f64_t>::try_;
+        result.to.f32 = &cast_gt<scalar_at, f32_t>::try_;
+        result.to.bf16 = &cast_gt<scalar_at, bf16_t>::try_;
+        result.to.f16 = &cast_gt<scalar_at, f16_t>::try_;
+        result.to.e5m2 = &cast_gt<scalar_at, e5m2_t>::try_;
+        result.to.e4m3 = &cast_gt<scalar_at, e4m3_t>::try_;
+        result.to.e3m2 = &cast_gt<scalar_at, e3m2_t>::try_;
+        result.to.e2m3 = &cast_gt<scalar_at, e2m3_t>::try_;
+        result.to.i8 = &cast_gt<scalar_at, i8_t>::try_;
+        result.to.u8 = &cast_gt<scalar_at, u8_t>::try_;
+        result.to.b1x8 = &cast_gt<scalar_at, b1x8_t>::try_;
+
+        return result;
+    }
+
+    static casts_punned_t make(scalar_kind_t scalar_kind) noexcept {
+        switch (scalar_kind) {
+        case scalar_kind_t::f64_k: return casts_punned_t::make<f64_t>();
+        case scalar_kind_t::f32_k: return casts_punned_t::make<f32_t>();
+        case scalar_kind_t::bf16_k: return casts_punned_t::make<bf16_t>();
+        case scalar_kind_t::f16_k: return casts_punned_t::make<f16_t>();
+        case scalar_kind_t::e5m2_k: return casts_punned_t::make<e5m2_t>();
+        case scalar_kind_t::e4m3_k: return casts_punned_t::make<e4m3_t>();
+        case scalar_kind_t::e3m2_k: return casts_punned_t::make<e3m2_t>();
+        case scalar_kind_t::e2m3_k: return casts_punned_t::make<e2m3_t>();
+        case scalar_kind_t::i8_k: return casts_punned_t::make<i8_t>();
+        case scalar_kind_t::u8_k: return casts_punned_t::make<u8_t>();
+        case scalar_kind_t::b1x8_k: return casts_punned_t::make<b1x8_t>();
+        default: return {};
+        }
+    }
+};
+
+/*  Don't complain if the vectorization of the inner loops fails:
+ *
+ *  > warning: loop not vectorized: the optimizer was unable to perform the requested transformation;
+ *  > the transformation might be disabled or specified as part of an unsupported transformation ordering
+ */
+#if defined(USEARCH_DEFINED_CLANG)
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wpass-failed"
+#endif
 
 /**
  *  @brief  Inner (Dot) Product distance.
+ *          Vectors should be normalized to unit length,
+ *          otherwise `::metric_cos_gt` should be used instead.
  */
 template <typename scalar_at = float, typename result_at = scalar_at> struct metric_ip_gt {
     using scalar_t = scalar_at;
@@ -1207,7 +2449,8 @@ template <typename scalar_at = float, typename result_at = float> struct metric_
             b_sq_sum += bi * bi;
         }
         result_t denom = (dim * a_sq_sum - a_sum * a_sum) * (dim * b_sq_sum - b_sum * b_sum);
-        if (denom == 0)
+        // could be negative
+        if (denom <= 0)
             return 0;
         result_t corr = dim * ab_sum - a_sum * b_sum;
         denom = std::sqrt(denom);
@@ -1245,7 +2488,10 @@ template <typename scalar_at = float, typename result_at = float> struct metric_
     }
 };
 
-struct cos_i8_t {
+/**
+ *  @brief  Cosine (Angular) distance for signed 8-bit integers using 16-bit intermediates.
+ */
+struct metric_cos_i8_t {
     using scalar_t = i8_t;
     using result_t = f32_t;
 
@@ -1271,7 +2517,11 @@ struct cos_i8_t {
     }
 };
 
-struct l2sq_i8_t {
+/**
+ *  @brief  Squared Euclidean (L2) distance for signed 8-bit integers using 16-bit intermediates.
+ *          Square root is avoided at the end, as it won't affect the ordering.
+ */
+struct metric_l2sq_i8_t {
     using scalar_t = i8_t;
     using result_t = f32_t;
 
@@ -1286,6 +2536,57 @@ struct l2sq_i8_t {
 #endif
         for (std::size_t i = 0; i != dim; i++)
             ab_deltas_sq += square(std::int16_t(a[i]) - std::int16_t(b[i]));
+        return static_cast<result_t>(ab_deltas_sq);
+    }
+};
+
+/**
+ *  @brief  Cosine (Angular) distance for unsigned 8-bit integers using 32-bit intermediates.
+ */
+struct metric_cos_u8_t {
+    using scalar_t = u8_t;
+    using result_t = f32_t;
+
+    inline result_t operator()(u8_t const* a, u8_t const* b, std::size_t dim) const noexcept {
+        std::int64_t ab{}, a2{}, b2{};
+#if USEARCH_USE_OPENMP
+#pragma omp simd reduction(+ : ab, a2, b2)
+#elif defined(USEARCH_DEFINED_CLANG)
+#pragma clang loop vectorize(enable)
+#elif defined(USEARCH_DEFINED_GCC)
+#pragma GCC ivdep
+#endif
+        for (std::size_t i = 0; i != dim; i++) {
+            std::int32_t ai{a[i]};
+            std::int32_t bi{b[i]};
+            ab += ai * bi;
+            a2 += square(ai);
+            b2 += square(bi);
+        }
+        result_t a2f = std::sqrt(static_cast<result_t>(a2));
+        result_t b2f = std::sqrt(static_cast<result_t>(b2));
+        return (ab != 0) ? (1.f - ab / (a2f * b2f)) : 0;
+    }
+};
+
+/**
+ *  @brief  Squared Euclidean (L2) distance for unsigned 8-bit integers using 32-bit intermediates.
+ */
+struct metric_l2sq_u8_t {
+    using scalar_t = u8_t;
+    using result_t = f32_t;
+
+    inline result_t operator()(u8_t const* a, u8_t const* b, std::size_t dim) const noexcept {
+        std::int32_t ab_deltas_sq{};
+#if USEARCH_USE_OPENMP
+#pragma omp simd reduction(+ : ab_deltas_sq)
+#elif defined(USEARCH_DEFINED_CLANG)
+#pragma clang loop vectorize(enable)
+#elif defined(USEARCH_DEFINED_GCC)
+#pragma GCC ivdep
+#endif
+        for (std::size_t i = 0; i != dim; i++)
+            ab_deltas_sq += square(std::int32_t(a[i]) - std::int32_t(b[i]));
         return static_cast<result_t>(ab_deltas_sq);
     }
 };
@@ -1331,10 +2632,193 @@ enum class metric_punned_signature_t {
     array_array_state_k,
 };
 
+#if USEARCH_USE_NUMKONG
+
+/**
+ *  @brief  Returns the result of `nk_capabilities()`, cached in a function-local static.
+ *          Every call-site that needs the current CPU's capability mask should use this
+ *          instead of caching the value in its own `static` local.
+ */
+inline nk_capability_t nk_cached_capabilities() noexcept {
+    static nk_capability_t caps = [] {
+        nk_capability_t c = nk_capabilities();
+        nk_configure_thread(c);
+        return c;
+    }();
+    return caps;
+}
+
+/**
+ *  @brief  Converts a USearch `scalar_kind_t` to the corresponding NumKong `nk_dtype_t`.
+ *  @return The matching dtype, or `(nk_dtype_t)0` when there is no NumKong equivalent.
+ */
+inline nk_dtype_t scalar_kind_to_nk_dtype(scalar_kind_t sk) noexcept {
+    switch (sk) {
+    case scalar_kind_t::f64_k: return (nk_dtype_t)nk_f64_k;
+    case scalar_kind_t::f32_k: return (nk_dtype_t)nk_f32_k;
+    case scalar_kind_t::bf16_k: return (nk_dtype_t)nk_bf16_k;
+    case scalar_kind_t::f16_k: return (nk_dtype_t)nk_f16_k;
+    case scalar_kind_t::e5m2_k: return (nk_dtype_t)nk_e5m2_k;
+    case scalar_kind_t::e4m3_k: return (nk_dtype_t)nk_e4m3_k;
+    case scalar_kind_t::e3m2_k: return (nk_dtype_t)nk_e3m2_k;
+    case scalar_kind_t::e2m3_k: return (nk_dtype_t)nk_e2m3_k;
+    case scalar_kind_t::i8_k: return (nk_dtype_t)nk_i8_k;
+    case scalar_kind_t::u8_k: return (nk_dtype_t)nk_u8_k;
+    case scalar_kind_t::b1x8_k: return (nk_dtype_t)nk_u1_k;
+    default: return (nk_dtype_t)0;
+    }
+}
+
+/**
+ *  @brief  One entry in the ISA capability-to-name mapping table.
+ */
+struct isa_target_t {
+    nk_capability_t cap;
+    char const* name;
+};
+
+/**
+ *  @brief  Returns the static table mapping each NumKong capability bit to its human-readable name.
+ *          Both `hardware_acceleration_available` and `hardware_acceleration_compiled` use this table
+ *          together with the bitmasks from `nk_capabilities_available()` / `nk_capabilities_compiled()`.
+ */
+inline span_gt<isa_target_t const> isa_targets() noexcept {
+    static isa_target_t const table[] = {
+        {nk_cap_serial_k, "serial"},
+        // x86
+        {nk_cap_haswell_k, "haswell"},
+        {nk_cap_skylake_k, "skylake"},
+        {nk_cap_icelake_k, "icelake"},
+        {nk_cap_genoa_k, "genoa"},
+        {nk_cap_sapphire_k, "sapphire"},
+        {nk_cap_sapphireamx_k, "sapphireamx"},
+        {nk_cap_graniteamx_k, "graniteamx"},
+        {nk_cap_turin_k, "turin"},
+        {nk_cap_sierra_k, "sierra"},
+        {nk_cap_alder_k, "alder"},
+        {nk_cap_diamond_k, "diamond"},
+        // ARM NEON
+        {nk_cap_neon_k, "neon"},
+        {nk_cap_neonhalf_k, "neonhalf"},
+        {nk_cap_neonsdot_k, "neonsdot"},
+        {nk_cap_neonbfdot_k, "neonbfdot"},
+        {nk_cap_neonfhm_k, "neonfhm"},
+        {nk_cap_neonfp8_k, "neonfp8"},
+        // ARM SVE
+        {nk_cap_sve_k, "sve"},
+        {nk_cap_svehalf_k, "svehalf"},
+        {nk_cap_svesdot_k, "svesdot"},
+        {nk_cap_svebfdot_k, "svebfdot"},
+        {nk_cap_sve2_k, "sve2"},
+        {nk_cap_sve2p1_k, "sve2p1"},
+        // ARM SME
+        {nk_cap_sme_k, "sme"},
+        {nk_cap_sme2_k, "sme2"},
+        {nk_cap_sme2p1_k, "sme2p1"},
+        {nk_cap_smef64_k, "smef64"},
+        {nk_cap_smefa64_k, "smefa64"},
+        {nk_cap_smehalf_k, "smehalf"},
+        {nk_cap_smebf16_k, "smebf16"},
+        {nk_cap_smelut2_k, "smelut2"},
+        {nk_cap_smebi32_k, "smebi32"},
+        // RISC-V
+        {nk_cap_rvv_k, "rvv"},
+        {nk_cap_rvvhalf_k, "rvvhalf"},
+        {nk_cap_rvvbf16_k, "rvvbf16"},
+        {nk_cap_rvvbb_k, "rvvbb"},
+        // WebAssembly
+        {nk_cap_v128relaxed_k, "v128relaxed"},
+        // LoongArch
+        {nk_cap_loongsonasx_k, "loongsonasx"},
+        // IBM Power
+        {nk_cap_powervsx_k, "powervsx"},
+    };
+    return {table, sizeof(table) / sizeof(table[0])};
+}
+
+/**
+ *  @brief  Returns the human-readable name for a single capability bit.
+ *  @param  cap  A single `nk_capability_t` bit (not a bitmask of multiple capabilities).
+ *  @return The name string, or "unknown" if the bit is not in the table.
+ */
+inline char const* capability_name(nk_capability_t cap) noexcept {
+    span_gt<isa_target_t const> table = isa_targets();
+    for (std::size_t i = 0; i != table.size(); ++i)
+        if (table[i].cap == cap)
+            return table[i].name;
+    return "unknown";
+}
+
+/**
+ *  @brief  Formats all ISA targets whose bits are set in `caps` into a comma-separated string.
+ *  @param  caps    Capability bitmask to filter against.
+ *  @param  buf     Output buffer.
+ *  @param  buf_len Size of the output buffer in bytes.
+ *  @return The number of characters written (excluding the null terminator).
+ */
+inline std::size_t isa_targets_format(nk_capability_t caps, char* buf, std::size_t buf_len) noexcept {
+    if (!buf_len)
+        return 0;
+    span_gt<isa_target_t const> table = isa_targets();
+    char* p = buf;
+    char* end = buf + buf_len - 1;
+    std::size_t matched = 0;
+    for (std::size_t i = 0; i != table.size(); ++i) {
+        if (!(caps & table[i].cap))
+            continue;
+        std::size_t name_len = std::strlen(table[i].name);
+        std::size_t needed = name_len + (matched ? 2 : 0);
+        if (p + needed > end)
+            break;
+        if (matched++)
+            *p++ = ',', *p++ = ' ';
+        std::memcpy(p, table[i].name, name_len);
+        p += name_len;
+    }
+    *p = '\0';
+    return static_cast<std::size_t>(p - buf);
+}
+
+/**
+ *  @brief  Returns a comma-separated list of ISAs available at runtime (compiled AND supported by CPU).
+ *  @return Pointer to a static null-terminated string. Thread-safe after first call.
+ */
+inline char const* hardware_acceleration_available() noexcept {
+    static char buf[1024];
+    static bool initialized = false;
+    if (!initialized) {
+        nk_cached_capabilities(); // ensures nk_configure_thread is called
+        isa_targets_format(nk_capabilities_available(), buf, sizeof(buf));
+        initialized = true;
+    }
+    return buf;
+}
+
+/**
+ *  @brief  Returns a comma-separated list of ISAs that were compiled into this binary.
+ *  @return Pointer to a static null-terminated string. Thread-safe after first call.
+ */
+inline char const* hardware_acceleration_compiled() noexcept {
+    static char buf[1024];
+    static bool initialized = false;
+    if (!initialized) {
+        isa_targets_format(nk_capabilities_compiled(), buf, sizeof(buf));
+        initialized = true;
+    }
+    return buf;
+}
+
+#else
+
+inline char const* hardware_acceleration_available() noexcept { return "serial"; }
+inline char const* hardware_acceleration_compiled() noexcept { return "serial"; }
+
+#endif
+
 /**
  *  @brief  Type-punned metric class, which unlike STL's `std::function` avoids any memory allocations.
  *          It also provides additional APIs to check, if SIMD hardware-acceleration is available.
- *          Wraps the `simsimd_metric_punned_t` when available. The auto-vectorized backend otherwise.
+ *          Wraps the `nk_metric_dense_punned_t` when available. The auto-vectorized backend otherwise.
  */
 class metric_punned_t {
   public:
@@ -1351,9 +2835,9 @@ class metric_punned_t {
     /// Distance function that takes two arrays and some callback state and returns a scalar.
     using metric_array_array_state_t = result_t (*)(uptr_t, uptr_t, uptr_t);
     /// Distance function callback, like `metric_array_array_size_t`, but depends on member variables.
-    using metric_rounted_t = result_t (metric_punned_t::*)(uptr_t, uptr_t) const;
+    using metric_routed_t = result_t (metric_punned_t::*)(uptr_t, uptr_t) const;
 
-    metric_rounted_t metric_routed_ = nullptr;
+    metric_routed_t metric_routed_ = nullptr;
     uptr_t metric_ptr_ = 0;
     uptr_t metric_third_arg_ = 0;
 
@@ -1361,8 +2845,8 @@ class metric_punned_t {
     metric_kind_t metric_kind_ = metric_kind_t::unknown_k;
     scalar_kind_t scalar_kind_ = scalar_kind_t::unknown_k;
 
-#if USEARCH_USE_SIMSIMD
-    simsimd_capability_t isa_kind_ = simsimd_cap_serial_k;
+#if USEARCH_USE_NUMKONG
+    nk_capability_t isa_kind_ = nk_cap_serial_k;
 #endif
 
   public:
@@ -1389,7 +2873,7 @@ class metric_punned_t {
 
     /**
      *  @brief  Creates a metric of a natively supported kind, choosing the best
-     *          available backend internally or from SimSIMD.
+     *          available backend internally or from NumKong.
      *
      *  @param  dimensions      The number of elements in the input arrays.
      *  @param  metric_kind     The kind of metric to use.
@@ -1407,12 +2891,8 @@ class metric_punned_t {
         metric.metric_kind_ = metric_kind;
         metric.scalar_kind_ = scalar_kind;
 
-#if USEARCH_USE_SIMSIMD
-        if (!metric.configure_with_simsimd())
+        if (!metric.configure_with_numkong())
             metric.configure_with_autovec();
-#else
-        metric.configure_with_autovec();
-#endif
 
         return metric;
     }
@@ -1447,23 +2927,25 @@ class metric_punned_t {
     }
 
     /**
-     *  @brief  Creates a metric using the provided function pointer for a statefull metric.
+     *  @brief  Creates a metric using the provided function pointer for a stateful metric.
      *          The third argument is the state that will be passed to the metric function.
      *
+     *  @param  dimensions      The number of elements in the input arrays.
      *  @param  metric_uintptr  The function pointer to the metric function.
      *  @param  metric_state    The state to pass to the metric function.
      *  @param  metric_kind     The kind of metric to use.
      *  @param  scalar_kind     The kind of scalar to use.
      *  @return                 A metric object that can be used to compute distances between vectors.
      */
-    inline static metric_punned_t statefull(std::uintptr_t metric_uintptr, std::uintptr_t metric_state,
-                                            metric_kind_t metric_kind = metric_kind_t::unknown_k,
-                                            scalar_kind_t scalar_kind = scalar_kind_t::unknown_k) noexcept {
+    inline static metric_punned_t stateful( //
+        std::size_t dimensions, std::uintptr_t metric_uintptr, std::uintptr_t metric_state,
+        metric_kind_t metric_kind = metric_kind_t::unknown_k,
+        scalar_kind_t scalar_kind = scalar_kind_t::unknown_k) noexcept {
         metric_punned_t metric;
         metric.metric_routed_ = &metric_punned_t::invoke_array_array_third;
         metric.metric_ptr_ = metric_uintptr;
         metric.metric_third_arg_ = metric_state;
-        metric.dimensions_ = 0;
+        metric.dimensions_ = dimensions;
         metric.metric_kind_ = metric_kind;
         metric.scalar_kind_ = scalar_kind;
         return metric;
@@ -1475,7 +2957,7 @@ class metric_punned_t {
     inline explicit operator bool() const noexcept { return metric_routed_ && metric_ptr_; }
 
     /**
-     *  @brief  Checks fi we've failed to initialized the metric with provided arguments.
+     *  @brief  Checks if we've failed to initialize the metric with provided arguments.
      *
      *  It's different from `operator bool()` when it comes to explicitly uninitialized metrics.
      *  It's a common case, where a NULL state is created only to be overwritten later, when
@@ -1486,20 +2968,11 @@ class metric_punned_t {
     inline char const* isa_name() const noexcept {
         if (!*this)
             return "uninitialized";
-
-#if USEARCH_USE_SIMSIMD
-        switch (isa_kind_) {
-        case simsimd_cap_serial_k: return "serial";
-        case simsimd_cap_neon_k: return "neon";
-        case simsimd_cap_sve_k: return "sve";
-        case simsimd_cap_haswell_k: return "haswell";
-        case simsimd_cap_skylake_k: return "skylake";
-        case simsimd_cap_ice_k: return "ice";
-        case simsimd_cap_sapphire_k: return "sapphire";
-        default: return "unknown";
-        }
-#endif
+#if USEARCH_USE_NUMKONG
+        return capability_name(isa_kind_);
+#else
         return "serial";
+#endif
     }
 
     inline std::size_t bytes_per_vector() const noexcept {
@@ -1511,56 +2984,83 @@ class metric_punned_t {
     }
 
   private:
-#if USEARCH_USE_SIMSIMD
-    bool configure_with_simsimd(simsimd_capability_t simd_caps) noexcept {
-        simsimd_metric_kind_t kind = simsimd_metric_unknown_k;
-        simsimd_datatype_t datatype = simsimd_datatype_unknown_k;
-        simsimd_capability_t allowed = simsimd_cap_any_k;
+#if USEARCH_USE_NUMKONG
+    /**
+     *  @brief  Typed invoke template for NumKong kernels.
+     *
+     *  The accumulator type and IP-reversal flag are selected once in `configure_with_numkong`
+     *  and baked into the member-function pointer stored in `metric_routed_`.
+     */
+    template <typename accumulator_at, bool reverse_ak>
+#if defined(USEARCH_DEFINED_CLANG) || defined(USEARCH_DEFINED_GCC)
+    __attribute__((no_sanitize("all")))
+#endif
+    result_t invoke_numkong(uptr_t a, uptr_t b) const noexcept {
+        accumulator_at result = 0;
+        auto function_pointer = (nk_metric_dense_punned_t)(metric_ptr_);
+        function_pointer(reinterpret_cast<void const*>(a), reinterpret_cast<void const*>(b), metric_third_arg_,
+                         &result);
+        return reverse_ak ? (result_t)(1 - (result_t)result) : (result_t)result;
+    }
+
+    /// Shorthand: casts an `invoke_numkong` instantiation to the opaque `metric_routed_t` type.
+    template <typename accumulator_at, bool reverse_ak> //
+    static metric_routed_t numkong_routed() noexcept {
+        return reinterpret_cast<metric_routed_t>(&metric_punned_t::invoke_numkong<accumulator_at, reverse_ak>);
+    }
+
+    bool configure_with_numkong(nk_capability_t simd_caps) noexcept {
+        nk_kernel_kind_t kind = (nk_kernel_kind_t)0;
         switch (metric_kind_) {
-        case metric_kind_t::ip_k: kind = simsimd_metric_dot_k; break;
-        case metric_kind_t::cos_k: kind = simsimd_metric_cos_k; break;
-        case metric_kind_t::l2sq_k: kind = simsimd_metric_l2sq_k; break;
-        case metric_kind_t::hamming_k: kind = simsimd_metric_hamming_k; break;
-        case metric_kind_t::tanimoto_k: kind = simsimd_metric_jaccard_k; break;
-        case metric_kind_t::jaccard_k: kind = simsimd_metric_jaccard_k; break;
-        default: break;
+        case metric_kind_t::ip_k: kind = nk_kernel_dot_k; break;
+        case metric_kind_t::cos_k: kind = nk_kernel_angular_k; break;
+        case metric_kind_t::l2sq_k: kind = nk_kernel_sqeuclidean_k; break;
+        case metric_kind_t::hamming_k: kind = nk_kernel_hamming_k; break;
+        case metric_kind_t::tanimoto_k: kind = nk_kernel_jaccard_k; break;
+        case metric_kind_t::jaccard_k: kind = nk_kernel_jaccard_k; break;
+        default: return false;
         }
-        switch (scalar_kind_) {
-        case scalar_kind_t::f32_k: datatype = simsimd_datatype_f32_k; break;
-        case scalar_kind_t::f64_k: datatype = simsimd_datatype_f64_k; break;
-        case scalar_kind_t::f16_k: datatype = simsimd_datatype_f16_k; break;
-        case scalar_kind_t::i8_k: datatype = simsimd_datatype_i8_k; break;
-        case scalar_kind_t::b1x8_k: datatype = simsimd_datatype_b8_k; break;
-        default: break;
-        }
-        simsimd_metric_punned_t simd_metric = NULL;
-        simsimd_capability_t simd_kind = simsimd_cap_any_k;
-        simsimd_find_metric_punned(kind, datatype, simd_caps, allowed, &simd_metric, &simd_kind);
+        nk_dtype_t datatype = scalar_kind_to_nk_dtype(scalar_kind_);
+        nk_metric_dense_punned_t simd_metric = NULL;
+        nk_capability_t simd_kind = nk_cap_any_k;
+        nk_find_kernel_punned(kind, datatype, simd_caps, (nk_kernel_punned_t*)&simd_metric, &simd_kind);
         if (simd_metric == nullptr)
             return false;
 
         std::memcpy(&metric_ptr_, &simd_metric, sizeof(simd_metric));
-        metric_routed_ = metric_kind_ == metric_kind_t::ip_k
-                             ? reinterpret_cast<metric_rounted_t>(&metric_punned_t::invoke_simsimd_reverse)
-                             : reinterpret_cast<metric_rounted_t>(&metric_punned_t::invoke_simsimd);
+
+        // Select the typed invoke variant based on the kernel's output dtype to avoid per-call branching.
+        // The output type depends on both scalar_kind and metric_kind (e.g. i8 dot->i32, i8 l2sq->u32, i8 cos->f32).
+        nk_dtype_t out_dtype = nk_kernel_output_dtype(kind, datatype);
+        bool is_ip = (metric_kind_ == metric_kind_t::ip_k);
+        switch (out_dtype) {
+        case nk_f64_k:
+            metric_routed_ = is_ip ? numkong_routed<nk_f64_t, true>() : numkong_routed<nk_f64_t, false>();
+            break;
+        case nk_f32_k:
+            metric_routed_ = is_ip ? numkong_routed<nk_f32_t, true>() : numkong_routed<nk_f32_t, false>();
+            break;
+        case nk_i32_k:
+            metric_routed_ = is_ip ? numkong_routed<std::int32_t, true>() : numkong_routed<std::int32_t, false>();
+            break;
+        case nk_u32_k:
+            metric_routed_ = is_ip ? numkong_routed<std::uint32_t, true>() : numkong_routed<std::uint32_t, false>();
+            break;
+        default: metric_routed_ = is_ip ? numkong_routed<nk_f64_t, true>() : numkong_routed<nk_f64_t, false>(); break;
+        }
         isa_kind_ = simd_kind;
+
+        // NumKong binary-set kernels (Hamming, Jaccard/Tanimoto) expect the third argument
+        // to be the number of dimensions (bits), not the number of bytes.
+        if (scalar_kind_ == scalar_kind_t::b1x8_k)
+            metric_third_arg_ = dimensions_;
+
         return true;
     }
-    bool configure_with_simsimd() noexcept {
-        static simsimd_capability_t static_capabilities = simsimd_capabilities();
-        return configure_with_simsimd(static_capabilities);
-    }
-    result_t invoke_simsimd(uptr_t a, uptr_t b) const noexcept {
-        simsimd_distance_t result;
-        // Here `reinterpret_cast` raises warning... we know what we are doing!
-        auto function_pointer = (simsimd_metric_punned_t)(metric_ptr_);
-        function_pointer(reinterpret_cast<void const*>(a), reinterpret_cast<void const*>(b), metric_third_arg_,
-                         &result);
-        return (result_t)result;
-    }
-    result_t invoke_simsimd_reverse(uptr_t a, uptr_t b) const noexcept { return 1 - invoke_simsimd(a, b); }
+
+    bool configure_with_numkong() noexcept { return configure_with_numkong(nk_cached_capabilities()); }
 #else
-    bool configure_with_simsimd() noexcept { return false; }
+    bool configure_with_numkong() noexcept { return false; }
 #endif
     result_t invoke_array_array_third(uptr_t a, uptr_t b) const noexcept {
         auto function_pointer = (metric_array_array_size_t)(metric_ptr_);
@@ -1576,60 +3076,108 @@ class metric_punned_t {
         switch (metric_kind_) {
         case metric_kind_t::ip_k: {
             switch (scalar_kind_) {
-            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<f32_t>>; break;
-            case scalar_kind_t::f16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<f16_t, f32_t>>; break;
-            case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<i8_t, f32_t>>; break;
             case scalar_kind_t::f64_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<f64_t>>; break;
+            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<f32_t>>; break;
+            case scalar_kind_t::bf16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<bf16_t, f32_t>>; break;
+            case scalar_kind_t::f16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<f16_t, f32_t>>; break;
+            case scalar_kind_t::e5m2_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<e5m2_t, f32_t>>; break;
+            case scalar_kind_t::e4m3_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<e4m3_t, f32_t>>; break;
+            case scalar_kind_t::e3m2_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<e3m2_t, f32_t>>; break;
+            case scalar_kind_t::e2m3_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<e2m3_t, f32_t>>; break;
+            case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<i8_t, f32_t>>; break;
+            case scalar_kind_t::u8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_ip_gt<u8_t, f32_t>>; break;
             default: metric_ptr_ = 0; break;
             }
             break;
         }
         case metric_kind_t::cos_k: {
             switch (scalar_kind_) {
-            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<f32_t>>; break;
-            case scalar_kind_t::f16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<f16_t, f32_t>>; break;
-            case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<i8_t, f32_t>>; break;
             case scalar_kind_t::f64_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<f64_t>>; break;
+            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<f32_t>>; break;
+            case scalar_kind_t::bf16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<bf16_t, f32_t>>; break;
+            case scalar_kind_t::f16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<f16_t, f32_t>>; break;
+            case scalar_kind_t::e5m2_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<e5m2_t, f32_t>>; break;
+            case scalar_kind_t::e4m3_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<e4m3_t, f32_t>>; break;
+            case scalar_kind_t::e3m2_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<e3m2_t, f32_t>>; break;
+            case scalar_kind_t::e2m3_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_gt<e2m3_t, f32_t>>; break;
+            case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_i8_t>; break;
+            case scalar_kind_t::u8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_cos_u8_t>; break;
             default: metric_ptr_ = 0; break;
             }
             break;
         }
         case metric_kind_t::l2sq_k: {
             switch (scalar_kind_) {
-            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<f32_t>>; break;
-            case scalar_kind_t::f16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<f16_t, f32_t>>; break;
-            case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<i8_t, f32_t>>; break;
             case scalar_kind_t::f64_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<f64_t>>; break;
+            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<f32_t>>; break;
+            case scalar_kind_t::bf16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<bf16_t, f32_t>>; break;
+            case scalar_kind_t::f16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<f16_t, f32_t>>; break;
+            case scalar_kind_t::e5m2_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<e5m2_t, f32_t>>; break;
+            case scalar_kind_t::e4m3_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<e4m3_t, f32_t>>; break;
+            case scalar_kind_t::e3m2_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<e3m2_t, f32_t>>; break;
+            case scalar_kind_t::e2m3_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_gt<e2m3_t, f32_t>>; break;
+            case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_i8_t>; break;
+            case scalar_kind_t::u8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_l2sq_u8_t>; break;
             default: metric_ptr_ = 0; break;
             }
             break;
         }
         case metric_kind_t::pearson_k: {
             switch (scalar_kind_) {
-            case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<i8_t, f32_t>>; break;
-            case scalar_kind_t::f16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<f16_t, f32_t>>; break;
-            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<f32_t>>; break;
             case scalar_kind_t::f64_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<f64_t>>; break;
+            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<f32_t>>; break;
+            case scalar_kind_t::bf16_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<bf16_t, f32_t>>;
+                break;
+            case scalar_kind_t::f16_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<f16_t, f32_t>>; break;
+            case scalar_kind_t::e5m2_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<e5m2_t, f32_t>>;
+                break;
+            case scalar_kind_t::e4m3_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<e4m3_t, f32_t>>;
+                break;
+            case scalar_kind_t::e3m2_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<e3m2_t, f32_t>>;
+                break;
+            case scalar_kind_t::e2m3_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<e2m3_t, f32_t>>;
+                break;
+            case scalar_kind_t::i8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<i8_t, f32_t>>; break;
+            case scalar_kind_t::u8_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_pearson_gt<u8_t, f32_t>>; break;
             default: metric_ptr_ = 0; break;
             }
             break;
         }
         case metric_kind_t::haversine_k: {
             switch (scalar_kind_) {
-            case scalar_kind_t::f16_k: metric_ptr_ = 0; break; //< Having half-precision 2D coordinates is a bit silly.
-            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_haversine_gt<f32_t>>; break;
             case scalar_kind_t::f64_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_haversine_gt<f64_t>>; break;
+            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_haversine_gt<f32_t>>; break;
             default: metric_ptr_ = 0; break;
             }
             break;
         }
         case metric_kind_t::divergence_k: {
             switch (scalar_kind_) {
+            case scalar_kind_t::f64_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<f64_t>>; break;
+            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<f32_t>>; break;
+            case scalar_kind_t::bf16_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<bf16_t, f32_t>>;
+                break;
             case scalar_kind_t::f16_k:
                 metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<f16_t, f32_t>>;
                 break;
-            case scalar_kind_t::f32_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<f32_t>>; break;
-            case scalar_kind_t::f64_k: metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<f64_t>>; break;
+            case scalar_kind_t::e5m2_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<e5m2_t, f32_t>>;
+                break;
+            case scalar_kind_t::e4m3_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<e4m3_t, f32_t>>;
+                break;
+            case scalar_kind_t::e3m2_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<e3m2_t, f32_t>>;
+                break;
+            case scalar_kind_t::e2m3_k:
+                metric_ptr_ = (uptr_t)&equidimensional_<metric_divergence_gt<e2m3_t, f32_t>>;
+                break;
             default: metric_ptr_ = 0; break;
             }
             break;
@@ -1649,36 +3197,42 @@ class metric_punned_t {
     }
 };
 
+/* Allow complaining about vectorization after this point. */
+#if defined(USEARCH_DEFINED_CLANG)
+#pragma clang diagnostic pop
+#endif
+
 /**
  *  @brief  View over a potentially-strided memory buffer, containing a row-major matrix.
  */
 template <typename scalar_at> //
-class vectors_view_gt {
+class matrix_slice_gt {
     using scalar_t = scalar_at;
+    using byte_addressable_t = typename std::conditional<std::is_const<scalar_t>::value, byte_t const, byte_t>::type;
 
-    scalar_t const* begin_{};
+    scalar_t* begin_{};
     std::size_t dimensions_{};
     std::size_t count_{};
     std::size_t stride_bytes_{};
 
   public:
-    vectors_view_gt() noexcept = default;
-    vectors_view_gt(vectors_view_gt const&) noexcept = default;
-    vectors_view_gt& operator=(vectors_view_gt const&) noexcept = default;
+    matrix_slice_gt() noexcept = default;
+    matrix_slice_gt(matrix_slice_gt const&) noexcept = default;
+    matrix_slice_gt& operator=(matrix_slice_gt const&) noexcept = default;
 
-    vectors_view_gt(scalar_t const* begin, std::size_t dimensions, std::size_t count = 1) noexcept
-        : vectors_view_gt(begin, dimensions, count, dimensions * sizeof(scalar_at)) {}
+    matrix_slice_gt(scalar_t* begin, std::size_t dimensions, std::size_t count = 1) noexcept
+        : matrix_slice_gt(begin, dimensions, count, dimensions * sizeof(scalar_at)) {}
 
-    vectors_view_gt(scalar_t const* begin, std::size_t dimensions, std::size_t count, std::size_t stride_bytes) noexcept
+    matrix_slice_gt(scalar_t* begin, std::size_t dimensions, std::size_t count, std::size_t stride_bytes) noexcept
         : begin_(begin), dimensions_(dimensions), count_(count), stride_bytes_(stride_bytes) {}
 
     explicit operator bool() const noexcept { return begin_; }
     std::size_t size() const noexcept { return count_; }
     std::size_t dimensions() const noexcept { return dimensions_; }
-    std::size_t stride() const noexcept { return stride_bytes_; }
-    scalar_t const* data() const noexcept { return begin_; }
-    scalar_t const* at(std::size_t i) const noexcept {
-        return reinterpret_cast<scalar_t const*>(reinterpret_cast<byte_t const*>(begin_) + i * stride_bytes_);
+    std::size_t stride_bytes() const noexcept { return stride_bytes_; }
+    scalar_t* data() const noexcept { return begin_; }
+    scalar_t* at(std::size_t i) const noexcept {
+        return reinterpret_cast<scalar_t*>(reinterpret_cast<byte_addressable_t*>(begin_) + i * stride_bytes_);
     }
 };
 
@@ -1687,7 +3241,7 @@ struct exact_offset_and_distance_t {
     f32_t distance;
 };
 
-using exact_search_results_t = vectors_view_gt<exact_offset_and_distance_t>;
+using exact_search_results_t = matrix_slice_gt<exact_offset_and_distance_t const>;
 
 /**
  *  @brief  Helper-structure for exact search operations.
@@ -1708,15 +3262,14 @@ class exact_search_t {
 
   public:
     template <typename scalar_at, typename executor_at = dummy_executor_t, typename progress_at = dummy_progress_t>
-    exact_search_results_t operator()(                                          //
-        vectors_view_gt<scalar_at> dataset, vectors_view_gt<scalar_at> queries, //
-        std::size_t wanted, metric_punned_t const& metric,                      //
+    exact_search_results_t operator()(                                                      //
+        matrix_slice_gt<scalar_at const> dataset, matrix_slice_gt<scalar_at const> queries, //
+        std::size_t wanted, metric_punned_t const& metric,                                  //
         executor_at&& executor = executor_at{}, progress_at&& progress = progress_at{}) {
-        return operator()(                                                                     //
-            metric,                                                                            //
-            reinterpret_cast<byte_t const*>(dataset.data()), dataset.size(), dataset.stride(), //
-            reinterpret_cast<byte_t const*>(queries.data()), queries.size(), queries.stride(), //
-            wanted, executor, progress);
+        return operator()(                                                                           //
+            reinterpret_cast<byte_t const*>(dataset.data()), dataset.size(), dataset.stride_bytes(), //
+            reinterpret_cast<byte_t const*>(queries.data()), queries.size(), queries.stride_bytes(), //
+            wanted, metric, executor, progress);
     }
 
     template <typename executor_at = dummy_executor_t, typename progress_at = dummy_progress_t>
@@ -1726,9 +3279,8 @@ class exact_search_t {
         std::size_t wanted, metric_punned_t const& metric, executor_at&& executor = executor_at{},
         progress_at&& progress = progress_at{}) {
 
-        // Allocate temporary memory to store the distance matrix
-        // Previous version didn't need temporary memory, but the performance was much lower.
-        // In the new design we keep two buffers - original and transposed, as in-place transpositions
+        // Allocate temporary memory to store the distance matrix.
+        // We keep two buffers - original and transposed, as in-place transpositions
         // of non-rectangular matrixes is expensive.
         std::size_t tasks_count = dataset_count * queries_count;
         if (keys_and_distances.size() < tasks_count * 2)
@@ -1774,9 +3326,6 @@ class exact_search_t {
         executor.fixed(queries_count, [&](std::size_t, std::size_t query_idx) {
             auto start = keys_and_distances_per_query + dataset_count * query_idx;
             if (wanted > 1) {
-                // TODO: Consider alternative sorting approaches
-                // radix_sort(start, start + dataset_count, wanted);
-                // std::sort(start, start + dataset_count, &smaller_distance);
                 std::partial_sort(start, start + wanted, start + dataset_count, &smaller_distance);
             } else {
                 auto min_it = std::min_element(start, start + dataset_count, &smaller_distance);
@@ -1791,6 +3340,344 @@ class exact_search_t {
                 dataset_count * sizeof(exact_offset_and_distance_t)};
     }
 };
+
+struct kmeans_clustering_result_t {
+    error_t error{};
+    std::size_t computed_distances{};
+    /// @brief The number of iterations the algorithm took to converge.
+    std::size_t iterations{};
+    /// @brief The number of points that changed clusters in the last iteration.
+    std::size_t last_iteration_points_shifted{};
+    /// @brief The inertia of the last iteration (sum of squared distances to centroids).
+    f64_t last_iteration_inertia{};
+    /// @brief The total elapsed runtime of the algorithm in seconds.
+    f64_t runtime_seconds{};
+    /// @brief The total distance between the points and their assigned centroids.
+    f64_t aggregate_distance{};
+
+    explicit operator bool() const noexcept { return !error; }
+    kmeans_clustering_result_t failed(error_t message) noexcept {
+        error = std::move(message);
+        return std::move(*this);
+    }
+};
+
+/**
+ *  @brief  Helper-class for K-Means clustering of dense vectors.
+ *          Doesn't require constructing the index, but benefits from mixed-precision logic.
+ *          ! Doesn't guarantee that the clusters are balanced in size.
+ *
+ *  The algorithm is as follows:
+ *  - Initialization: Select K initial centroids (randomly or with a heuristic).
+ *  - Assignment: Assign each data point to the nearest centroid based on the Euclidean distance.
+ *  - Update: Recalculate the centroids as the mean of all points assigned to each centroid.
+ *  - Repeat: Repeat the assignment and update steps until the centroids no longer change significantly
+ *            or an early-exit condition is met.
+ */
+template <typename allocator_at = std::allocator<char>> class kmeans_clustering_gt {
+  public:
+    using distance_t = distance_punned_t;
+
+    metric_kind_t metric_kind{metric_kind_t::l2sq_k};
+    scalar_kind_t quantization_kind{scalar_kind_t::bf16_k};
+
+    static constexpr std::size_t max_iterations_default_k = 300;
+    static constexpr f64_t inertia_threshold_default_k = 1e-4;
+    static constexpr f64_t max_seconds_default_k = 60.0;
+    static constexpr f64_t min_shifts_default_k = 0.01;
+
+    /// @brief Early-exit parameter - the maximum number of iterations to perform.
+    std::size_t max_iterations{max_iterations_default_k};
+    /// @brief Early-exit parameter - the threshold for the final inertia to terminate early.
+    f64_t inertia_threshold{inertia_threshold_default_k};
+    /// @brief Early-exit parameter - the maximum runtime allowed in seconds.
+    f64_t max_seconds{max_seconds_default_k};
+    /// @brief Early-exit parameter - the minimum share of points that must change clusters per iteration.
+    f64_t min_shifts{min_shifts_default_k};
+    /// @brief The random seed to use for centroid initialization.
+    std::uint64_t seed{0};
+
+    kmeans_clustering_gt(std::uint64_t seed) noexcept : seed(seed) {}
+    kmeans_clustering_gt() noexcept(false) {
+        std::random_device random_device;
+        seed = random_device();
+    }
+
+    kmeans_clustering_gt(kmeans_clustering_gt const&) = default;
+    kmeans_clustering_gt& operator=(kmeans_clustering_gt const&) = default;
+
+    template <typename scalar_at, typename executor_at = dummy_executor_t, typename progress_at = dummy_progress_t>
+    kmeans_clustering_result_t operator()( //
+        matrix_slice_gt<scalar_at const> points, matrix_slice_gt<scalar_at> centroids,
+        span_gt<std::size_t> point_to_centroid_index, span_gt<distance_t> point_to_centroid_distance, //
+        executor_at&& executor = executor_at{}, progress_at&& progress = progress_at{}) {
+        return operator()(                                                                        //
+            reinterpret_cast<byte_t const*>(points.data()), points.size(), points.stride_bytes(), //
+            reinterpret_cast<byte_t*>(centroids.data()), centroids.size(), centroids.stride_bytes(),
+            point_to_centroid_index.data(), point_to_centroid_distance.data(), //
+            scalar_kind<scalar_at>(), points.dimensions(), executor, progress);
+    }
+
+    template <typename executor_at = dummy_executor_t, typename progress_at = dummy_progress_t>
+    kmeans_clustering_result_t operator()(                                                       //
+        byte_t const* points_data, std::size_t points_count, std::size_t points_stride_bytes,    //
+        byte_t* centroids_data, std::size_t wanted_clusters, std::size_t centroids_stride_bytes, //
+        std::size_t* point_to_centroid_index, distance_t* point_to_centroid_distance,            //
+        scalar_kind_t original_scalar_kind, std::size_t dimensions, executor_at&& executor = executor_at{},
+        progress_at&& progress = progress_at{}) {
+
+        (void)progress; // TODO
+
+        // Perform sanity checks for algorithm settings.
+        kmeans_clustering_result_t result;
+        if (max_iterations < 1)
+            return result.failed("The number of iterations must be at least 1");
+
+        // Perform sanity checks for input arguments.
+        if (wanted_clusters < 2)
+            return result.failed("The number of clusters must be at least 2");
+        if (wanted_clusters >= points_count)
+            return result.failed("The number of clusters must be less than the number of vectors");
+
+        metric_punned_t metric = metric_punned_t::builtin(dimensions, metric_kind, quantization_kind);
+        if (!metric)
+            return result.failed("Unsupported metric or scalar kind");
+
+        // Let's allocate memory for the centroids coordinates and make sure it's
+        // rows are aligned to cache lines to avoid false sharing.
+        buffer_gt<distance_t, aligned_allocator_gt<distance_t, 64>> point_to_centroid_distance_buffer(points_count);
+        buffer_gt<std::size_t, aligned_allocator_gt<std::size_t, 64>> point_to_centroid_index_buffer(points_count);
+        buffer_gt<std::atomic<std::size_t>, aligned_allocator_gt<std::atomic<std::size_t>, 64>> cluster_sizes_buffer(
+            wanted_clusters);
+
+        // For a mixed precision computation, we keep the centroids represented in two forms -
+        // double precision and quantized the same way as in the index, to avoid paying conversion penalties.
+        // Double precision is needed to avoid accumulating errors when aggregating too many entries.
+        std::size_t const bytes_per_vector_original =
+            divide_round_up<CHAR_BIT>(dimensions * bits_per_scalar(original_scalar_kind));
+        std::size_t const bytes_per_vector_quantized = metric.bytes_per_vector();
+        std::size_t const stride_per_vector_quantized = divide_round_up<64>(bytes_per_vector_quantized) * 64;
+        buffer_gt<byte_t, aligned_allocator_gt<byte_t, 64>> points_quantized_buffer( //
+            points_count * stride_per_vector_quantized);
+        buffer_gt<byte_t, aligned_allocator_gt<byte_t, 64>> centroids_quantized_buffer( //
+            wanted_clusters * stride_per_vector_quantized);
+
+        // When aggregating centroids, we want to parallelize the operation and need more memory.
+        // For every thread we keep two double-precision vectors. One is the up-casting output buffer for quantized
+        // coordinates, and the other is the temporary buffer for the partial sums of the double-precision coordinates.
+        // The ordering:
+        //
+        //      - thread 0: [centroid 0, centroid 1, centroid 2, centroid 3, ...]
+        //      - thread 1: [centroid 0, centroid 1, centroid 2, centroid 3, ...]
+        //      - thread 2: [centroid 0, centroid 1, centroid 2, centroid 3, ...]
+        //
+        std::size_t const thread_count = executor.size();
+        buffer_gt<f64_t, aligned_allocator_gt<f64_t, 64>> centroids_precise_buffer( //
+            wanted_clusters * dimensions * thread_count);
+        buffer_gt<f64_t, aligned_allocator_gt<f64_t, 64>> points_precise_buffer( //
+            wanted_clusters * dimensions * thread_count);
+
+        // Check if all memory allocations were successful.
+        if (!centroids_precise_buffer || !points_precise_buffer || !centroids_quantized_buffer ||
+            !point_to_centroid_index_buffer || !cluster_sizes_buffer || !point_to_centroid_distance_buffer ||
+            !points_quantized_buffer)
+            return result.failed("No memory for result outputs!");
+
+        std::fill_n(point_to_centroid_index_buffer.data(), points_count, wanted_clusters);
+        std::fill_n(point_to_centroid_distance_buffer.data(), points_count, (std::numeric_limits<distance_t>::max)());
+
+        // Initialize the casting kernel for quantization and export.
+        casts_punned_t casts = casts_punned_t::make(quantization_kind);
+        cast_punned_t const& compress_points = casts.from[original_scalar_kind];
+        cast_punned_t const& decompress_points = casts.to[original_scalar_kind];
+        cast_punned_t const& compress_precise = casts.from.f64;
+        cast_punned_t const& decompress_precise = casts.to.f64;
+        for (std::size_t i = 0; i < points_count; i++) {
+            byte_t const* vector = points_data + i * points_stride_bytes;
+            byte_t* quantized = points_quantized_buffer.data() + i * stride_per_vector_quantized;
+            if (!compress_points(vector, dimensions, quantized))
+                std::memcpy(quantized, vector, bytes_per_vector_original);
+        }
+
+        // Initialize centroids with random points vectors.
+        std::mt19937_64 random_engine;
+        random_engine.seed(seed);
+        for (std::size_t i = 0; i < wanted_clusters; i++) {
+            // Generate the random index of the points vector,
+            // that is unique and not already used as a centroid.
+            std::size_t random_index;
+            do {
+                random_index = random_engine() % points_count;
+                bool is_unique = true;
+                for (std::size_t j = 0; j < i; j++) {
+                    if (point_to_centroid_index_buffer[j] == random_index) {
+                        is_unique = false;
+                        break;
+                    }
+                }
+                if (is_unique)
+                    break;
+            } while (true);
+
+            // Copy the vector to the centroid and quantize it.
+            byte_t const* quantized_point = points_quantized_buffer.data() + random_index * stride_per_vector_quantized;
+            byte_t* quantized_centroid = centroids_quantized_buffer.data() + i * stride_per_vector_quantized;
+            std::memcpy(quantized_centroid, quantized_point, bytes_per_vector_quantized);
+            point_to_centroid_index_buffer[random_index] = i;
+            point_to_centroid_distance_buffer[random_index] = 0;
+        }
+
+        auto start_time = std::chrono::high_resolution_clock::now();
+        std::size_t iterations = 0;
+        std::size_t const min_points_shifted_per_iteration = static_cast<std::size_t>(min_shifts * points_count);
+        f64_t last_aggregate_distance = (std::numeric_limits<f64_t>::max)();
+
+        while (iterations < max_iterations) {
+            iterations++;
+
+            // For every point, find the closest centroid.
+            std::atomic<std::size_t> points_shifted{0};
+            executor.dynamic(points_count, [&](std::size_t, std::size_t points_idx) {
+                byte_t const* quantized_point =
+                    points_quantized_buffer.data() + points_idx * stride_per_vector_quantized;
+                byte_t const* quantized_centroids = centroids_quantized_buffer.data();
+                distance_t closest_distance_local = (std::numeric_limits<distance_t>::max)();
+                std::size_t closest_idx_local = 0;
+                for (std::size_t centroid_idx = 0; centroid_idx < wanted_clusters; centroid_idx++) {
+                    byte_t const* quantized_centroid = quantized_centroids + centroid_idx * stride_per_vector_quantized;
+                    distance_t distance = metric(quantized_point, quantized_centroid);
+                    if (distance < closest_distance_local) {
+                        closest_distance_local = distance;
+                        closest_idx_local = centroid_idx;
+                    }
+                }
+
+                distance_t& closest_distance_ref = point_to_centroid_distance_buffer[points_idx];
+                std::size_t& closest_idx_ref = point_to_centroid_index_buffer[points_idx];
+                if (closest_idx_local != closest_idx_ref) {
+                    closest_idx_ref = closest_idx_local;
+                    points_shifted.fetch_add(1, std::memory_order_relaxed);
+                }
+
+                closest_distance_ref = closest_distance_local;
+                return true;
+            });
+
+            f64_t aggregate_distance = 0.0;
+            for (std::size_t i = 0; i < points_count; i++)
+                aggregate_distance += point_to_centroid_distance_buffer[i];
+            f64_t aggregate_distance_change =
+                std::abs(aggregate_distance - last_aggregate_distance) / last_aggregate_distance;
+
+            auto current_time = std::chrono::high_resolution_clock::now();
+            std::chrono::duration<f64_t> elapsed_time = current_time - start_time;
+            result.runtime_seconds = elapsed_time.count();
+            result.last_iteration_inertia = aggregate_distance_change;
+            result.last_iteration_points_shifted = points_shifted.load(std::memory_order_relaxed);
+
+            // Check for early-exit conditions
+            if (last_aggregate_distance != 0.0 && inertia_threshold != 0.0)
+                if (aggregate_distance_change <= inertia_threshold)
+                    break;
+            if (min_points_shifted_per_iteration != 0 || result.last_iteration_points_shifted == 0)
+                if (result.last_iteration_points_shifted <= min_points_shifted_per_iteration)
+                    break;
+            if (max_seconds != 0)
+                if (result.runtime_seconds >= max_seconds)
+                    break;
+
+            // For every centroid, recalculate the mean of all points assigned to it.
+            // That part is problematic to parallelize on many-core-systems, because of the contention.
+            // Alternatively, a tree-like approach can be used, where every core accumulates it's own partial sums.
+            // And those are later aggregated by a single thread.
+            std::memset(centroids_precise_buffer.data(), 0,
+                        wanted_clusters * dimensions * thread_count * sizeof(f64_t));
+            std::memset(reinterpret_cast<byte_t*>(cluster_sizes_buffer.data()), 0,
+                        wanted_clusters * sizeof(std::atomic<std::size_t>));
+            executor.dynamic(points_count, [&](std::size_t thread_idx, std::size_t points_idx) {
+                std::size_t centroid_idx = point_to_centroid_index_buffer[points_idx];
+                byte_t const* quantized_point =
+                    points_quantized_buffer.data() + points_idx * stride_per_vector_quantized;
+                f64_t* centroid_precise = centroids_precise_buffer.data() + wanted_clusters * dimensions * thread_idx +
+                                          centroid_idx * dimensions;
+
+                // Upcast the points point into a buffer of double-precision floats.
+                f64_t* point_precise = points_precise_buffer.data() + wanted_clusters * dimensions * thread_idx +
+                                       centroid_idx * dimensions;
+                if (!decompress_precise(quantized_point, dimensions, reinterpret_cast<byte_t*>(point_precise)))
+                    std::memcpy(reinterpret_cast<byte_t*>(point_precise), quantized_point, bytes_per_vector_quantized);
+
+                // Now add the vector from the points into the centroid partial sum.
+                for (std::size_t i = 0; i < dimensions; i++)
+                    centroid_precise[i] += point_precise[i];
+
+                cluster_sizes_buffer[centroid_idx].fetch_add(1, std::memory_order_relaxed);
+                return true;
+            });
+
+            // Aggregate the partial sums into the final centroids - storing them in the high-precision
+            // buffer of the first thread. Normalization procedure is different for different metrics.
+            for (std::size_t centroid_idx = 0; centroid_idx < wanted_clusters; centroid_idx++) {
+                f64_t* centroid_precise_aggregated = centroids_precise_buffer.data() + centroid_idx * dimensions;
+                for (std::size_t thread_idx = 1; thread_idx < thread_count; thread_idx++) {
+                    f64_t* centroid_precise = centroids_precise_buffer.data() +
+                                              wanted_clusters * dimensions * thread_idx + centroid_idx * dimensions;
+                    for (std::size_t i = 0; i < dimensions; i++)
+                        centroid_precise_aggregated[i] += centroid_precise[i];
+                }
+
+                // Normalize based on the metric kind
+                if (metric_kind == metric_kind_t::l2sq_k) {
+                    // Normalize for Euclidean distance (L2)
+                    std::size_t cluster_size = cluster_sizes_buffer[centroid_idx].load(std::memory_order_relaxed);
+                    if (cluster_size > 0)
+                        for (std::size_t i = 0; i < dimensions; i++)
+                            centroid_precise_aggregated[i] /= static_cast<f64_t>(cluster_size);
+
+                } else if (metric_kind == metric_kind_t::cos_k) {
+                    // Normalize for Cosine distance
+                    f64_t norm = 0.0;
+                    for (std::size_t i = 0; i < dimensions; i++)
+                        norm += centroid_precise_aggregated[i] * centroid_precise_aggregated[i];
+                    norm = std::sqrt(norm);
+                    if (norm > 0.0)
+                        for (std::size_t i = 0; i < dimensions; i++)
+                            centroid_precise_aggregated[i] /= norm;
+                }
+
+                // Quantize the centroid after normalization for further iterations
+                byte_t* centroid_quantized =
+                    centroids_quantized_buffer.data() + centroid_idx * stride_per_vector_quantized;
+                if (!compress_precise(reinterpret_cast<byte_t*>(centroid_precise_aggregated), dimensions,
+                                      centroid_quantized))
+                    std::memcpy(centroid_quantized, reinterpret_cast<byte_t*>(centroid_precise_aggregated),
+                                bytes_per_vector_quantized);
+            }
+        }
+
+        // Export stats.
+        result.iterations = iterations;
+        result.computed_distances = points_count * wanted_clusters * iterations;
+        result.aggregate_distance = 0;
+        for (distance_t distance : point_to_centroid_distance_buffer)
+            result.aggregate_distance += distance;
+
+        // We've finished all the iterations, now we can export the centroids back to the original precision.
+        std::memcpy(point_to_centroid_index, point_to_centroid_index_buffer.data(), points_count * sizeof(std::size_t));
+        std::memcpy(point_to_centroid_distance, point_to_centroid_distance_buffer.data(),
+                    points_count * sizeof(distance_t));
+        for (std::size_t i = 0; i < wanted_clusters; i++) {
+            byte_t const* quantized_centroid = centroids_quantized_buffer.data() + i * stride_per_vector_quantized;
+            byte_t* centroid = centroids_data + i * centroids_stride_bytes;
+            if (!decompress_points(quantized_centroid, dimensions, centroid))
+                std::memcpy(centroid, quantized_centroid, bytes_per_vector_quantized);
+        }
+
+        return result;
+    }
+};
+
+using kmeans_clustering_t = kmeans_clustering_gt<>;
 
 /**
  *  @brief  C++11 Multi-Hash-Set with Linear Probing.
@@ -1879,7 +3766,7 @@ class flat_hash_multi_set_gt {
         // Allocate new memory
         data_ = (char*)allocator_t{}.allocate(other.buckets_ * bytes_per_bucket());
         if (!data_)
-            throw std::bad_alloc();
+            usearch_raise_runtime_error("failed memory allocation");
 
         // Copy metadata
         buckets_ = other.buckets_;
@@ -1919,7 +3806,7 @@ class flat_hash_multi_set_gt {
         // Allocate new memory
         data_ = (char*)allocator_t{}.allocate(other.buckets_ * bytes_per_bucket());
         if (!data_)
-            throw std::bad_alloc();
+            usearch_raise_runtime_error("failed memory allocation");
 
         // Copy metadata
         buckets_ = other.buckets_;
@@ -1959,6 +3846,7 @@ class flat_hash_multi_set_gt {
         clear(); // Clear all elements
         if (data_)
             allocator_t{}.deallocate(data_, buckets_ * bytes_per_bucket());
+        data_ = nullptr;
         buckets_ = 0;
         populated_slots_ = 0;
         capacity_slots_ = 0;
@@ -2027,12 +3915,17 @@ class flat_hash_multi_set_gt {
                           equals_t const& equals)
             : index_(index), parent_(parent), query_(query), equals_(equals) {}
 
-        // Pre-increment
+        // Pre-increment: advance past tombstones and non-matching entries,
+        // stopping at the next matching live entry or an empty slot.
         equal_iterator_gt& operator++() {
             do {
                 index_ = (index_ + 1) & (parent_->capacity_slots_ - 1);
-            } while (!equals_(parent_->slot_ref(index_).element, query_) &&
-                     (parent_->slot_ref(index_).header.populated & parent_->slot_ref(index_).mask));
+                auto slot = parent_->slot_ref(index_);
+                bool is_empty = ~slot.header.populated & slot.mask;
+                bool is_match = !(slot.header.deleted & slot.mask) && equals_(slot.element, query_);
+                if (is_empty || is_match)
+                    break;
+            } while (true);
             return *this;
         }
 
@@ -2291,7 +4184,7 @@ class flat_hash_multi_set_gt {
 
     void reserve(std::size_t capacity) {
         if (!try_reserve(capacity))
-            throw std::bad_alloc();
+            usearch_raise_runtime_error("failed to reserve memory");
     }
 
     bool try_emplace(element_t const& element) noexcept {

--- a/test/sql/hnsw/hnsw_filtered.test
+++ b/test/sql/hnsw/hnsw_filtered.test
@@ -77,17 +77,16 @@ physical_plan	<!REGEX>:.*SEMI.*
 
 # ───────────────────────────────────────────────────────────────────────────────
 # 3. Equality filter — all returned rows must have label='A'.
-#    Approximate filtered search may return fewer than LIMIT.
 # ───────────────────────────────────────────────────────────────────────────────
 
-# At least 1 result returned
+# Exactly LIMIT results returned (early-termination bug fixed in usearch 2.17.8)
 query I
-SELECT count(*) >= 1 FROM (
+SELECT count(*) FROM (
     SELECT id FROM flt WHERE label = 'A'
     ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5
 );
 ----
-true
+5
 
 # Verify all returned rows actually satisfy the filter
 query I
@@ -103,12 +102,12 @@ SELECT count(*) FROM (
 # ───────────────────────────────────────────────────────────────────────────────
 
 query I
-SELECT count(*) >= 1 FROM (
+SELECT count(*) FROM (
     SELECT id FROM flt WHERE id >= 50
     ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5
 );
 ----
-true
+5
 
 query I
 SELECT count(*) FROM (
@@ -123,25 +122,25 @@ SELECT count(*) FROM (
 # ───────────────────────────────────────────────────────────────────────────────
 
 query I
-SELECT count(*) >= 1 FROM (
+SELECT count(*) FROM (
     SELECT id FROM flt WHERE label IS NOT NULL
     ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5
 );
 ----
-true
+5
 
 # ───────────────────────────────────────────────────────────────────────────────
 # 6. Highly selective filter: only 3 rows match, LIMIT=10.
-#    Must return at most 3, and all must satisfy the predicate.
+#    Must return exactly 3 (all matching rows, no more).
 # ───────────────────────────────────────────────────────────────────────────────
 
 query I
-SELECT count(*) <= 3 FROM (
+SELECT count(*) FROM (
     SELECT id FROM flt WHERE id IN (10, 50, 90)
     ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 10
 );
 ----
-true
+3
 
 # All returned rows must be in the allowed set
 query I

--- a/test/sql/hnsw/hnsw_filtered.test
+++ b/test/sql/hnsw/hnsw_filtered.test
@@ -1,0 +1,193 @@
+# name: test/sql/hnsw/hnsw_filtered.test
+# description: Filtered HNSW - WHERE clause filters pushed into index scan via bitmap pre-filter
+# group: [hnsw]
+
+require vss
+
+# ───────────────────────────────────────────────────────────────────────────────
+# Setup: 100 rows with a deterministic label column and 1D-like vectors so that
+# distance ordering is predictable.  Rows with even id get label='A', odd id get
+# label='B'.  Vectors are along the x-axis so array_distance([0.5,0,0]) always
+# gives |i*0.01 - 0.5|, and the k-nearest are those with i closest to 50.
+# ───────────────────────────────────────────────────────────────────────────────
+
+statement ok
+CREATE TABLE flt (
+    id    INTEGER,
+    label VARCHAR,
+    vec   FLOAT[3]
+);
+
+statement ok
+INSERT INTO flt
+SELECT
+    i,
+    CASE WHEN i % 2 = 0 THEN 'A' ELSE 'B' END,
+    array_value((i * 0.01)::FLOAT, 0.0::FLOAT, 0.0::FLOAT)
+FROM range(100) t(i);
+
+statement ok
+CREATE INDEX flt_idx ON flt USING HNSW (vec);
+
+# Use high ef_search so results are near-exact on this tiny table
+statement ok
+SET hnsw_ef_search = 200;
+
+# ───────────────────────────────────────────────────────────────────────────────
+# 1. No filter — baseline regression: index scan still works.
+#    Plan: HNSW_INDEX_SCAN with no FILTER node and no Filters detail.
+# ───────────────────────────────────────────────────────────────────────────────
+
+query II
+EXPLAIN SELECT id FROM flt ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5;
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_SCAN.*
+
+query I
+SELECT count(*) FROM (
+    SELECT id FROM flt ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5
+);
+----
+5
+
+# ───────────────────────────────────────────────────────────────────────────────
+# 2. Plan shape: WITH filter pushdown enabled the HNSW_INDEX_SCAN shows pushed
+#    Filters (label='A') and there is no separate FILTER node above the scan.
+# ───────────────────────────────────────────────────────────────────────────────
+
+statement ok
+SET hnsw_enable_filter_pushdown = true;
+
+# Positive: scan has filters pushed in
+query II
+EXPLAIN SELECT id FROM flt WHERE label = 'A' ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5;
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_SCAN.*Filters:.*label.*
+
+# Negative: no standalone FILTER node, no SEMI join, no SEQ_SCAN
+query II
+EXPLAIN SELECT id FROM flt WHERE label = 'A' ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5;
+----
+physical_plan	<!REGEX>:.*SEQ_SCAN.*
+
+query II
+EXPLAIN SELECT id FROM flt WHERE label = 'A' ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5;
+----
+physical_plan	<!REGEX>:.*SEMI.*
+
+# ───────────────────────────────────────────────────────────────────────────────
+# 3. Equality filter — all returned rows must have label='A'.
+#    Approximate filtered search may return fewer than LIMIT.
+# ───────────────────────────────────────────────────────────────────────────────
+
+# At least 1 result returned
+query I
+SELECT count(*) >= 1 FROM (
+    SELECT id FROM flt WHERE label = 'A'
+    ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5
+);
+----
+true
+
+# Verify all returned rows actually satisfy the filter
+query I
+SELECT count(*) FROM (
+    SELECT id, label FROM flt WHERE label = 'A'
+    ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5
+) WHERE label != 'A';
+----
+0
+
+# ───────────────────────────────────────────────────────────────────────────────
+# 4. Range filter — all returned rows must have id >= 50.
+# ───────────────────────────────────────────────────────────────────────────────
+
+query I
+SELECT count(*) >= 1 FROM (
+    SELECT id FROM flt WHERE id >= 50
+    ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5
+);
+----
+true
+
+query I
+SELECT count(*) FROM (
+    SELECT id FROM flt WHERE id >= 50
+    ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5
+) WHERE id < 50;
+----
+0
+
+# ───────────────────────────────────────────────────────────────────────────────
+# 5. IS NOT NULL filter — all 100 rows qualify so this behaves like no filter.
+# ───────────────────────────────────────────────────────────────────────────────
+
+query I
+SELECT count(*) >= 1 FROM (
+    SELECT id FROM flt WHERE label IS NOT NULL
+    ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5
+);
+----
+true
+
+# ───────────────────────────────────────────────────────────────────────────────
+# 6. Highly selective filter: only 3 rows match, LIMIT=10.
+#    Must return at most 3, and all must satisfy the predicate.
+# ───────────────────────────────────────────────────────────────────────────────
+
+query I
+SELECT count(*) <= 3 FROM (
+    SELECT id FROM flt WHERE id IN (10, 50, 90)
+    ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 10
+);
+----
+true
+
+# All returned rows must be in the allowed set
+query I
+SELECT count(*) FROM (
+    SELECT id FROM flt WHERE id IN (10, 50, 90)
+    ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 10
+) WHERE id NOT IN (10, 50, 90);
+----
+0
+
+# ───────────────────────────────────────────────────────────────────────────────
+# 7. Escape hatch: SET hnsw_enable_filter_pushdown = false reverts to the old
+#    post-filter behavior.  Plan has a FILTER node and no pushed Filters detail.
+# ───────────────────────────────────────────────────────────────────────────────
+
+statement ok
+SET hnsw_enable_filter_pushdown = false;
+
+# FILTER node present in plan
+query II
+EXPLAIN SELECT id FROM flt WHERE label = 'A'
+ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5;
+----
+physical_plan	<REGEX>:.*FILTER.*
+
+# HNSW scan is still used (under the FILTER)
+query II
+EXPLAIN SELECT id FROM flt WHERE label = 'A'
+ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]) LIMIT 5;
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_SCAN.*
+
+# Re-enable for subsequent tests
+statement ok
+SET hnsw_enable_filter_pushdown = true;
+
+# ───────────────────────────────────────────────────────────────────────────────
+# 8. Correctness: sequential scan result ordering must match expectations.
+#    This validates that the distance metric produces the expected ordering
+#    independent of the HNSW index.
+# ───────────────────────────────────────────────────────────────────────────────
+
+query I
+SELECT id FROM flt WHERE id IN (10, 50, 90)
+ORDER BY array_distance(vec, [0.5, 0.0, 0.0]::FLOAT[3]);
+----
+50
+90
+10


### PR DESCRIPTION
### Problem

DuckDB's `HNSW_INDEX_SCAN` does not support filter predicates. DuckDB VSS extension only has post-filtering. Standard example below: <10 results returned even when >10 exist (i.e. satisfy filter).
```sql
SELECT id
FROM items
WHERE category = 'electronics'
ORDER BY array_distance(vec, [0.5, 0.5, 0.5]::FLOAT[3])
LIMIT 10;
```


### Approach

Build a **bitmap pre-filter** before the HNSW search:

1. One O(n) scan over the filter column(s) (with zone-map pruning) marks passing `row_id`s in a `FilterBitmap`.
2. The bitmap is passed as a predicate to USearch's `filtered_ef_search`, which skips non-matching nodes during graph traversal so they don't consume the `LIMIT` budget.
3. The optimizer removes the `TopN` and `FILTER` nodes — the HNSW scan enforces both internally.

With approximate filtered search, the HNSW graph traversal may still return fewer than `LIMIT` results when the predicate is selective, because USearch's radius-based early termination can cut short exploration (see Limitations). Increasing `hnsw_ef_search` widens the traversal beam and improves recall.

```sql
SET hnsw_enable_filter_pushdown = true;   -- default
SET hnsw_enable_filter_pushdown = false;  -- escape hatch: revert to post-filter
SET hnsw_ef_search = 400;                 -- widen beam for selective filters
```

### Limitations

- **Approximate filtered search can underfill.** USearch's HNSW traversal terminates when the closest unexplored candidate is farther than the worst result in the top-k buffer. With a predicate, only passing nodes enter the top-k buffer, so the radius collapses quickly and the search exits before finding `LIMIT` results. This is a USearch algorithm limitation, addressed by 2.17.0 (duckdb-vss is using 2.12.0). Currently reviewing a Usearch upgrade in a [fork PR](https://github.com/Jeadie/duckdb-vss/pull/1)

- **O(n) bitmap build** per query. Acceptable for selective filters on indexed tables; may be expensive for very large tables with non-selective filters (disable with `SET hnsw_enable_filter_pushdown = false`).
- **Static `table_filters` only.** Computed predicates (`lower(col) = 'x'`) that DuckDB keeps as `LogicalFilter` nodes are not pushed down.
