### PR TITLE
Apply patches from duckdb/duckdb

### DIFF
--- a/.github/workflows/MainDistributionPipeline.yml
+++ b/.github/workflows/MainDistributionPipeline.yml
@@ -27,7 +27,7 @@ jobs:
     uses: duckdb/extension-ci-tools/.github/workflows/_extension_distribution.yml@main
     with:
       extension_name: vss
-      duckdb_version: main
+      duckdb_version: fc4002c6e36f1e2d17d7c5b1a604777d69238d2b
       ci_tools_version: main
       # Also verify musl builds in CI
       opt_in_archs: linux_amd64_musl
@@ -40,7 +40,7 @@ jobs:
     secrets: inherit
     with:
       extension_name: vss
-      duckdb_version: main
+      duckdb_version: fc4002c6e36f1e2d17d7c5b1a604777d69238d2b
       ci_tools_version: main
       deploy_latest: ${{ startsWith(github.ref, 'refs/tags/v') || github.ref == 'refs/heads/main' }}
 

--- a/src/hnsw/hnsw_index_macros.cpp
+++ b/src/hnsw/hnsw_index_macros.cpp
@@ -1,4 +1,5 @@
 #include "duckdb/function/table_macro_function.hpp"
+#include "duckdb/parser/expression/columnref_expression.hpp"
 #include "duckdb/main/extension/extension_loader.hpp"
 #include "duckdb/parser/parsed_data/create_macro_info.hpp"
 #include "duckdb/parser/parser.hpp"
@@ -91,7 +92,7 @@ static void RegisterTableMacro(ExtensionLoader &loader, const string &name, cons
 
 	for (auto &param : named_params) {
 		func->parameters.push_back(make_uniq<ColumnRefExpression>(param.first));
-		func->default_parameters[Identifier(param.first)] = make_uniq<ConstantExpression>(Value(param.second));
+		func->default_parameters[Identifier(param.first)] = ConstantExpression::FromValue(Value(param.second));
 	}
 
 	CreateMacroInfo info(CatalogType::TABLE_MACRO_ENTRY);

--- a/src/hnsw/hnsw_optimize_expr.cpp
+++ b/src/hnsw/hnsw_optimize_expr.cpp
@@ -1,5 +1,6 @@
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression/bound_function_expression.hpp"
+#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/scalar_function_catalog_entry.hpp"
 #include "duckdb/optimizer/optimizer.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"

--- a/src/hnsw/hnsw_optimize_scan.cpp
+++ b/src/hnsw/hnsw_optimize_scan.cpp
@@ -1,6 +1,7 @@
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/optimizer/optimizer_extension.hpp"
 #include "duckdb/planner/column_binding_map.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/expression_iterator.hpp"
 #include "duckdb/planner/operator/logical_get.hpp"

--- a/src/hnsw/hnsw_optimize_topk.cpp
+++ b/src/hnsw/hnsw_optimize_topk.cpp
@@ -1,4 +1,6 @@
+#include "duckdb/catalog/catalog.hpp"
 #include "duckdb/catalog/catalog_entry/aggregate_function_catalog_entry.hpp"
+#include "duckdb/planner/expression/bound_columnref_expression.hpp"
 #include "duckdb/catalog/catalog_entry/duck_table_entry.hpp"
 #include "duckdb/planner/expression/bound_constant_expression.hpp"
 #include "duckdb/planner/operator/logical_aggregate.hpp"


### PR DESCRIPTION
This PR applies patches from duckdb/duckdb:
- `0001-hnsw-catalog-columnref-includes.patch`
- `0001-literal-constant-expression.patch`

It also bumps the duckdb submodules and `.github/workflows/MainDistributionPipeline.yml` to v2.0.0.
