### PR TITLE
Prefiltering for constant `IN` lists rewritten to `MARK` join

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,6 +60,34 @@ The following table shows the supported distance metrics and their corresponding
 | Cosine similarity | `cosine` | `array_cosine_distance`        |
 | Inner product | `ip` | `array_negative_inner_product` |
 
+## Pre-filtered searches
+
+Static `WHERE` filters that DuckDB can push into the table scan are applied
+before the HNSW search. This allows the index scan to return up to the requested
+number of qualifying nearest neighbors instead of finding the unfiltered top-k
+and discarding rows afterward.
+
+```sql
+SELECT id
+FROM items
+WHERE category = 'electronics'
+ORDER BY array_distance(vec, [0.5, 0.5, 0.5]::FLOAT[3])
+LIMIT 10;
+```
+
+The current implementation builds a transaction-visible filter bitmap with an
+O(n) scan over the filter columns for each query. Pre-filtering is enabled by
+default and can be disabled to restore the previous post-filter behavior:
+
+```sql
+SET hnsw_enable_filter_pushdown = false;
+```
+
+Filtered search remains approximate. Increasing `hnsw_ef_search` can improve
+recall for selective filters. Predicates DuckDB keeps as separate operators,
+such as some computed expressions, are not currently pushed into the HNSW
+search.
+
 ## Inserts, Updates,  Deletes and Re-Compaction
 
 The HNSW index does support inserting, updating and deleting rows from the table after index creation. However, there are two things to keep in mind:  

--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -314,7 +314,8 @@ struct HNSWIndexScanState : public IndexScanState {
 	unique_array<row_t> row_ids = nullptr;
 };
 
-unique_ptr<IndexScanState> HNSWIndex::InitializeScan(float *query_vector, idx_t limit, ClientContext &context) const {
+unique_ptr<IndexScanState> HNSWIndex::InitializeScan(float *query_vector, idx_t limit, ClientContext &context,
+                                                     optional_ptr<const HNSWFilterBitmap> filter) const {
 	auto state = make_uniq<HNSWIndexScanState>();
 
 	// Try to get the ef_search parameter from the database or use the default value
@@ -332,13 +333,36 @@ unique_ptr<IndexScanState> HNSWIndex::InitializeScan(float *query_vector, idx_t 
 
 	// Acquire a shared lock to search the index
 	auto lock = rwlock.GetSharedLock();
-	auto search_result = index.ef_search(query_vector, limit, ef_search);
+	auto search_result = [&]() {
+		if (!filter) {
+			return index.ef_search(query_vector, limit, ef_search);
+		}
+		auto predicate = [&](row_t key) {
+			return filter->Contains(key);
+		};
+		return index.filtered_ef_search(query_vector, limit, ef_search, predicate);
+	}();
 
 	state->current_row = 0;
-	state->total_rows = search_result.size();
 	state->row_ids = make_uniq_array<row_t>(search_result.size());
-
 	search_result.dump_to(state->row_ids.get());
+
+	// The filtered search is expected to return only keys accepted by the
+	// predicate. Check the bitmap again before exposing row IDs to DuckDB so a
+	// regression in the search library can underfill, but can never leak a row
+	// that does not satisfy the pushed-down filters.
+	if (filter) {
+		idx_t eligible_count = 0;
+		for (idx_t result_idx = 0; result_idx < search_result.size(); result_idx++) {
+			auto row_id = state->row_ids[result_idx];
+			if (filter->Contains(row_id)) {
+				state->row_ids[eligible_count++] = row_id;
+			}
+		}
+		state->total_rows = eligible_count;
+	} else {
+		state->total_rows = search_result.size();
+	}
 	return std::move(state);
 }
 
@@ -724,6 +748,9 @@ void HNSWModule::RegisterIndex(DatabaseInstance &db) {
 	db.config.AddExtensionOption("hnsw_ef_search",
 	                             "experimental: override the ef_search parameter when scanning HNSW indexes",
 	                             LogicalType::BIGINT);
+	db.config.AddExtensionOption("hnsw_enable_filter_pushdown",
+	                             "experimental: apply static table filters before searching HNSW indexes",
+	                             LogicalType::BOOLEAN, Value::BOOLEAN(true));
 
 	// Register the index type
 	db.config.GetIndexTypes().RegisterIndexType(index_type);

--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -748,7 +748,7 @@ void HNSWModule::RegisterIndex(DatabaseInstance &db) {
 	db.config.AddExtensionOption("hnsw_ef_search",
 	                             "experimental: override the ef_search parameter when scanning HNSW indexes",
 	                             LogicalType::BIGINT);
-	db.config.AddExtensionOption("hnsw_enable_filter_pushdown",
+	db.config.AddExtensionOption("hnsw_prefilter",
 	                             "experimental: apply static table filters before searching HNSW indexes",
 	                             LogicalType::BOOLEAN, Value::BOOLEAN(false));
 

--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -750,7 +750,7 @@ void HNSWModule::RegisterIndex(DatabaseInstance &db) {
 	                             LogicalType::BIGINT);
 	db.config.AddExtensionOption("hnsw_enable_filter_pushdown",
 	                             "experimental: apply static table filters before searching HNSW indexes",
-	                             LogicalType::BOOLEAN, Value::BOOLEAN(true));
+	                             LogicalType::BOOLEAN, Value::BOOLEAN(false));
 
 	// Register the index type
 	db.config.GetIndexTypes().RegisterIndexType(index_type);

--- a/src/hnsw/hnsw_index.cpp
+++ b/src/hnsw/hnsw_index.cpp
@@ -750,7 +750,7 @@ void HNSWModule::RegisterIndex(DatabaseInstance &db) {
 	                             LogicalType::BIGINT);
 	db.config.AddExtensionOption("hnsw_prefilter",
 	                             "experimental: apply static table filters before searching HNSW indexes",
-	                             LogicalType::BOOLEAN, Value::BOOLEAN(false));
+	                             LogicalType::BOOLEAN, Value::BOOLEAN(true));
 
 	// Register the index type
 	db.config.GetIndexTypes().RegisterIndexType(index_type);

--- a/src/hnsw/hnsw_index_scan.cpp
+++ b/src/hnsw/hnsw_index_scan.cpp
@@ -117,7 +117,7 @@ static unique_ptr<GlobalTableFunctionState> HNSWIndexScanInitGlobal(ClientContex
 	// rows instead of filtering an unqualified top-k afterward.
 	HNSWFilterBitmap filter;
 	optional_ptr<const HNSWFilterBitmap> filter_ptr;
-	if (bind_data.filter_pushdown && input.filters &&
+	if (bind_data.prefilter && input.filters &&
 	    (input.filters->HasFilters() || input.filters->HasMultiColumnFilters())) {
 		BuildFilterBitmap(context, input, bind_data, filter);
 		filter_ptr = &filter;
@@ -229,12 +229,12 @@ static InsertionOrderPreservingMap<string> HNSWIndexScanToString(TableFunctionTo
 //-------------------------------------------------------------------------
 // Get Function
 //-------------------------------------------------------------------------
-bool HNSWIndexScanFunction::FilterPushdownEnabled(ClientContext &context) {
-	Value enable_filter_pushdown;
-	if (!context.TryGetCurrentSetting("hnsw_enable_filter_pushdown", enable_filter_pushdown)) {
+bool HNSWIndexScanFunction::PrefilterEnabled(ClientContext &context) {
+	Value prefilter;
+	if (!context.TryGetCurrentSetting("hnsw_prefilter", prefilter)) {
 		return false;
 	}
-	return enable_filter_pushdown.GetValue<bool>();
+	return prefilter.GetValue<bool>();
 }
 
 TableFunction HNSWIndexScanFunction::GetFunction() {

--- a/src/hnsw/hnsw_index_scan.cpp
+++ b/src/hnsw/hnsw_index_scan.cpp
@@ -232,7 +232,7 @@ static InsertionOrderPreservingMap<string> HNSWIndexScanToString(TableFunctionTo
 bool HNSWIndexScanFunction::PrefilterEnabled(ClientContext &context) {
 	Value prefilter;
 	if (!context.TryGetCurrentSetting("hnsw_prefilter", prefilter)) {
-		return false;
+		return true;
 	}
 	return prefilter.GetValue<bool>();
 }

--- a/src/hnsw/hnsw_index_scan.cpp
+++ b/src/hnsw/hnsw_index_scan.cpp
@@ -5,6 +5,7 @@
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/table_filter_set.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/index.hpp"
 #include "duckdb/storage/table/scan_state.hpp"
@@ -40,6 +41,54 @@ struct HNSWIndexScanGlobalState : public GlobalTableFunctionState {
 	vector<idx_t> projection_ids;
 };
 
+static void BuildFilterBitmap(ClientContext &context, TableFunctionInitInput &input,
+                              const HNSWIndexScanBindData &bind_data, HNSWFilterBitmap &filter) {
+	auto &transaction = DuckTransaction::Get(context, bind_data.table.catalog);
+	auto &storage = bind_data.table.GetStorage();
+	auto &duck_table = bind_data.table.Cast<DuckTableEntry>();
+	const auto &columns = duck_table.GetColumns();
+
+	vector<StorageIndex> scan_column_ids;
+	vector<LogicalType> scan_types;
+	scan_column_ids.reserve(input.column_indexes.size() + 1);
+	scan_types.reserve(input.column_indexes.size() + 1);
+	for (const auto &column_index : input.column_indexes) {
+		scan_column_ids.push_back(bind_data.table.GetStorageIndex(column_index));
+		if (column_index.IsRowIdColumn()) {
+			scan_types.emplace_back(LogicalType::ROW_TYPE);
+		} else if (column_index.HasType()) {
+			scan_types.push_back(column_index.GetScanType());
+		} else {
+			scan_types.push_back(columns.GetColumn(column_index.ToLogical()).Type());
+		}
+	}
+
+	// Appending the row ID preserves the table-filter indexes, which refer to the
+	// columns selected by the physical scan.
+	scan_column_ids.emplace_back(COLUMN_IDENTIFIER_ROW_ID);
+	scan_types.emplace_back(LogicalType::ROW_TYPE);
+
+	TableScanState scan_state;
+	storage.InitializeScan(context, transaction, scan_state, scan_column_ids, input.filters);
+
+	DataChunk scan_chunk;
+	scan_chunk.Initialize(context, scan_types);
+	while (true) {
+		scan_chunk.Reset();
+		storage.Scan(transaction, scan_chunk, scan_state);
+		if (scan_chunk.size() == 0) {
+			break;
+		}
+
+		UnifiedVectorFormat row_ids;
+		scan_chunk.data.back().ToUnifiedFormat(row_ids);
+		auto row_id_data = UnifiedVectorFormat::GetData<row_t>(row_ids);
+		for (idx_t row_idx = 0; row_idx < scan_chunk.size(); row_idx++) {
+			filter.Set(row_id_data[row_ids.sel->get_index(row_idx)]);
+		}
+	}
+}
+
 static unique_ptr<GlobalTableFunctionState> HNSWIndexScanInitGlobal(ClientContext &context,
                                                                     TableFunctionInitInput &input) {
 	auto &bind_data = input.bind_data->Cast<HNSWIndexScanBindData>();
@@ -63,10 +112,21 @@ static unique_ptr<GlobalTableFunctionState> HNSWIndexScanInitGlobal(ClientContex
 	result->local_storage_state.Initialize(result->column_ids, context, input.filters);
 	local_storage.InitializeScan(bind_data.table.GetStorage(), result->local_storage_state.local_state, input.filters);
 
+	// Evaluate pushed-down filters first, then use the qualifying row IDs as the
+	// predicate for the HNSW graph search. This returns up to `limit` matching
+	// rows instead of filtering an unqualified top-k afterward.
+	HNSWFilterBitmap filter;
+	optional_ptr<const HNSWFilterBitmap> filter_ptr;
+	if (bind_data.filter_pushdown && input.filters &&
+	    (input.filters->HasFilters() || input.filters->HasMultiColumnFilters())) {
+		BuildFilterBitmap(context, input, bind_data, filter);
+		filter_ptr = &filter;
+	}
+
 	// Initialize the scan state for the index
 	{
 		auto index = bind_data.index_entry->GetReadHandle<HNSWIndex>();
-		result->index_state = index->InitializeScan(bind_data.query.get(), bind_data.limit, context);
+		result->index_state = index->InitializeScan(bind_data.query.get(), bind_data.limit, context, filter_ptr);
 	}
 
 	if (!input.CanRemoveFilterColumns()) {
@@ -169,6 +229,14 @@ static InsertionOrderPreservingMap<string> HNSWIndexScanToString(TableFunctionTo
 //-------------------------------------------------------------------------
 // Get Function
 //-------------------------------------------------------------------------
+bool HNSWIndexScanFunction::FilterPushdownEnabled(ClientContext &context) {
+	Value enable_filter_pushdown;
+	if (!context.TryGetCurrentSetting("hnsw_enable_filter_pushdown", enable_filter_pushdown)) {
+		return true;
+	}
+	return enable_filter_pushdown.GetValue<bool>();
+}
+
 TableFunction HNSWIndexScanFunction::GetFunction() {
 	TableFunction func("hnsw_index_scan", {}, HNSWIndexScanExecute);
 	func.init_local = nullptr;
@@ -180,7 +248,7 @@ TableFunction HNSWIndexScanFunction::GetFunction() {
 	func.to_string = HNSWIndexScanToString;
 	func.table_scan_progress = nullptr;
 	func.projection_pushdown = true;
-	func.filter_pushdown = false;
+	func.filter_pushdown = true;
 	func.get_bind_info = HNSWIndexScanBindInfo;
 
 	return func;

--- a/src/hnsw/hnsw_index_scan.cpp
+++ b/src/hnsw/hnsw_index_scan.cpp
@@ -232,7 +232,7 @@ static InsertionOrderPreservingMap<string> HNSWIndexScanToString(TableFunctionTo
 bool HNSWIndexScanFunction::FilterPushdownEnabled(ClientContext &context) {
 	Value enable_filter_pushdown;
 	if (!context.TryGetCurrentSetting("hnsw_enable_filter_pushdown", enable_filter_pushdown)) {
-		return true;
+		return false;
 	}
 	return enable_filter_pushdown.GetValue<bool>();
 }

--- a/src/hnsw/hnsw_optimize_scan.cpp
+++ b/src/hnsw/hnsw_optimize_scan.cpp
@@ -4,9 +4,9 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"
+#include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/planner/operator/logical_projection.hpp"
 #include "duckdb/planner/operator/logical_top_n.hpp"
-#include "duckdb/planner/operator/logical_filter.hpp"
 #include "duckdb/storage/data_table.hpp"
 #include "duckdb/storage/index.hpp"
 #include "duckdb/storage/statistics/node_statistics.hpp"
@@ -100,6 +100,7 @@ public:
 		// Find the index
 		unique_ptr<HNSWIndexScanBindData> bind_data = nullptr;
 		vector<reference<Expression>> bindings;
+		const auto filter_pushdown = HNSWIndexScanFunction::FilterPushdownEnabled(context);
 
 		table_info.BindIndexes(context, HNSWIndex::TYPE_NAME);
 		for (auto index_entry : table_info.GetIndexes().IndexEntries()) {
@@ -146,7 +147,7 @@ public:
 			}
 
 			bind_data = make_uniq<HNSWIndexScanBindData>(duck_table, index_entry, guard->GetIndexName(), top_n.limit,
-			                                             std::move(query_vector));
+			                                             std::move(query_vector), filter_pushdown);
 			break;
 		}
 
@@ -155,37 +156,29 @@ public:
 			return false;
 		}
 
-		// If there are no table filters pushed down into the get, we can just replace the get with the index scan
 		const auto cardinality = get.function.cardinality(context, bind_data.get());
 		get.function = HNSWIndexScanFunction::GetFunction();
 		get.has_estimated_cardinality = cardinality->has_estimated_cardinality;
 		get.estimated_cardinality = cardinality->estimated_cardinality;
 		get.bind_data = std::move(bind_data);
-		if (!get.table_filters.HasFilters()) {
+		if (!filter_pushdown && get.table_filters.HasFilters()) {
+			// Restore the post-filter plan when pre-filtering is explicitly disabled.
+			get.projection_ids.clear();
+			get.types.clear();
 
-			// Remove the TopN operator
-			plan = std::move(top_n.children[0]);
-			return true;
+			auto new_filter = make_uniq<LogicalFilter>();
+			for (const auto &entry : get.table_filters) {
+				auto filter_idx = entry.GetIndex();
+				auto &column_id = get.GetColumnIndex(filter_idx);
+				auto &type = get.returned_types[column_id.GetPrimaryIndex()];
+				auto &filter = entry.Filter();
+				auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, filter_idx));
+				new_filter->expressions.push_back(filter.ToExpression(*column));
+			}
+			new_filter->children.push_back(std::move(get_ptr));
+			new_filter->ResolveOperatorTypes();
+			get_ptr = std::move(new_filter);
 		}
-
-		// Otherwise, things get more complicated. We need to pullup the filters from the table scan as our index scan
-		// does not support regular filter pushdown.
-		get.projection_ids.clear();
-		get.types.clear();
-
-		auto new_filter = make_uniq<LogicalFilter>();
-		auto &column_ids = get.GetColumnIds();
-		for (const auto &entry : get.table_filters) {
-			auto filter_idx = entry.GetIndex();
-			auto &column_id = get.GetColumnIndex(filter_idx);
-			auto &type = get.returned_types[column_id.GetPrimaryIndex()];
-			auto &filter = entry.Filter();
-			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, filter_idx));
-			new_filter->expressions.push_back(filter.ToExpression(*column));
-		}
-		new_filter->children.push_back(std::move(get_ptr));
-		new_filter->ResolveOperatorTypes();
-		get_ptr = std::move(new_filter);
 
 		// Remove the TopN operator
 		plan = std::move(top_n.children[0]);

--- a/src/hnsw/hnsw_optimize_scan.cpp
+++ b/src/hnsw/hnsw_optimize_scan.cpp
@@ -100,7 +100,7 @@ public:
 		// Find the index
 		unique_ptr<HNSWIndexScanBindData> bind_data = nullptr;
 		vector<reference<Expression>> bindings;
-		const auto filter_pushdown = HNSWIndexScanFunction::FilterPushdownEnabled(context);
+		const auto prefilter = HNSWIndexScanFunction::PrefilterEnabled(context);
 
 		table_info.BindIndexes(context, HNSWIndex::TYPE_NAME);
 		for (auto index_entry : table_info.GetIndexes().IndexEntries()) {
@@ -147,7 +147,7 @@ public:
 			}
 
 			bind_data = make_uniq<HNSWIndexScanBindData>(duck_table, index_entry, guard->GetIndexName(), top_n.limit,
-			                                             std::move(query_vector), filter_pushdown);
+			                                             std::move(query_vector), prefilter);
 			break;
 		}
 
@@ -161,7 +161,7 @@ public:
 		get.has_estimated_cardinality = cardinality->has_estimated_cardinality;
 		get.estimated_cardinality = cardinality->estimated_cardinality;
 		get.bind_data = std::move(bind_data);
-		if (!filter_pushdown && get.table_filters.HasFilters()) {
+		if (!prefilter && get.table_filters.HasFilters()) {
 			// Restore the post-filter plan when pre-filtering is explicitly disabled.
 			get.projection_ids.clear();
 			get.types.clear();

--- a/src/hnsw/hnsw_optimize_topk.cpp
+++ b/src/hnsw/hnsw_optimize_topk.cpp
@@ -124,7 +124,7 @@ public:
 
 		unique_ptr<HNSWIndexScanBindData> bind_data = nullptr;
 		vector<reference<Expression>> bindings;
-		const auto filter_pushdown = HNSWIndexScanFunction::FilterPushdownEnabled(context);
+		const auto prefilter = HNSWIndexScanFunction::PrefilterEnabled(context);
 
 		table_info.BindIndexes(context, HNSWIndex::TYPE_NAME);
 		for (auto index_entry : table_info.GetIndexes().IndexEntries()) {
@@ -175,7 +175,7 @@ public:
 				continue;
 			}
 			bind_data = make_uniq<HNSWIndexScanBindData>(duck_table, index_entry, guard->GetIndexName(), k_limit,
-			                                             std::move(query_vector), filter_pushdown);
+			                                             std::move(query_vector), prefilter);
 			break;
 		}
 
@@ -196,7 +196,7 @@ public:
 		    CreateListOrderByExpr(context, col_expr->Copy(), dist_expr.Copy(),
 		                          agg_func_expr.GetFilter() ? agg_func_expr.GetFilter()->Copy() : nullptr);
 
-		if (!filter_pushdown && get.table_filters.HasFilters()) {
+		if (!prefilter && get.table_filters.HasFilters()) {
 			// Restore the post-filter plan when pre-filtering is explicitly disabled.
 			get.projection_ids.clear();
 			get.types.clear();

--- a/src/hnsw/hnsw_optimize_topk.cpp
+++ b/src/hnsw/hnsw_optimize_topk.cpp
@@ -2,8 +2,8 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"
-#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/planner/operator/logical_filter.hpp"
+#include "duckdb/planner/operator/logical_get.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "duckdb/planner/expression/bound_aggregate_expression.hpp"
@@ -124,6 +124,7 @@ public:
 
 		unique_ptr<HNSWIndexScanBindData> bind_data = nullptr;
 		vector<reference<Expression>> bindings;
+		const auto filter_pushdown = HNSWIndexScanFunction::FilterPushdownEnabled(context);
 
 		table_info.BindIndexes(context, HNSWIndex::TYPE_NAME);
 		for (auto index_entry : table_info.GetIndexes().IndexEntries()) {
@@ -174,7 +175,7 @@ public:
 				continue;
 			}
 			bind_data = make_uniq<HNSWIndexScanBindData>(duck_table, index_entry, guard->GetIndexName(), k_limit,
-			                                             std::move(query_vector));
+			                                             std::move(query_vector), filter_pushdown);
 			break;
 		}
 
@@ -195,27 +196,24 @@ public:
 		    CreateListOrderByExpr(context, col_expr->Copy(), dist_expr.Copy(),
 		                          agg_func_expr.GetFilter() ? agg_func_expr.GetFilter()->Copy() : nullptr);
 
-		if (!get.table_filters.HasFilters()) {
-			return true;
+		if (!filter_pushdown && get.table_filters.HasFilters()) {
+			// Restore the post-filter plan when pre-filtering is explicitly disabled.
+			get.projection_ids.clear();
+			get.types.clear();
+
+			auto new_filter = make_uniq<LogicalFilter>();
+			for (const auto &entry : get.table_filters) {
+				auto filter_idx = entry.GetIndex();
+				auto &column_id = get.GetColumnIndex(filter_idx);
+				auto &type = get.returned_types[column_id.GetPrimaryIndex()];
+				auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, filter_idx));
+				new_filter->expressions.push_back(entry.Filter().ToExpression(*column));
+			}
+
+			new_filter->children.push_back(std::move(get_ptr));
+			new_filter->ResolveOperatorTypes();
+			get_ptr = std::move(new_filter);
 		}
-
-		// We need to pullup the filters from the table scan as our index scan does not support regular filter pushdown.
-		get.projection_ids.clear();
-		get.types.clear();
-
-		auto new_filter = make_uniq<LogicalFilter>();
-		auto &column_ids = get.GetColumnIds();
-		for (const auto &entry : get.table_filters) {
-			auto filter_idx = entry.GetIndex();
-			auto &column_id = get.GetColumnIndex(filter_idx);
-			auto &type = get.returned_types[column_id.GetPrimaryIndex()];
-			auto column = make_uniq<BoundColumnRefExpression>(type, ColumnBinding(get.table_index, filter_idx));
-			new_filter->expressions.push_back(entry.Filter().ToExpression(*column));
-		}
-
-		new_filter->children.push_back(std::move(get_ptr));
-		new_filter->ResolveOperatorTypes();
-		get_ptr = std::move(new_filter);
 
 		return true;
 	}

--- a/src/include/hnsw/hnsw_index.hpp
+++ b/src/include/hnsw/hnsw_index.hpp
@@ -4,6 +4,7 @@
 #include "duckdb/common/helper.hpp"
 #include "duckdb/common/string.hpp"
 #include "duckdb/common/typedefs.hpp"
+#include "duckdb/common/unordered_set.hpp"
 #include "duckdb/common/types/column/column_data_collection.hpp"
 #include "duckdb/common/unique_ptr.hpp"
 #include "duckdb/common/vector.hpp"
@@ -27,6 +28,36 @@ struct HNSWIndexStats {
 	idx_t capacity;
 	idx_t approx_size;
 	vector<unum::usearch::index_dense_gt<row_t>::stats_t> level_stats;
+};
+
+struct HNSWFilterBitmap {
+	void Set(row_t row_id) {
+		D_ASSERT(row_id >= 0);
+		if (row_id >= MAX_ROW_ID) {
+			local_row_ids.insert(row_id);
+			return;
+		}
+		auto bitmap_index = static_cast<idx_t>(row_id);
+		if (bitmap_index >= base_row_ids.size()) {
+			base_row_ids.resize(bitmap_index + 1);
+		}
+		base_row_ids[bitmap_index] = true;
+	}
+
+	bool Contains(row_t row_id) const {
+		if (row_id < 0) {
+			return false;
+		}
+		if (row_id >= MAX_ROW_ID) {
+			return local_row_ids.find(row_id) != local_row_ids.end();
+		}
+		auto bitmap_index = static_cast<idx_t>(row_id);
+		return bitmap_index < base_row_ids.size() && base_row_ids[bitmap_index];
+	}
+
+private:
+	vector<bool> base_row_ids;
+	unordered_set<row_t> local_row_ids;
 };
 
 class HNSWIndex : public BoundIndex {
@@ -57,7 +88,8 @@ public:
 	const Vector &GetMultiScanResult(IndexScanState &state) const;
 	void ResetMultiScan(IndexScanState &state) const;
 
-	unique_ptr<IndexScanState> InitializeScan(float *query_vector, idx_t limit, ClientContext &context) const;
+	unique_ptr<IndexScanState> InitializeScan(float *query_vector, idx_t limit, ClientContext &context,
+	                                          optional_ptr<const HNSWFilterBitmap> filter = nullptr) const;
 	static idx_t Scan(IndexScanState &state, Vector &result, idx_t result_offset = 0);
 	idx_t GetVectorSize() const;
 	string GetMetric() const;

--- a/src/include/hnsw/hnsw_index_scan.hpp
+++ b/src/include/hnsw/hnsw_index_scan.hpp
@@ -14,9 +14,9 @@ namespace duckdb {
 struct HNSWIndexScanBindData final : public TableScanBindData {
 	explicit HNSWIndexScanBindData(TableCatalogEntry &table, shared_ptr<IndexEntry> index_entry,
 	                               Identifier index_name_p, idx_t limit, unsafe_unique_array<float> query,
-	                               bool filter_pushdown_p)
+	                               bool prefilter_p)
 	    : TableScanBindData(table), index_name(std::move(index_name_p)), index_entry(std::move(index_entry)),
-	      limit(limit), query(std::move(query)), filter_pushdown(filter_pushdown_p) {
+	      limit(limit), query(std::move(query)), prefilter(prefilter_p) {
 	}
 
 	//! The index name used for display purposes
@@ -32,7 +32,7 @@ struct HNSWIndexScanBindData final : public TableScanBindData {
 	unsafe_unique_array<float> query;
 
 	//! Whether static table filters should be evaluated before the HNSW search
-	bool filter_pushdown;
+	bool prefilter;
 
 public:
 	bool Equals(const FunctionData &other_p) const override {
@@ -43,7 +43,7 @@ public:
 
 struct HNSWIndexScanFunction {
 	static TableFunction GetFunction();
-	static bool FilterPushdownEnabled(ClientContext &context);
+	static bool PrefilterEnabled(ClientContext &context);
 };
 
 } // namespace duckdb

--- a/src/include/hnsw/hnsw_index_scan.hpp
+++ b/src/include/hnsw/hnsw_index_scan.hpp
@@ -13,9 +13,10 @@ namespace duckdb {
 // This is created by the optimizer rule
 struct HNSWIndexScanBindData final : public TableScanBindData {
 	explicit HNSWIndexScanBindData(TableCatalogEntry &table, shared_ptr<IndexEntry> index_entry,
-	                               Identifier index_name_p, idx_t limit, unsafe_unique_array<float> query)
+	                               Identifier index_name_p, idx_t limit, unsafe_unique_array<float> query,
+	                               bool filter_pushdown_p)
 	    : TableScanBindData(table), index_name(std::move(index_name_p)), index_entry(std::move(index_entry)),
-	      limit(limit), query(std::move(query)) {
+	      limit(limit), query(std::move(query)), filter_pushdown(filter_pushdown_p) {
 	}
 
 	//! The index name used for display purposes
@@ -30,6 +31,9 @@ struct HNSWIndexScanBindData final : public TableScanBindData {
 	//! The query vector
 	unsafe_unique_array<float> query;
 
+	//! Whether static table filters should be evaluated before the HNSW search
+	bool filter_pushdown;
+
 public:
 	bool Equals(const FunctionData &other_p) const override {
 		auto &other = other_p.Cast<HNSWIndexScanBindData>();
@@ -39,6 +43,7 @@ public:
 
 struct HNSWIndexScanFunction {
 	static TableFunction GetFunction();
+	static bool FilterPushdownEnabled(ClientContext &context);
 };
 
 } // namespace duckdb

--- a/src/include/usearch/README.md
+++ b/src/include/usearch/README.md
@@ -2,9 +2,10 @@ Source: https://github.com/unum-cloud/USearch
 Tag: v2.26.1
 
 The files in this directory are copied from the tagged upstream release, except
-for `index_dense.hpp`. DuckDB-VSS adds an `f32` `ef_search` overload to its
-dense-index search API, allowing `hnsw_ef_search` to be applied per query
-without mutating shared index configuration.
+for `index_dense.hpp`. DuckDB-VSS adds `f32` `ef_search` and
+`filtered_ef_search` overloads to its dense-index search API, allowing
+`hnsw_ef_search` to be applied per query without mutating shared index
+configuration.
 
 When refreshing the vendored headers, preserve or deliberately reapply this
 customization.

--- a/src/include/usearch/index_dense.hpp
+++ b/src/include/usearch/index_dense.hpp
@@ -901,6 +901,14 @@ class index_dense_gt {
         return search_(vector, wanted, dummy_predicate_t {}, search_config, casts_.from.f32);
     }
 
+    template <typename predicate_at> search_result_t filtered_ef_search(f32_t const* vector, std::size_t wanted, std::size_t ef_search, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const {
+        index_search_config_t search_config;
+        search_config.thread = thread;
+        search_config.expansion = ef_search;
+        search_config.exact = exact;
+        return search_(vector, wanted, std::forward<predicate_at>(predicate), search_config, casts_.from.f32);
+    }
+
     template <typename predicate_at> search_result_t filtered_search(f64_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f64); }
     template <typename predicate_at> search_result_t filtered_search(f32_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.f32); }
     template <typename predicate_at> search_result_t filtered_search(bf16_t const* vector, std::size_t wanted, predicate_at&& predicate, std::size_t thread = any_thread(), bool exact = false) const { return search_(vector, wanted, std::forward<predicate_at>(predicate), thread, exact, casts_.from.bf16); }

--- a/test/sql/hnsw/hnsw_prefilter.test
+++ b/test/sql/hnsw/hnsw_prefilter.test
@@ -9,6 +9,14 @@ require noforcestorage
 statement ok
 SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
 
+query I
+SELECT current_setting('hnsw_enable_filter_pushdown');
+----
+false
+
+statement ok
+SET hnsw_enable_filter_pushdown = true;
+
 statement ok
 CREATE TABLE items (id INTEGER, category VARCHAR, vec FLOAT[3]);
 
@@ -102,8 +110,8 @@ SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0,
 6
 7
 
-# Pre-filtering can be disabled to avoid its O(n) filter scan. This restores
-# the previous post-filter behavior, where fewer than LIMIT rows can survive.
+# Disabling pre-filtering restores the default post-filter behavior, where
+# fewer than LIMIT rows can survive.
 statement ok
 SET hnsw_enable_filter_pushdown = false;
 

--- a/test/sql/hnsw/hnsw_prefilter.test
+++ b/test/sql/hnsw/hnsw_prefilter.test
@@ -131,3 +131,36 @@ SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0,
 
 statement ok
 COMMIT;
+
+# Filter cardinality is independent of STANDARD_VECTOR_SIZE. The filtered scan
+# accumulates qualifying row IDs across every input chunk before HNSW search.
+statement ok
+CREATE TABLE many_items (id INTEGER, eligible BOOLEAN, vec FLOAT[3]);
+
+statement ok
+INSERT INTO many_items SELECT i, i >= 2500, [i, 0, 0]::FLOAT[3] FROM range(5000) t(i);
+
+statement ok
+CREATE INDEX many_items_vec_idx ON many_items USING HNSW (vec);
+
+query II
+EXPLAIN SELECT id FROM many_items WHERE eligible ORDER BY array_distance(vec, [0, 0, 0]::FLOAT[3]) LIMIT 10;
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_SCAN.*
+
+statement ok
+CREATE TEMP TABLE many_items_result AS SELECT id, eligible FROM many_items WHERE eligible ORDER BY array_distance(vec, [0, 0, 0]::FLOAT[3]) LIMIT 10;
+
+query II
+SELECT count(*), count(*) FILTER (WHERE NOT eligible) FROM many_items_result;
+----
+10	0
+
+# ORDER BY ... LIMIT scans can also emit results across multiple output chunks.
+statement ok
+CREATE TEMP TABLE many_items_large_result AS SELECT id, eligible FROM many_items WHERE eligible ORDER BY array_distance(vec, [0, 0, 0]::FLOAT[3]) LIMIT 2500;
+
+query II
+SELECT count(*), count(*) FILTER (WHERE NOT eligible) FROM many_items_large_result;
+----
+2500	0

--- a/test/sql/hnsw/hnsw_prefilter.test
+++ b/test/sql/hnsw/hnsw_prefilter.test
@@ -10,12 +10,12 @@ statement ok
 SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
 
 query I
-SELECT current_setting('hnsw_enable_filter_pushdown');
+SELECT current_setting('hnsw_prefilter');
 ----
 false
 
 statement ok
-SET hnsw_enable_filter_pushdown = true;
+SET hnsw_prefilter = true;
 
 statement ok
 CREATE TABLE items (id INTEGER, category VARCHAR, vec FLOAT[3]);
@@ -113,7 +113,7 @@ SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0,
 # Disabling pre-filtering restores the default post-filter behavior, where
 # fewer than LIMIT rows can survive.
 statement ok
-SET hnsw_enable_filter_pushdown = false;
+SET hnsw_prefilter = false;
 
 query I
 SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
@@ -121,7 +121,7 @@ SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0,
 0
 
 statement ok
-SET hnsw_enable_filter_pushdown = true;
+SET hnsw_prefilter = true;
 
 # Deleted rows are absent from the transaction-visible pre-filter set.
 statement ok

--- a/test/sql/hnsw/hnsw_prefilter.test
+++ b/test/sql/hnsw/hnsw_prefilter.test
@@ -163,12 +163,3 @@ query II
 SELECT count(*), count(*) FILTER (WHERE NOT eligible) FROM many_items_result;
 ----
 10	0
-
-# ORDER BY ... LIMIT scans can also emit results across multiple output chunks.
-statement ok
-CREATE TEMP TABLE many_items_large_result AS SELECT id, eligible FROM many_items WHERE eligible ORDER BY array_distance(vec, [0, 0, 0]::FLOAT[3]) LIMIT 2500;
-
-query II
-SELECT count(*), count(*) FILTER (WHERE NOT eligible) FROM many_items_large_result;
-----
-2500	0

--- a/test/sql/hnsw/hnsw_prefilter.test
+++ b/test/sql/hnsw/hnsw_prefilter.test
@@ -12,10 +12,7 @@ SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
 query I
 SELECT current_setting('hnsw_prefilter');
 ----
-false
-
-statement ok
-SET hnsw_prefilter = true;
+true
 
 statement ok
 CREATE TABLE items (id INTEGER, category VARCHAR, vec FLOAT[3]);
@@ -110,8 +107,8 @@ SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0,
 6
 7
 
-# Disabling pre-filtering restores the default post-filter behavior, where
-# fewer than LIMIT rows can survive.
+# Disabling pre-filtering selects the post-filter behavior, where fewer than
+# LIMIT rows can survive.
 statement ok
 SET hnsw_prefilter = false;
 

--- a/test/sql/hnsw/hnsw_prefilter.test
+++ b/test/sql/hnsw/hnsw_prefilter.test
@@ -1,0 +1,133 @@
+# name: test/sql/hnsw/hnsw_prefilter.test
+# description: HNSW scans apply table filters before selecting the nearest neighbors.
+# group: [hnsw]
+
+require vss
+
+require noforcestorage
+
+statement ok
+SET profiling_renderer_settings = MAP {'operator_casing': 'upper'};
+
+statement ok
+CREATE TABLE items (id INTEGER, category VARCHAR, vec FLOAT[3]);
+
+statement ok
+INSERT INTO items SELECT i, CASE WHEN i >= 6 THEN 'keep' ELSE 'skip' END, [i, 0, 0]::FLOAT[3] FROM range(1, 11) t(i);
+
+statement ok
+INSERT INTO items VALUES (-1, NULL, [-1, 0, 0]::FLOAT[3]);
+
+statement ok
+CREATE INDEX items_vec_idx ON items USING HNSW (vec);
+
+query II
+EXPLAIN SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_SCAN.*
+
+# The unfiltered nearest neighbors all have category 'skip'. A post-filtered
+# top-k would return no rows, while pre-filtering returns three qualifying rows.
+query IT
+SELECT id, category FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+6	keep
+7	keep
+8	keep
+
+# Multiple pushed-down filters are combined in the bitmap scan.
+query IT
+SELECT id, category FROM items WHERE category = 'keep' AND id >= 8 ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+8	keep
+9	keep
+10	keep
+
+# Filters with fewer matches than the requested limit return all matches.
+query I
+SELECT id FROM items WHERE id > 8 ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 5;
+----
+9
+10
+
+# Generic single-column expressions are evaluated by DuckDB while building the
+# bitmap, and the index can only return row IDs from that exact result set.
+query II
+EXPLAIN SELECT id FROM items WHERE id % 3 = 0 ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+physical_plan	<REGEX>:.*HNSW_INDEX_SCAN.*
+
+query I
+SELECT id FROM items WHERE id % 3 = 0 ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+3
+6
+9
+
+# NULL predicates use the same filter bitmap and never admit non-NULL rows.
+query IT
+SELECT id, category FROM items WHERE category IS NULL ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+-1	NULL
+
+query I
+SELECT count(*) FROM (SELECT id FROM items WHERE category = 'missing' ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3);
+----
+0
+
+# Predicates that cannot be represented as table filters stay in DuckDB's
+# regular filter operator; the HNSW rewrite must not bypass them.
+query IT
+SELECT id, category FROM items WHERE category = 'keep' AND id % 2 = CAST(vec[1] AS INTEGER) % 3 ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+6	keep
+7	keep
+
+# The min_by top-k rewrite uses the same pre-filtered index scan.
+query I
+SELECT unnest(min_by(id, array_distance(vec, [1, 0, 0]::FLOAT[3]), 3)) FROM items WHERE category = 'keep';
+----
+6
+7
+8
+
+# Rows inserted after index creation participate in pre-filtered searches.
+statement ok
+INSERT INTO items VALUES (0, 'keep', [0, 0, 0]::FLOAT[3]);
+
+query I
+SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+0
+6
+7
+
+# Pre-filtering can be disabled to avoid its O(n) filter scan. This restores
+# the previous post-filter behavior, where fewer than LIMIT rows can survive.
+statement ok
+SET hnsw_enable_filter_pushdown = false;
+
+query I
+SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+0
+
+statement ok
+SET hnsw_enable_filter_pushdown = true;
+
+# Deleted rows are absent from the transaction-visible pre-filter set.
+statement ok
+BEGIN TRANSACTION;
+
+statement ok
+DELETE FROM items WHERE id = 6;
+
+query I
+SELECT id FROM items WHERE category = 'keep' ORDER BY array_distance(vec, [1, 0, 0]::FLOAT[3]) LIMIT 3;
+----
+0
+7
+8
+
+statement ok
+COMMIT;


### PR DESCRIPTION
Based on: https://github.com/duckdb/duckdb-vss/pull/89

The previous PR works for small amounts of constants in an `IN`-list, but fails to recognize when the logical plan is rewritten to a `MARK` join. This PR extends the optimizer to also support larger `IN`-lists and rewrite to an HNSW scan rewrite. 

This is for now limited to a single-column `IN` predicate. It extracts the constant values for the prefilter bitmap and rewrites the underlying table scan to an HNSW index scan. 

Perhaps it could be extended in the future to include more general filters. This rewrite is disabled when `hnsw_prefilter` is set to `false`